### PR TITLE
Fix foreign key constraint in Alchemer survey response

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/AlchemerSurveyResponse.java
+++ b/src/main/java/uy/com/bay/utiles/data/AlchemerSurveyResponse.java
@@ -35,7 +35,7 @@ public class AlchemerSurveyResponse extends AbstractEntity {
 
     public void setData(AlchemerSurveyResponseData data) {
         if (data != null) {
-            data.setContact(data.getContact());
+            data.setSurveyResponse(this);
         }
         this.data = data;
     }

--- a/src/main/java/uy/com/bay/utiles/data/AlchemerSurveyResponseData.java
+++ b/src/main/java/uy/com/bay/utiles/data/AlchemerSurveyResponseData.java
@@ -29,6 +29,9 @@ public class AlchemerSurveyResponseData extends AbstractEntity {
     @JoinColumn(name = "contact_id", referencedColumnName = "id")
     private AlchemerContact contact;
 
+    @OneToOne(mappedBy = "data")
+    private AlchemerSurveyResponse surveyResponse;
+
     public boolean isTest() {
         return isTest;
     }
@@ -86,5 +89,13 @@ public class AlchemerSurveyResponseData extends AbstractEntity {
             contact.setSurveyResponseData(this);
         }
         this.contact = contact;
+    }
+
+    public AlchemerSurveyResponse getSurveyResponse() {
+        return surveyResponse;
+    }
+
+    public void setSurveyResponse(AlchemerSurveyResponse surveyResponse) {
+        this.surveyResponse = surveyResponse;
     }
 }


### PR DESCRIPTION
The `alchemer_survey_response_data` table had an incorrect foreign key constraint on the `contact_id` column, referencing the `alchemer_survey_response` table instead of the `alchemer_contact` table. This caused a `SQLIntegrityConstraintViolationException` when saving a new survey response.

This commit fixes the issue by:

1.  Adding a `OneToOne` relationship from `AlchemerSurveyResponseData` to `AlchemerSurveyResponse`.
2.  Updating the `AlchemerSurveyResponse.setData()` method to correctly establish the bidirectional relationship between `AlchemerSurveyResponse` and `AlchemerSurveyResponseData`.