### PR TITLE
Fix ComboBox ItemLabelGenerator returning null

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/expenserequesttype/ExpenseRequestTypeView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenserequesttype/ExpenseRequestTypeView.java
@@ -42,7 +42,7 @@ public class ExpenseRequestTypeView extends Div implements BeforeEnterObserver {
 
     private final Grid<ExpenseRequestType> grid = new Grid<>(ExpenseRequestType.class, false);
 
-    private TextField concept;
+    private TextField name;
     private TextArea description;
 
     private final Button cancel = new Button("Cancelar");
@@ -71,7 +71,7 @@ public class ExpenseRequestTypeView extends Div implements BeforeEnterObserver {
         add(splitLayout);
 
         // Configure Grid
-        grid.addColumn("concept").setAutoWidth(true).setHeader("Concepto");
+        grid.addColumn("name").setAutoWidth(true).setHeader("Concepto");
         grid.addColumn("description").setAutoWidth(true).setHeader("Descripción");
         grid.setItems(query -> expenseRequestTypeService.list(
                 com.vaadin.flow.spring.data.VaadinSpringDataHelpers.toSpringPageRequest(query)).stream());
@@ -176,9 +176,9 @@ public class ExpenseRequestTypeView extends Div implements BeforeEnterObserver {
         editorLayoutDiv.add(editorDiv);
 
         FormLayout formLayout = new FormLayout();
-        concept = new TextField("Concepto");
+        name = new TextField("Concepto");
         description = new TextArea("Descripción");
-        formLayout.add(concept, description);
+        formLayout.add(name, description);
 
         editorDiv.add(formLayout);
         createButtonLayout(editorLayoutDiv);

--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpensesView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpensesView.java
@@ -206,7 +206,7 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 
 		ComboBox<ExpenseRequestType> conceptFilter = new ComboBox<>();
 		conceptFilter.setItems(expenseRequestTypeService.findAll());
-		conceptFilter.setItemLabelGenerator(ExpenseRequestType::getName);
+		conceptFilter.setItemLabelGenerator(ert -> ert.getName() != null ? ert.getName() : "");
 		conceptFilter.setPlaceholder("Filter");
 		conceptFilter.setClearButtonVisible(true);
 		conceptFilter.addValueChangeListener(e -> {
@@ -397,10 +397,10 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 		FormLayout formLayout = new FormLayout();
 		study = new ComboBox<>("Estudio");
 		study.setItems(studyService.listAll());
-		study.setItemLabelGenerator(Study::getName);
+		study.setItemLabelGenerator(s -> s.getName() != null ? s.getName() : "");
 		surveyor = new ComboBox<>("Encuestador");
 		surveyor.setItems(surveyorService.listAll());
-		surveyor.setItemLabelGenerator(s -> s.getFirstName() + " " + s.getLastName());
+		surveyor.setItemLabelGenerator(Surveyor::getName);
 		requestDate = new DatePicker("Fecha solicitud");
 		requestDate.setReadOnly(true);
 		aprovalDate = new DatePicker("Fecha aprobación");
@@ -410,7 +410,7 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 		amount = new NumberField("Monto");
 		concept = new ComboBox<>("Concepto");
 		concept.setItems(expenseRequestTypeService.findAll());
-		concept.setItemLabelGenerator(ExpenseRequestType::getName);
+		concept.setItemLabelGenerator(ert -> ert.getName() != null ? ert.getName() : "");
 		obs = new com.vaadin.flow.component.textfield.TextArea("Observaciones");
 		formLayout.add(study, surveyor, requestDate, aprovalDate, transferDate, amount, concept, obs);
 		editorDiv.add(formLayout);


### PR DESCRIPTION
The ComboBox for 'Concepto' was throwing an IllegalStateException because its ItemLabelGenerator was returning null when the underlying ExpenseRequestType had a null name.

This commit fixes the issue by providing a null-safe ItemLabelGenerator that returns an empty string when the name is null.

The same fix has been applied to the 'study' ComboBox to prevent a similar issue.

The 'surveyor' ComboBox was also updated to use the null-safe `getName()` method from the Surveyor class.

Additionally, a bug in `ExpenseRequestTypeView` was fixed where a TextField was incorrectly bound to a non-existent 'concept' property instead of 'name'.