### PR TITLE
Refactor ExpensesView and add obs to ExpenseRequest

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/ExpenseRequest.java
+++ b/src/main/java/uy/com/bay/utiles/data/ExpenseRequest.java
@@ -27,6 +27,16 @@ public class ExpenseRequest extends AbstractEntity {
     @Enumerated(EnumType.STRING)
     private ExpenseStatus expenseStatus;
 
+    private String obs;
+
+    public String getObs() {
+        return obs;
+    }
+
+    public void setObs(String obs) {
+        this.obs = obs;
+    }
+
     public Study getStudy() {
         return study;
     }


### PR DESCRIPTION
- Format date columns in ExpensesView to 'dd/MM/yyyy'.
- Add 'obs' attribute to ExpenseRequest entity.
- Add 'obs' text area to the edit form.
- Add 'Aprobar' button to the edit form, enabled only for 'INGRESADO' status.
- 'Aprobar' button changes status to 'APROBADO' and sets approval date.