### PR TITLE
I've fixed an issue in your `AlchemerController`. It was failing to d…

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/AlchemerSurveyResponseData.java
+++ b/src/main/java/uy/com/bay/utiles/data/AlchemerSurveyResponseData.java
@@ -1,7 +1,11 @@
 package uy.com.bay.utiles.data;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.*;
+import java.util.List;
+import java.util.Map;
 
 @Entity
 @Table(name = "alchemer_survey_response_data")
@@ -84,11 +88,24 @@ public class AlchemerSurveyResponseData extends AbstractEntity {
         return contact;
     }
 
+    @JsonIgnore
     public void setContact(AlchemerContact contact) {
         if (contact != null) {
             contact.setSurveyResponseData(this);
         }
         this.contact = contact;
+    }
+
+    @JsonProperty("contact")
+    @SuppressWarnings("unchecked")
+    public void setContactValue(Object contactJson) {
+        if (contactJson instanceof Map) {
+            final ObjectMapper mapper = new ObjectMapper();
+            AlchemerContact contact = mapper.convertValue(contactJson, AlchemerContact.class);
+            setContact(contact);
+        } else if (contactJson instanceof List) {
+            setContact(null);
+        }
     }
 
     public AlchemerSurveyResponse getSurveyResponse() {


### PR DESCRIPTION
…eserialize incoming webhooks from Alchemer when the `contact` field in the JSON payload was an empty array (`[]`). This caused an `HttpMessageNotReadableException` because Jackson was trying to map a JSON array to a plain Java object.

To resolve this, I introduced a custom setter for the `contact` field in the `AlchemerSurveyResponseData` class. The new setter can handle both a JSON object and an empty JSON array. If the `contact` field is an object, it's deserialized as an `AlchemerContact` as before. If it's an empty array, the `contact` field is set to `null`, preventing the application from crashing.