### PR TITLE
Refactor ExpensesView with multiple improvements.

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/ExpenseRequestRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/ExpenseRequestRepository.java
@@ -1,7 +1,8 @@
 package uy.com.bay.utiles.data.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import uy.com.bay.utiles.data.ExpenseRequest;
 
-public interface ExpenseRequestRepository extends JpaRepository<ExpenseRequest, Long> {
+public interface ExpenseRequestRepository extends JpaRepository<ExpenseRequest, Long>, JpaSpecificationExecutor<ExpenseRequest> {
 }

--- a/src/main/java/uy/com/bay/utiles/services/ExpenseRequestService.java
+++ b/src/main/java/uy/com/bay/utiles/services/ExpenseRequestService.java
@@ -2,6 +2,7 @@ package uy.com.bay.utiles.services;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import uy.com.bay.utiles.data.ExpenseRequest;
 import uy.com.bay.utiles.data.repository.ExpenseRequestRepository;
@@ -33,8 +34,16 @@ public class ExpenseRequestService {
         return repository.findAll(pageable);
     }
 
+    public Page<ExpenseRequest> list(Pageable pageable, Specification<ExpenseRequest> filter) {
+        return repository.findAll(filter, pageable);
+    }
+
     public int count() {
         return (int) repository.count();
+    }
+
+    public int count(Specification<ExpenseRequest> filter) {
+        return (int) repository.count(filter);
     }
 
 }


### PR DESCRIPTION
This commit refactors the ExpensesView to implement several user-requested features:

1.  Replaced the static title with a "Crear solicitud" (Create Request) button. Clicking this button opens the form to create a new ExpenseRequest.
2.  The expense request editor form is now hidden by default. It appears when creating a new request or editing an existing one, and it occupies 20% of the screen width.
3.  Added filters to all columns in the expenses grid, allowing users to search and filter the data.
4.  The grid now sorts the expense requests by `requestDate` in descending order by default.
5.  Implemented lazy loading with pagination for the grid to efficiently handle large datasets.