### PR TITLE
Fix LazyInitializationException in ExpenseReportsView

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/ExpenseReport.java
+++ b/src/main/java/uy/com/bay/utiles/data/ExpenseReport.java
@@ -8,6 +8,7 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
@@ -29,7 +30,7 @@ public class ExpenseReport extends AbstractEntity {
     @Enumerated(EnumType.STRING)
     private ExpenseStatus expenseStatus;
 
-    @OneToMany(mappedBy = "expenseReport", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "expenseReport", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     private List<ExpenseReportFile> files = new ArrayList<>();
 
     public Study getStudy() {


### PR DESCRIPTION
This commit fixes a `LazyInitializationException` that occurred when accessing the `files` collection in a detached `ExpenseReport` entity.

The fix changes the fetch type of the `files` collection in the `ExpenseReport` entity from the default `LAZY` to `EAGER`. This ensures that the collection is loaded from the database at the same time as the parent entity, preventing the exception in the view layer.