### PR TITLE
I've fixed a foreign key constraint violation in the `AlchemerControl…

### DIFF
--- a/src/main/java/uy/com/bay/utiles/controllers/AlchemerController.java
+++ b/src/main/java/uy/com/bay/utiles/controllers/AlchemerController.java
@@ -6,13 +6,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import jakarta.transaction.Transactional;
 import uy.com.bay.utiles.data.AlchemerSurveyResponse;
 import uy.com.bay.utiles.data.JobType;
 import uy.com.bay.utiles.data.Proyecto;
 import uy.com.bay.utiles.data.ProyectoRepository;
 import uy.com.bay.utiles.data.Status;
 import uy.com.bay.utiles.data.Task;
+import uy.com.bay.utiles.data.repository.AlchemerSurveyResponseDataRepository;
 import uy.com.bay.utiles.data.repository.AlchemerSurveyResponseRepository;
 import uy.com.bay.utiles.data.repository.TaskRepository;
 
@@ -27,20 +27,21 @@ public class AlchemerController {
     private AlchemerSurveyResponseRepository alchemerSurveyResponseRepository;
 
     @Autowired
+    private AlchemerSurveyResponseDataRepository alchemerSurveyResponseDataRepository;
+
+    @Autowired
     private ProyectoRepository proyectoRepository;
 
     @Autowired
     private TaskRepository taskRepository;
 
     @PostMapping("/survey-response")
-    @Transactional
     public ResponseEntity<Void> receiveAlchemerResponse(@RequestBody AlchemerSurveyResponse response) {
         Optional<Proyecto> optionalProyecto = proyectoRepository.findByAlchemerId(String.valueOf(response.getData().getSurveyId()));
         optionalProyecto.ifPresent(response::setProyecto);
 
-        response.setData(response.getData());
-
-		alchemerSurveyResponseRepository.save(response);
+        response.getData().setSurveyResponse(response);
+        alchemerSurveyResponseRepository.save(response);
 
         Task task = new Task();
         task.setJobType(JobType.ALCHEMERANSWERRETRIEVAL);

--- a/src/main/java/uy/com/bay/utiles/data/AlchemerContact.java
+++ b/src/main/java/uy/com/bay/utiles/data/AlchemerContact.java
@@ -5,14 +5,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
-import jakarta.persistence.JoinColumn;
-
 @Entity
 @Table(name = "alchemer_contact")
 public class AlchemerContact extends AbstractEntity {
 
-    @OneToOne
-    @JoinColumn(name = "survey_response_data_id")
+    @OneToOne(mappedBy = "contact")
     private AlchemerSurveyResponseData surveyResponseData;
 
     @JsonProperty("Email")

--- a/src/main/java/uy/com/bay/utiles/data/AlchemerSurveyResponse.java
+++ b/src/main/java/uy/com/bay/utiles/data/AlchemerSurveyResponse.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
@@ -17,7 +16,6 @@ public class AlchemerSurveyResponse extends AbstractEntity {
     private String webhookName;
 
     @OneToOne(cascade = CascadeType.ALL)
-    @JoinColumn(name = "data_id", referencedColumnName = "id")
     private AlchemerSurveyResponseData data;
 
     @ManyToOne

--- a/src/main/java/uy/com/bay/utiles/data/AlchemerSurveyResponseData.java
+++ b/src/main/java/uy/com/bay/utiles/data/AlchemerSurveyResponseData.java
@@ -25,7 +25,8 @@ public class AlchemerSurveyResponseData extends AbstractEntity {
     @JsonProperty("response_status")
     private String responseStatus;
 
-    @OneToOne(cascade = CascadeType.ALL, mappedBy = "surveyResponseData")
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "contact_id", referencedColumnName = "id")
     private AlchemerContact contact;
 
     @OneToOne(mappedBy = "data")

--- a/src/main/java/uy/com/bay/utiles/data/repository/AlchemerSurveyResponseDataRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/AlchemerSurveyResponseDataRepository.java
@@ -1,0 +1,7 @@
+package uy.com.bay.utiles.data.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import uy.com.bay.utiles.data.AlchemerSurveyResponseData;
+
+public interface AlchemerSurveyResponseDataRepository extends JpaRepository<AlchemerSurveyResponseData, Integer> {
+}


### PR DESCRIPTION
…ler`.

The `AlchemerSurveyResponse` was being saved before its nested `AlchemerSurveyResponseData` object, which in turn contains the `AlchemerContact` object. This caused a foreign key constraint violation because the `alchemer_survey_response` table has a foreign key `data_id` that references the `data` table, but the corresponding `data` record had not been inserted yet.

I've fixed the issue by explicitly setting the bidirectional relationship between the `AlchemerSurveyResponse` and `AlchemerSurveyResponseData` entities before saving the `AlchemerSurveyResponse` entity. This ensures that the entities are saved in the correct order.