### PR TITLE
feat: Add scheduled task for SurveyToGo surveyor retrieval

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/SurveyToGoUser.java
+++ b/src/main/java/uy/com/bay/utiles/data/SurveyToGoUser.java
@@ -1,0 +1,65 @@
+package uy.com.bay.utiles.data;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SurveyToGoUser {
+
+    @JsonProperty("ID")
+    private String id;
+
+    @JsonProperty("Username")
+    private String username;
+
+    @JsonProperty("ExternalRefID")
+    private String externalRefID;
+
+    @JsonProperty("IsAccountDisabled")
+    private boolean isAccountDisabled;
+
+    @JsonProperty("IsAccountLocked")
+    private boolean isAccountLocked;
+
+    // Getters and setters
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getExternalRefID() {
+        return externalRefID;
+    }
+
+    public void setExternalRefID(String externalRefID) {
+        this.externalRefID = externalRefID;
+    }
+
+    public boolean isAccountDisabled() {
+        return isAccountDisabled;
+    }
+
+    public void setAccountDisabled(boolean accountDisabled) {
+        isAccountDisabled = accountDisabled;
+    }
+
+    public boolean isAccountLocked() {
+        return isAccountLocked;
+    }
+
+    public void setAccountLocked(boolean accountLocked) {
+        isAccountLocked = accountLocked;
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/data/Surveyor.java
+++ b/src/main/java/uy/com/bay/utiles/data/Surveyor.java
@@ -15,7 +15,7 @@ public class Surveyor extends AbstractEntity {
 	}
 
 	public void setSurveyToGoId(String surveyToGoId) {
-		surveyToGoId = surveyToGoId;
+		this.surveyToGoId = surveyToGoId;
 	}
 
 	public String getFirstName() {

--- a/src/main/java/uy/com/bay/utiles/data/SurveyorRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/SurveyorRepository.java
@@ -3,6 +3,8 @@ package uy.com.bay.utiles.data;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface SurveyorRepository extends JpaRepository<Surveyor, Long>, JpaSpecificationExecutor<Surveyor> {
+import java.util.Optional;
 
+public interface SurveyorRepository extends JpaRepository<Surveyor, Long>, JpaSpecificationExecutor<Surveyor> {
+    Optional<Surveyor> findBySurveyToGoId(String surveyToGoId);
 }

--- a/src/main/java/uy/com/bay/utiles/services/SurveyorService.java
+++ b/src/main/java/uy/com/bay/utiles/services/SurveyorService.java
@@ -46,4 +46,7 @@ public class SurveyorService {
     public List<Surveyor> findAll() {
         return repository.findAll();
     }
+    public Optional<Surveyor> findBySurveyToGoId(String surveyToGoId) {
+        return repository.findBySurveyToGoId(surveyToGoId);
+    }
 }

--- a/src/main/java/uy/com/bay/utiles/tasks/SurveyToGoSurveyorRetriever.java
+++ b/src/main/java/uy/com/bay/utiles/tasks/SurveyToGoSurveyorRetriever.java
@@ -1,0 +1,83 @@
+package uy.com.bay.utiles.tasks;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import uy.com.bay.utiles.data.SurveyToGoUser;
+import uy.com.bay.utiles.data.Surveyor;
+import uy.com.bay.utiles.services.SurveyorService;
+
+import java.util.Base64;
+import java.util.Optional;
+
+@Component
+public class SurveyToGoSurveyorRetriever {
+
+    private final SurveyorService surveyorService;
+
+    @Value("${surveyToGo.username}")
+    private String username;
+
+    @Value("${surveyToGo.password}")
+    private String password;
+
+    private final RestTemplate restTemplate;
+
+    public SurveyToGoSurveyorRetriever(SurveyorService surveyorService) {
+        this.surveyorService = surveyorService;
+        this.restTemplate = new RestTemplate();
+    }
+
+    @Scheduled(cron = "0 0 * * * ?") // Runs every hour
+    public void retrieveAndSaveSurveyors() {
+        System.out.println("Starting SurveyToGo Surveyor Retriever Task...");
+
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            String auth = username + ":" + password;
+            byte[] encodedAuth = Base64.getEncoder().encode(auth.getBytes());
+            String authHeader = "Basic " + new String(encodedAuth);
+            headers.set("Authorization", authHeader);
+
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+
+            String url = "http://api.dooblo.net/newapi/Admin/GetSurveyorUsers";
+            ResponseEntity<SurveyToGoUser[]> response = restTemplate.exchange(url, HttpMethod.GET, entity, SurveyToGoUser[].class);
+
+            SurveyToGoUser[] users = response.getBody();
+            if (users == null || users.length == 0) {
+                System.out.println("No surveyors fetched from SurveyToGo. Task finished.");
+                return;
+            }
+
+            System.out.println("Fetched " + users.length + " users from SurveyToGo.");
+
+            for (SurveyToGoUser user : users) {
+                if (user.getId() == null || user.getId().trim().isEmpty()) {
+                    System.out.println("Skipping user with null or empty ID.");
+                    continue;
+                }
+
+                Optional<Surveyor> existingSurveyorOpt = surveyorService.findBySurveyToGoId(user.getId());
+                Surveyor surveyor = existingSurveyorOpt.orElse(new Surveyor());
+
+                surveyor.setSurveyToGoId(user.getId());
+                surveyor.setFirstName(user.getUsername());
+                surveyor.setCi(user.getExternalRefID());
+
+                surveyorService.save(surveyor);
+            }
+
+            System.out.println("SurveyToGo Surveyor Retriever Task finished successfully.");
+
+        } catch (Exception e) {
+            System.err.println("Error during SurveyToGo Surveyor Retriever Task: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,3 +39,7 @@ odoo.password=bubilla@equipos.com.uy
 # Alchemer API credentials
 alchemer.api.token=73305b19aec9ea61725b082179b9556ae32f494efc37e5b113
 alchemer.api.token.secret=A9lwGSTYjI0bQ
+
+# SurveyToGo API credentials
+surveyToGo.username=your_username
+surveyToGo.password=your_password


### PR DESCRIPTION
Implement a new scheduled task, `SurveyToGoSurveyorRetriever`, that runs hourly to fetch surveyor user data from the SurveyToGo API.

This task performs the following actions:
- Connects to `http://api.dooblo.net/newapi/Admin/GetSurveyorUsers` using Basic Authentication.
- Reads credentials (`surveyToGo.username`, `surveyToGo.password`) from `application.properties`.
- For each user returned by the API, it checks if a corresponding `Surveyor` entity exists in the database based on the `surveyToGoId`.
- If the surveyor does not exist, a new one is created.
- If the surveyor exists, its information is updated.
- The `firstName` is mapped from the API's `Username`, and `ci` is mapped from `ExternalRefID`.

Changes include:
- A new `SurveyToGoSurveyorRetriever` class in the `tasks` package.
- A `SurveyToGoUser` DTO to map the API response.
- Updates to `SurveyorRepository` and `SurveyorService` to allow finding surveyors by `surveyToGoId`.
- A bug fix in the `Surveyor` entity's `setSurveyToGoId` method.
- Configuration properties added to `application.properties`.
- Ensured that scheduling is enabled in the main application class.