### PR TITLE
Refactor(AlchemerController): Check for existing survey response befo…

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/AlchemerSurveyResponseRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/AlchemerSurveyResponseRepository.java
@@ -3,10 +3,10 @@ package uy.com.bay.utiles.data.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import uy.com.bay.utiles.data.AlchemerSurveyResponse;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface AlchemerSurveyResponseRepository extends JpaRepository<AlchemerSurveyResponse, Long> {
 
-    Optional<AlchemerSurveyResponse> findByDataResponseIdAndDataSurveyId(Long responseId, Integer surveyId);
+    List<AlchemerSurveyResponse> findByDataResponseIdAndDataSurveyId(Long responseId, Integer surveyId);
 
 }


### PR DESCRIPTION
…re saving

Adds a check to the `receiveAlchemerResponse` method in `AlchemerController` to prevent duplicate `AlchemerSurveyResponse` entries.

Before saving a new response, the method now queries the database to see if a response with the same `response_id` and `survey_id` already exists. If a duplicate is found, the new response is discarded, and a `200 OK` is returned.

Also adds logging to the method to provide more visibility into the process.