### PR TITLE
Refactor(AlchemerController): Check for existing survey response befo…

### DIFF
--- a/src/main/java/uy/com/bay/utiles/controllers/AlchemerController.java
+++ b/src/main/java/uy/com/bay/utiles/controllers/AlchemerController.java
@@ -37,6 +37,15 @@ public class AlchemerController {
 
     @PostMapping("/survey-response")
     public ResponseEntity<Void> receiveAlchemerResponse(@RequestBody AlchemerSurveyResponse response) {
+        Optional<AlchemerSurveyResponse> existingResponse = alchemerSurveyResponseRepository.findByDataResponseIdAndDataSurveyId(
+                (long) response.getData().getResponseId(),
+                response.getData().getSurveyId()
+        );
+
+        if (existingResponse.isPresent()) {
+            return ResponseEntity.ok().build();
+        }
+
         Optional<Proyecto> optionalProyecto = proyectoRepository.findByAlchemerId(String.valueOf(response.getData().getSurveyId()));
         optionalProyecto.ifPresent(response::setProyecto);
 

--- a/src/main/java/uy/com/bay/utiles/data/repository/AlchemerSurveyResponseRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/AlchemerSurveyResponseRepository.java
@@ -3,5 +3,10 @@ package uy.com.bay.utiles.data.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import uy.com.bay.utiles.data.AlchemerSurveyResponse;
 
+import java.util.Optional;
+
 public interface AlchemerSurveyResponseRepository extends JpaRepository<AlchemerSurveyResponse, Long> {
+
+    Optional<AlchemerSurveyResponse> findByDataResponseIdAndDataSurveyId(Long responseId, Integer surveyId);
+
 }


### PR DESCRIPTION
…re saving

Adds a check to the `receiveAlchemerResponse` method in `AlchemerController` to prevent duplicate `AlchemerSurveyResponse` entries.

Before saving a new response, the method now queries the database to see if a response with the same `response_id` and `survey_id` already exists. If a duplicate is found, the new response is discarded, and a `200 OK` is returned.