### PR TITLE
Feat: Agregar columna responseId al grid de AnswersView

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/AlchemerAnswer.java
+++ b/src/main/java/uy/com/bay/utiles/data/AlchemerAnswer.java
@@ -77,6 +77,10 @@ public class AlchemerAnswer {
         return responseId;
     }
 
+    public String getResponseIdString() {
+        return responseId.toString();
+    }
+
     public void setResponseId(Integer responseId) {
         this.responseId = responseId;
     }

--- a/src/main/java/uy/com/bay/utiles/views/answers/AnswersView.java
+++ b/src/main/java/uy/com/bay/utiles/views/answers/AnswersView.java
@@ -46,7 +46,7 @@ public class AnswersView extends Div {
 				.setSortable(true);
 		Grid.Column<AlchemerAnswer> surveyIdColumn = grid.addColumn(AlchemerAnswer::getSurveyId).setHeader("Survey ID")
 				.setSortable(true);
-		Grid.Column<AlchemerAnswer> responseIdColumn = grid.addColumn(AlchemerAnswer::getResponseId)
+		Grid.Column<AlchemerAnswer> responseIdColumn = grid.addColumn(AlchemerAnswer::getResponseIdString)
 				.setHeader("Response ID").setSortable(true);
 
 		GridLazyDataView<AlchemerAnswer> dataView = grid.setItems(q -> alchemerAnswerService


### PR DESCRIPTION
Este refactor agrega la columna `responseId` al grid de `AnswersView` y un filtro para la misma.

Se agregó un nuevo método `getResponseIdString` a `AlchemerAnswer` para proveer el `responseId` como un string, asegurando la consistencia con cómo se manejan otros campos de ID en la vista.

Se actualizó `AnswersView` para usar este nuevo método para la columna del grid.