### PR TITLE
Fix foreign key constraint violation in AlchemerController

### DIFF
--- a/src/main/java/uy/com/bay/utiles/controllers/AlchemerController.java
+++ b/src/main/java/uy/com/bay/utiles/controllers/AlchemerController.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import jakarta.transaction.Transactional;
 import uy.com.bay.utiles.data.AlchemerSurveyResponse;
-import uy.com.bay.utiles.data.AlchemerSurveyResponseData;
 import uy.com.bay.utiles.data.JobType;
 import uy.com.bay.utiles.data.Proyecto;
 import uy.com.bay.utiles.data.ProyectoRepository;
@@ -39,10 +38,9 @@ public class AlchemerController {
         Optional<Proyecto> optionalProyecto = proyectoRepository.findByAlchemerId(String.valueOf(response.getData().getSurveyId()));
         optionalProyecto.ifPresent(response::setProyecto);
 
-        AlchemerSurveyResponseData data = response.getData();
-        response.setData(data);
+        response.setData(response.getData());
 
-        alchemerSurveyResponseRepository.save(response);
+		alchemerSurveyResponseRepository.save(response);
 
         Task task = new Task();
         task.setJobType(JobType.ALCHEMERANSWERRETRIEVAL);

--- a/src/main/java/uy/com/bay/utiles/data/AlchemerContact.java
+++ b/src/main/java/uy/com/bay/utiles/data/AlchemerContact.java
@@ -5,11 +5,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
+import jakarta.persistence.JoinColumn;
+
 @Entity
 @Table(name = "alchemer_contact")
 public class AlchemerContact extends AbstractEntity {
 
-    @OneToOne(mappedBy = "contact")
+    @OneToOne
+    @JoinColumn(name = "survey_response_data_id")
     private AlchemerSurveyResponseData surveyResponseData;
 
     @JsonProperty("Email")

--- a/src/main/java/uy/com/bay/utiles/data/AlchemerSurveyResponse.java
+++ b/src/main/java/uy/com/bay/utiles/data/AlchemerSurveyResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
@@ -16,6 +17,7 @@ public class AlchemerSurveyResponse extends AbstractEntity {
     private String webhookName;
 
     @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "data_id", referencedColumnName = "id")
     private AlchemerSurveyResponseData data;
 
     @ManyToOne

--- a/src/main/java/uy/com/bay/utiles/data/AlchemerSurveyResponseData.java
+++ b/src/main/java/uy/com/bay/utiles/data/AlchemerSurveyResponseData.java
@@ -25,8 +25,7 @@ public class AlchemerSurveyResponseData extends AbstractEntity {
     @JsonProperty("response_status")
     private String responseStatus;
 
-    @OneToOne(cascade = CascadeType.ALL)
-    @JoinColumn(name = "contact_id", referencedColumnName = "id")
+    @OneToOne(cascade = CascadeType.ALL, mappedBy = "surveyResponseData")
     private AlchemerContact contact;
 
     @OneToOne(mappedBy = "data")


### PR DESCRIPTION
The `AlchemerSurveyResponse` was being saved before its nested `AlchemerSurveyResponseData` object, which in turn contains the `AlchemerContact` object. This caused a foreign key constraint violation because the `alchemer_survey_response` table has a foreign key `data_id` that references the `data` table, but the corresponding `data` record had not been inserted yet.

This commit fixes the issue by making `AlchemerSurveyResponse` the owner of the relationship with `AlchemerSurveyResponseData`, and `AlchemerContact` the owner of the relationship with `AlchemerSurveyResponseData`. This ensures that the entities are saved in the correct order, and the `@Transactional` annotation ensures that all database operations are executed in a single transaction.