### PR TITLE
feat: Add ExpenseReportApprovalView

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/ExpenseReport.java
+++ b/src/main/java/uy/com/bay/utiles/data/ExpenseReport.java
@@ -30,8 +30,18 @@ public class ExpenseReport extends AbstractEntity {
 	@Enumerated(EnumType.STRING)
 	private ExpenseReportStatus status;
 
+	private Date approvalDate;
+
 	@OneToMany(mappedBy = "expenseReport", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
 	private List<ExpenseReportFile> files = new ArrayList<>();
+
+	public Date getApprovalDate() {
+		return approvalDate;
+	}
+
+	public void setApprovalDate(Date approvalDate) {
+		this.approvalDate = approvalDate;
+	}
 
 	public Study getStudy() {
 		return study;
@@ -73,11 +83,11 @@ public class ExpenseReport extends AbstractEntity {
 		this.concept = concept;
 	}
 
-	public ExpenseReportStatus getExpenseStatus() {
+	public ExpenseReportStatus getStatus() {
 		return status;
 	}
 
-	public void setExpenseReportStatus(ExpenseReportStatus expenseReportStatus) {
+	public void setStatus(ExpenseReportStatus expenseReportStatus) {
 		this.status = expenseReportStatus;
 	}
 

--- a/src/main/java/uy/com/bay/utiles/data/repository/ExpenseReportRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/ExpenseReportRepository.java
@@ -3,6 +3,11 @@ package uy.com.bay.utiles.data.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import uy.com.bay.utiles.data.ExpenseReport;
+import uy.com.bay.utiles.data.ExpenseReportStatus;
+
+import java.util.List;
 
 public interface ExpenseReportRepository extends JpaRepository<ExpenseReport, Long>, JpaSpecificationExecutor<ExpenseReport> {
+
+    List<ExpenseReport> findAllByStatus(ExpenseReportStatus status);
 }

--- a/src/main/java/uy/com/bay/utiles/services/ExpenseReportService.java
+++ b/src/main/java/uy/com/bay/utiles/services/ExpenseReportService.java
@@ -4,10 +4,19 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
 import uy.com.bay.utiles.data.ExpenseReport;
+import uy.com.bay.utiles.data.ExpenseReportStatus;
 import uy.com.bay.utiles.data.repository.ExpenseReportRepository;
 
+import java.util.Date;
+import java.util.List;
+import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 public class ExpenseReportService {
@@ -40,6 +49,18 @@ public class ExpenseReportService {
 
     public Page<ExpenseReport> list(Pageable pageable, Specification<ExpenseReport> filter) {
         return repository.findAll(filter, pageable);
+    }
+
+    public List<ExpenseReport> findAllByStatus(ExpenseReportStatus status) {
+        return repository.findAllByStatus(status);
+    }
+
+    public void approveReports(Collection<ExpenseReport> reports) {
+        reports.forEach(report -> {
+            report.setStatus(ExpenseReportStatus.APROBADO);
+            report.setApprovalDate(new Date());
+            repository.save(report);
+        });
     }
 
     public long count(Specification<ExpenseReport> filter) {

--- a/src/main/java/uy/com/bay/utiles/views/MainLayout.java
+++ b/src/main/java/uy/com/bay/utiles/views/MainLayout.java
@@ -104,6 +104,9 @@ public class MainLayout extends AppLayout {
 		gastosItem.addItem(aprobarSolicitudesItem);
 		SideNavItem rendicionesItem = new SideNavItem("Rendiciones", "expense-reports");
 		rendicionesItem.setPrefixComponent(new Icon("vaadin", "file-text-o"));
+		SideNavItem aprobarRendicionesItem = new SideNavItem("Aprobar rendiciones", "expense-reports-approval");
+		aprobarRendicionesItem.setPrefixComponent(new Icon("vaadin", "check-square-o"));
+		rendicionesItem.addItem(aprobarRendicionesItem);
  		gastosItem.addItem(rendicionesItem);
 		nav.addItem(gastosItem);
 

--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportApprovalView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportApprovalView.java
@@ -1,0 +1,139 @@
+package uy.com.bay.utiles.views.expenses;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.GridVariant;
+import com.vaadin.flow.component.grid.HeaderRow;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.orderedlayout.FlexComponent;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.provider.ListDataProvider;
+import com.vaadin.flow.router.PageTitle;
+import java.util.Comparator;
+import com.vaadin.flow.router.Route;
+import jakarta.annotation.security.PermitAll;
+import uy.com.bay.utiles.data.ExpenseReport;
+import uy.com.bay.utiles.data.ExpenseReportStatus;
+import uy.com.bay.utiles.services.ExpenseReportService;
+import uy.com.bay.utiles.views.MainLayout;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@PageTitle("Aprobar Rendiciones")
+@Route(value = "expense-reports-approval", layout = MainLayout.class)
+@PermitAll
+public class ExpenseReportApprovalView extends Div {
+
+    private final ExpenseReportService expenseReportService;
+    private final Grid<ExpenseReport> grid = new Grid<>(ExpenseReport.class, false);
+    private ListDataProvider<ExpenseReport> dataProvider;
+
+    public ExpenseReportApprovalView(ExpenseReportService expenseReportService) {
+        this.expenseReportService = expenseReportService;
+        addClassName("expensereport-approval-view");
+        setSizeFull();
+        createGrid();
+        add(createToolbar(), grid);
+    }
+
+    private HorizontalLayout createToolbar() {
+        Button approveButton = new Button("Aprobar rendiciones", event -> approveSelectedReports());
+        approveButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+
+        H2 title = new H2("Aprobar Rendiciones");
+        HorizontalLayout toolbar = new HorizontalLayout(title, approveButton);
+        toolbar.setWidthFull();
+        toolbar.setAlignItems(FlexComponent.Alignment.BASELINE);
+        toolbar.setFlexGrow(1, title);
+        return toolbar;
+    }
+
+    private void createGrid() {
+        grid.addThemeVariants(GridVariant.LUMO_NO_BORDER, GridVariant.LUMO_ROW_STRIPES);
+        grid.setSelectionMode(Grid.SelectionMode.MULTI);
+
+        grid.addComponentColumn(report -> {
+            com.vaadin.flow.component.checkbox.Checkbox checkbox = new com.vaadin.flow.component.checkbox.Checkbox();
+            checkbox.setValue(grid.getSelectedItems().contains(report));
+            checkbox.addValueChangeListener(event -> {
+                if (event.getValue()) {
+                    grid.select(report);
+                } else {
+                    grid.deselect(report);
+                }
+            });
+            return checkbox;
+        }).setHeader("").setFlexGrow(0);
+
+        Grid.Column<ExpenseReport> dateColumn = grid.addColumn(ExpenseReport::getDate).setHeader("Date").setSortable(true);
+        Grid.Column<ExpenseReport> surveyorColumn = grid.addColumn(report -> report.getSurveyor().getFirstName() + " " + report.getSurveyor().getLastName()).setHeader("Surveyor").setSortable(true);
+        Grid.Column<ExpenseReport> studyColumn = grid.addColumn(report -> report.getStudy().getName()).setHeader("Study").setSortable(true);
+        Grid.Column<ExpenseReport> amountColumn = grid.addColumn(ExpenseReport::getAmount).setHeader("Amount").setSortable(true);
+        Grid.Column<ExpenseReport> conceptColumn = grid.addColumn(report -> report.getConcept().getName()).setHeader("Concept").setSortable(true);
+        Grid.Column<ExpenseReport> statusColumn = grid.addColumn(ExpenseReport::getStatus).setHeader("Status").setSortable(true);
+
+        // Fetch and set data
+        List<ExpenseReport> reports = expenseReportService.findAllByStatus(ExpenseReportStatus.INGRESADO);
+        reports.sort(Comparator.comparing(ExpenseReport::getDate).reversed());
+        dataProvider = new ListDataProvider<>(reports);
+        grid.setDataProvider(dataProvider);
+
+        // Create filters
+        HeaderRow filterRow = grid.appendHeaderRow();
+
+        // Date filter
+        TextField dateFilter = new TextField();
+        dateFilter.setPlaceholder("Filter by date...");
+        dateFilter.addValueChangeListener(event -> dataProvider.addFilter(
+            report -> report.getDate().toString().contains(event.getValue())));
+        filterRow.getCell(dateColumn).setComponent(dateFilter);
+
+        // Surveyor filter
+        TextField surveyorFilter = new TextField();
+        surveyorFilter.setPlaceholder("Filter by surveyor...");
+        surveyorFilter.addValueChangeListener(event -> dataProvider.addFilter(
+            report -> (report.getSurveyor().getFirstName() + " " + report.getSurveyor().getLastName()).toLowerCase().contains(event.getValue().toLowerCase())));
+        filterRow.getCell(surveyorColumn).setComponent(surveyorFilter);
+
+        // Study filter
+        TextField studyFilter = new TextField();
+        studyFilter.setPlaceholder("Filter by study...");
+        studyFilter.addValueChangeListener(event -> dataProvider.addFilter(
+            report -> report.getStudy().getName().toLowerCase().contains(event.getValue().toLowerCase())));
+        filterRow.getCell(studyColumn).setComponent(studyFilter);
+
+        // Amount filter
+        TextField amountFilter = new TextField();
+        amountFilter.setPlaceholder("Filter by amount...");
+        amountFilter.addValueChangeListener(event -> dataProvider.addFilter(
+            report -> report.getAmount().toString().contains(event.getValue())));
+        filterRow.getCell(amountColumn).setComponent(amountFilter);
+
+        // Concept filter
+        TextField conceptFilter = new TextField();
+        conceptFilter.setPlaceholder("Filter by concept...");
+        conceptFilter.addValueChangeListener(event -> dataProvider.addFilter(
+            report -> report.getConcept().getName().toLowerCase().contains(event.getValue().toLowerCase())));
+        filterRow.getCell(conceptColumn).setComponent(conceptFilter);
+
+        // Status filter
+        TextField statusFilter = new TextField();
+        statusFilter.setPlaceholder("Filter by status...");
+        statusFilter.addValueChangeListener(event -> dataProvider.addFilter(
+            report -> report.getStatus().toString().toLowerCase().contains(event.getValue().toLowerCase())));
+        filterRow.getCell(statusColumn).setComponent(statusFilter);
+
+    }
+
+    private void approveSelectedReports() {
+        expenseReportService.approveReports(grid.getSelectedItems());
+        grid.getSelectionModel().deselectAll();
+        UI.getCurrent().getPage().reload();
+    }
+}


### PR DESCRIPTION
This commit introduces the ExpenseReportApprovalView, a new view that allows users to approve expense reports.

The view includes a grid with filters for each column, and lists all expense reports with the status 'INGRESADO', sorted by date in descending order.

A button 'Aprobar rendiciones' allows users to approve selected reports, which updates their status to 'APROBADO' and sets the 'approvalDate' to the current date.

The ExpenseReport entity has been updated to include the 'approvalDate' field, and the corresponding service and repository have been updated to handle the new functionality.

A link to the new view has been added to the main layout's side navigation under 'Rendiciones'.