### PR TITLE
feat: Add expense transfer feature

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/ExpenseTransfer.java
+++ b/src/main/java/uy/com/bay/utiles/data/ExpenseTransfer.java
@@ -1,0 +1,53 @@
+package uy.com.bay.utiles.data;
+
+import java.util.Date;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+
+@Entity
+public class ExpenseTransfer extends AbstractEntity {
+
+    private Date transferDate;
+    private Double amount;
+
+    @OneToMany
+    private List<ExpenseRequest> expenseRequests;
+
+    @OneToMany(mappedBy = "expenseTransfer", cascade = CascadeType.ALL)
+    private List<ExpenseTransferFile> files;
+
+    public Date getTransferDate() {
+        return transferDate;
+    }
+
+    public void setTransferDate(Date transferDate) {
+        this.transferDate = transferDate;
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Double amount) {
+        this.amount = amount;
+    }
+
+    public List<ExpenseRequest> getExpenseRequests() {
+        return expenseRequests;
+    }
+
+    public void setExpenseRequests(List<ExpenseRequest> expenseRequests) {
+        this.expenseRequests = expenseRequests;
+    }
+
+    public List<ExpenseTransferFile> getFiles() {
+        return files;
+    }
+
+    public void setFiles(List<ExpenseTransferFile> files) {
+        this.files = files;
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/data/ExpenseTransferFile.java
+++ b/src/main/java/uy/com/bay/utiles/data/ExpenseTransferFile.java
@@ -1,0 +1,55 @@
+package uy.com.bay.utiles.data;
+
+import java.util.Date;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class ExpenseTransferFile extends AbstractEntity {
+
+    private String name;
+    private Date created;
+
+    @Lob
+    private byte[] content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "expense_transfer_id")
+    private ExpenseTransfer expenseTransfer;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Date getCreated() {
+        return created;
+    }
+
+    public void setCreated(Date created) {
+        this.created = created;
+    }
+
+    public byte[] getContent() {
+        return content;
+    }
+
+    public void setContent(byte[] content) {
+        this.content = content;
+    }
+
+    public ExpenseTransfer getExpenseTransfer() {
+        return expenseTransfer;
+    }
+
+    public void setExpenseTransfer(ExpenseTransfer expenseTransfer) {
+        this.expenseTransfer = expenseTransfer;
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/data/Surveyor.java
+++ b/src/main/java/uy/com/bay/utiles/data/Surveyor.java
@@ -42,4 +42,8 @@ public class Surveyor extends AbstractEntity {
 		this.ci = ci;
 	}
 
+	@jakarta.persistence.Transient
+	public String getName() {
+		return (firstName != null ? firstName : "") + " " + (lastName != null ? lastName : "");
+	}
 }

--- a/src/main/java/uy/com/bay/utiles/data/repository/ExpenseTransferFileRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/ExpenseTransferFileRepository.java
@@ -1,0 +1,7 @@
+package uy.com.bay.utiles.data.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import uy.com.bay.utiles.data.ExpenseTransferFile;
+
+public interface ExpenseTransferFileRepository extends JpaRepository<ExpenseTransferFile, Long> {
+}

--- a/src/main/java/uy/com/bay/utiles/data/repository/ExpenseTransferRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/ExpenseTransferRepository.java
@@ -1,0 +1,7 @@
+package uy.com.bay.utiles.data.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import uy.com.bay.utiles.data.ExpenseTransfer;
+
+public interface ExpenseTransferRepository extends JpaRepository<ExpenseTransfer, Long> {
+}

--- a/src/main/java/uy/com/bay/utiles/services/ExpenseTransferFileService.java
+++ b/src/main/java/uy/com/bay/utiles/services/ExpenseTransferFileService.java
@@ -1,0 +1,43 @@
+package uy.com.bay.utiles.services;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import uy.com.bay.utiles.data.ExpenseTransferFile;
+import uy.com.bay.utiles.data.repository.ExpenseTransferFileRepository;
+
+import java.util.Optional;
+
+@Service
+public class ExpenseTransferFileService {
+
+    private final ExpenseTransferFileRepository repository;
+
+    public ExpenseTransferFileService(ExpenseTransferFileRepository repository) {
+        this.repository = repository;
+    }
+
+    public Optional<ExpenseTransferFile> get(Long id) {
+        return repository.findById(id);
+    }
+
+    public ExpenseTransferFile update(ExpenseTransferFile entity) {
+        return repository.save(entity);
+    }
+
+    public ExpenseTransferFile save(ExpenseTransferFile entity) {
+        return repository.save(entity);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+
+    public Page<ExpenseTransferFile> list(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+    public int count() {
+        return (int) repository.count();
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/services/ExpenseTransferService.java
+++ b/src/main/java/uy/com/bay/utiles/services/ExpenseTransferService.java
@@ -1,0 +1,43 @@
+package uy.com.bay.utiles.services;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import uy.com.bay.utiles.data.ExpenseTransfer;
+import uy.com.bay.utiles.data.repository.ExpenseTransferRepository;
+
+import java.util.Optional;
+
+@Service
+public class ExpenseTransferService {
+
+    private final ExpenseTransferRepository repository;
+
+    public ExpenseTransferService(ExpenseTransferRepository repository) {
+        this.repository = repository;
+    }
+
+    public Optional<ExpenseTransfer> get(Long id) {
+        return repository.findById(id);
+    }
+
+    public ExpenseTransfer update(ExpenseTransfer entity) {
+        return repository.save(entity);
+    }
+
+    public ExpenseTransfer save(ExpenseTransfer entity) {
+        return repository.save(entity);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+
+    public Page<ExpenseTransfer> list(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+    public int count() {
+        return (int) repository.count();
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/views/MainLayout.java
+++ b/src/main/java/uy/com/bay/utiles/views/MainLayout.java
@@ -96,8 +96,14 @@ public class MainLayout extends AppLayout {
 		SideNavItem conceptosItem = new SideNavItem("Conceptos", "conceptos");
 		conceptosItem.setPrefixComponent(new Icon("vaadin", "file-text-o"));
 		gastosItem.addItem(conceptosItem);
-		SideNavItem solicitudesItem = new SideNavItem("Solicitudes", "expenses");
+		SideNavItem solicitudesItem = new SideNavItem("Solicitudes");
 		solicitudesItem.setPrefixComponent(new Icon("vaadin", "file-text-o"));
+		SideNavItem verSolicitudesItem = new SideNavItem("Ver Solicitudes", "expenses");
+		verSolicitudesItem.setPrefixComponent(new Icon("vaadin", "list"));
+		solicitudesItem.addItem(verSolicitudesItem);
+		SideNavItem transferirSolicitudesItem = new SideNavItem("Transferir Solicitudes", "expense-transfer");
+		transferirSolicitudesItem.setPrefixComponent(new Icon("vaadin", "exchange"));
+		solicitudesItem.addItem(transferirSolicitudesItem);
 		gastosItem.addItem(solicitudesItem);
 		SideNavItem aprobarSolicitudesItem = new SideNavItem("Aprobar solicitudes", "expenses-approval");
 		aprobarSolicitudesItem.setPrefixComponent(new Icon("vaadin", "check-square-o"));

--- a/src/main/java/uy/com/bay/utiles/views/expensetransfer/ExpenseTransferDialog.java
+++ b/src/main/java/uy/com/bay/utiles/views/expensetransfer/ExpenseTransferDialog.java
@@ -1,0 +1,136 @@
+package uy.com.bay.utiles.views.expensetransfer;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.textfield.NumberField;
+import com.vaadin.flow.component.upload.Upload;
+import com.vaadin.flow.component.upload.receivers.MultiFileMemoryBuffer;
+import com.vaadin.flow.data.binder.BeanValidationBinder;
+import uy.com.bay.utiles.data.ExpenseRequest;
+import uy.com.bay.utiles.data.ExpenseTransfer;
+
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.shared.Registration;
+import uy.com.bay.utiles.data.ExpenseTransferFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+public class ExpenseTransferDialog extends Dialog {
+
+    private DatePicker transferDate;
+    private NumberField amount;
+    private Upload upload;
+    protected MultiFileMemoryBuffer buffer;
+
+    private Button saveButton;
+    private Button cancelButton;
+
+    private BeanValidationBinder<ExpenseTransfer> binder;
+
+    protected ExpenseTransfer expenseTransfer;
+    protected Set<ExpenseRequest> selectedRequests;
+
+    public ExpenseTransferDialog(Set<ExpenseRequest> selectedRequests) {
+        this.selectedRequests = selectedRequests;
+        this.expenseTransfer = new ExpenseTransfer();
+
+        setHeaderTitle("Crear Transferencia");
+
+        FormLayout formLayout = new FormLayout();
+        transferDate = new DatePicker("Fecha de Transferencia");
+        transferDate.setValue(LocalDate.now());
+
+        amount = new NumberField("Monto");
+        amount.setReadOnly(true);
+        double totalAmount = selectedRequests.stream().mapToDouble(ExpenseRequest::getAmount).sum();
+        amount.setValue(totalAmount);
+
+        buffer = new MultiFileMemoryBuffer();
+        upload = new Upload(buffer);
+        upload.setAcceptedFileTypes("image/jpeg", "image/png", "application/pdf", ".doc", ".docx", ".xls", ".xlsx");
+        upload.setMaxFiles(5);
+        upload.setMaxFileSize(10 * 1024 * 1024); // 10MB
+
+        formLayout.add(transferDate, amount, upload);
+        add(formLayout);
+
+        createButtons();
+        getFooter().add(new HorizontalLayout(saveButton, cancelButton));
+
+        binder = new BeanValidationBinder<>(ExpenseTransfer.class);
+        binder.bind(amount, "amount");
+
+        binder.readBean(expenseTransfer);
+        expenseTransfer.setAmount(totalAmount);
+    }
+
+    private void createButtons() {
+        saveButton = new Button("Guardar", e -> save());
+        saveButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+
+        cancelButton = new Button("Cancelar", e -> close());
+    }
+
+    private void save() {
+        try {
+            if (binder.writeBeanIfValid(expenseTransfer)) {
+                List<ExpenseTransferFile> files = new ArrayList<>();
+                for (String fileName : buffer.getFiles()) {
+                    InputStream inputStream = buffer.getInputStream(fileName);
+                    byte[] content = inputStream.readAllBytes();
+
+                    ExpenseTransferFile file = new ExpenseTransferFile();
+                    file.setName(fileName);
+                    file.setCreated(new Date());
+                    file.setContent(content);
+                    file.setExpenseTransfer(expenseTransfer); // Link file to transfer
+                    files.add(file);
+                }
+                expenseTransfer.setFiles(files);
+                expenseTransfer.setExpenseRequests(new ArrayList<>(selectedRequests));
+
+                fireEvent(new SaveEvent(this, expenseTransfer));
+                close();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // Events
+    public static abstract class ExpenseTransferDialogEvent extends ComponentEvent<ExpenseTransferDialog> {
+        private final ExpenseTransfer expenseTransfer;
+
+        protected ExpenseTransferDialogEvent(ExpenseTransferDialog source, ExpenseTransfer expenseTransfer) {
+            super(source, false);
+            this.expenseTransfer = expenseTransfer;
+        }
+
+        public ExpenseTransfer getExpenseTransfer() {
+            return expenseTransfer;
+        }
+    }
+
+    public static class SaveEvent extends ExpenseTransferDialogEvent {
+        SaveEvent(ExpenseTransferDialog source, ExpenseTransfer expenseTransfer) {
+            super(source, expenseTransfer);
+        }
+    }
+
+    public <T extends ComponentEvent<?>> Registration addListener(Class<T> eventType,
+                                                                  ComponentEventListener<T> listener) {
+        return getEventBus().addListener(eventType, listener);
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/views/expensetransfer/ExpenseTransferView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expensetransfer/ExpenseTransferView.java
@@ -1,0 +1,179 @@
+package uy.com.bay.utiles.views.expensetransfer;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.Grid.SelectionMode;
+import com.vaadin.flow.data.provider.QuerySortOrder;
+import com.vaadin.flow.component.grid.HeaderRow;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.provider.SortDirection;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import jakarta.annotation.security.PermitAll;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import uy.com.bay.utiles.data.ExpenseRequest;
+import uy.com.bay.utiles.data.ExpenseStatus;
+import uy.com.bay.utiles.data.ExpenseTransfer;
+import uy.com.bay.utiles.services.ExpenseRequestService;
+import uy.com.bay.utiles.views.MainLayout;
+
+import java.util.Date;
+import java.util.List;
+
+import uy.com.bay.utiles.services.ExpenseTransferFileService;
+import uy.com.bay.utiles.services.ExpenseTransferService;
+
+@PageTitle("Transferir Solicitudes")
+@Route(value = "expense-transfer", layout = MainLayout.class)
+@PermitAll
+public class ExpenseTransferView extends VerticalLayout {
+
+    private final ExpenseRequestService expenseRequestService;
+    private final ExpenseTransferService expenseTransferService;
+    private final ExpenseTransferFileService expenseTransferFileService;
+
+    private Grid<ExpenseRequest> grid;
+    private Button transferButton;
+
+    private TextField surveyorFilter;
+    private TextField studyFilter;
+    private TextField conceptFilter;
+    private TextField obsFilter;
+
+    public ExpenseTransferView(ExpenseRequestService expenseRequestService,
+                               ExpenseTransferService expenseTransferService,
+                               ExpenseTransferFileService expenseTransferFileService) {
+        this.expenseRequestService = expenseRequestService;
+        this.expenseTransferService = expenseTransferService;
+        this.expenseTransferFileService = expenseTransferFileService;
+        addClassName("expensetransfer-view");
+        setSizeFull();
+
+        HorizontalLayout buttonLayout = new HorizontalLayout();
+        buttonLayout.setWidthFull();
+        createTransferButton();
+        buttonLayout.add(transferButton);
+
+        createGrid();
+
+        add(buttonLayout, grid);
+        refreshGrid();
+    }
+
+    private void createGrid() {
+        grid = new Grid<>(ExpenseRequest.class, false);
+        grid.setSelectionMode(SelectionMode.MULTI);
+
+        Grid.Column<ExpenseRequest> surveyorColumn = grid.addColumn(er -> er.getSurveyor() != null ? er.getSurveyor().getName() : "").setHeader("Encuestador").setSortable(true).setKey("surveyor.lastName");
+        Grid.Column<ExpenseRequest> studyColumn = grid.addColumn(er -> er.getStudy() != null ? er.getStudy().getName() : "").setHeader("Proyecto").setSortable(true).setKey("study.name");
+        grid.addColumn(ExpenseRequest::getRequestDate).setHeader("Fecha Solicitud").setSortable(true).setKey("requestDate");
+        grid.addColumn(ExpenseRequest::getAmount).setHeader("Monto").setSortable(true).setKey("amount");
+        Grid.Column<ExpenseRequest> conceptColumn = grid.addColumn(er -> er.getConcept() != null ? er.getConcept().getDescription() : "").setHeader("Concepto").setSortable(true).setKey("concept.description");
+        Grid.Column<ExpenseRequest> obsColumn = grid.addColumn(ExpenseRequest::getObs).setHeader("Observaciones");
+
+        HeaderRow filterRow = grid.appendHeaderRow();
+
+        surveyorFilter = new TextField();
+        surveyorFilter.setPlaceholder("Filtrar");
+        surveyorFilter.setClearButtonVisible(true);
+        surveyorFilter.addValueChangeListener(e -> refreshGrid());
+        filterRow.getCell(surveyorColumn).setComponent(surveyorFilter);
+
+        studyFilter = new TextField();
+        studyFilter.setPlaceholder("Filtrar");
+        studyFilter.setClearButtonVisible(true);
+        studyFilter.addValueChangeListener(e -> refreshGrid());
+        filterRow.getCell(studyColumn).setComponent(studyFilter);
+
+        conceptFilter = new TextField();
+        conceptFilter.setPlaceholder("Filtrar");
+        conceptFilter.setClearButtonVisible(true);
+        conceptFilter.addValueChangeListener(e -> refreshGrid());
+        filterRow.getCell(conceptColumn).setComponent(conceptFilter);
+
+        obsFilter = new TextField();
+        obsFilter.setPlaceholder("Filtrar");
+        obsFilter.setClearButtonVisible(true);
+        obsFilter.addValueChangeListener(e -> refreshGrid());
+        filterRow.getCell(obsColumn).setComponent(obsFilter);
+
+        grid.addThemeVariants(com.vaadin.flow.component.grid.GridVariant.LUMO_NO_BORDER);
+        grid.asMultiSelect().addValueChangeListener(event -> {
+            transferButton.setEnabled(!event.getValue().isEmpty());
+        });
+    }
+
+    private void createTransferButton() {
+        transferButton = new Button("Transferir solicitudes");
+        transferButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        transferButton.setEnabled(false);
+        transferButton.addClickListener(e -> {
+            if (!grid.getSelectedItems().isEmpty()) {
+                ExpenseTransferDialog dialog = new ExpenseTransferDialog(grid.getSelectedItems());
+                dialog.addListener(ExpenseTransferDialog.SaveEvent.class, this::saveTransfer);
+                dialog.open();
+            }
+        });
+    }
+
+    private void saveTransfer(ExpenseTransferDialog.SaveEvent event) {
+        ExpenseTransfer expenseTransfer = event.getExpenseTransfer();
+        Date now = new Date();
+        expenseTransfer.setTransferDate(now);
+
+        // 1. Save ExpenseTransfer with files
+        expenseTransferService.save(expenseTransfer);
+
+        // 2. Update ExpenseRequests
+        List<ExpenseRequest> requestsToUpdate = expenseTransfer.getExpenseRequests();
+        for (ExpenseRequest request : requestsToUpdate) {
+            request.setExpenseStatus(ExpenseStatus.TRANSFERIDO);
+            request.setTransferDate(now);
+            expenseRequestService.update(request);
+        }
+
+        // 3. Refresh grid
+        refreshGrid();
+
+        // 4. Show notification
+        Notification.show("Transferencia creada exitosamente.", 3000, Notification.Position.BOTTOM_START);
+    }
+
+    private void refreshGrid() {
+        grid.setItems(query -> {
+            List<QuerySortOrder> sortOrders = query.getSortOrders();
+            Sort sort;
+            if (sortOrders.isEmpty()) {
+                sort = Sort.by(Sort.Direction.DESC, "requestDate");
+            } else {
+                QuerySortOrder order = sortOrders.get(0);
+                sort = Sort.by(order.getDirection() == SortDirection.ASCENDING ? Sort.Direction.ASC : Sort.Direction.DESC, order.getSorted());
+            }
+
+            PageRequest pageRequest = PageRequest.of(query.getPage(), query.getPageSize(), sort);
+
+            Specification<ExpenseRequest> spec = (root, q, cb) -> cb.equal(root.get("expenseStatus"), ExpenseStatus.APROBADO);
+
+            if (surveyorFilter != null && !surveyorFilter.isEmpty()) {
+                spec = spec.and((root, q, cb) -> cb.like(cb.lower(root.get("surveyor").get("lastName")), "%" + surveyorFilter.getValue().toLowerCase() + "%"));
+            }
+            if (studyFilter != null && !studyFilter.isEmpty()) {
+                spec = spec.and((root, q, cb) -> cb.like(cb.lower(root.get("study").get("name")), "%" + studyFilter.getValue().toLowerCase() + "%"));
+            }
+            if (conceptFilter != null && !conceptFilter.isEmpty()) {
+                spec = spec.and((root, q, cb) -> cb.like(cb.lower(root.get("concept").get("description")), "%" + conceptFilter.getValue().toLowerCase() + "%"));
+            }
+            if (obsFilter != null && !obsFilter.isEmpty()) {
+                spec = spec.and((root, q, cb) -> cb.like(cb.lower(root.get("obs")), "%" + obsFilter.getValue().toLowerCase() + "%"));
+            }
+
+            return expenseRequestService.list(pageRequest, spec).stream();
+        });
+    }
+}


### PR DESCRIPTION
This commit introduces a new feature to transfer approved expense requests.

- Adds `ExpenseTransfer` and `ExpenseTransferFile` entities to store transfer information and associated files.
- Creates `ExpenseTransferRepository` and `ExpenseTransferService` for data access and business logic.
- Implements `ExpenseTransferView` which displays a grid of approved expense requests with filtering capabilities.
- A dialog (`ExpenseTransferDialog`) allows users to create a transfer, which includes setting a date, viewing the total amount, and uploading files.
- Upon saving a transfer, the selected expense requests are updated to "TRANSFERIDO" status, and their `transferDate` is set to the current date.
- Adds a navigation link to the new view under a "Solicitudes" dropdown in the main layout.
- Adds a helper method `getName()` to the `Surveyor` entity for display purposes in the new view.