### PR TITLE
Fix(ExpenseTransferDialog): Handle null amounts during sum

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/expensetransfer/ExpenseTransferDialog.java
+++ b/src/main/java/uy/com/bay/utiles/views/expensetransfer/ExpenseTransferDialog.java
@@ -54,7 +54,9 @@ public class ExpenseTransferDialog extends Dialog {
 
         amount = new NumberField("Monto");
         amount.setReadOnly(true);
-        double totalAmount = selectedRequests.stream().mapToDouble(ExpenseRequest::getAmount).sum();
+        double totalAmount = selectedRequests.stream()
+                .mapToDouble(er -> er.getAmount() != null ? er.getAmount() : 0)
+                .sum();
         amount.setValue(totalAmount);
 
         buffer = new MultiFileMemoryBuffer();


### PR DESCRIPTION
The constructor of `ExpenseTransferDialog` calculates the total amount from a set of `ExpenseRequest` objects. This calculation uses a stream and `mapToDouble`, which causes a `NullPointerException` if any `ExpenseRequest` has a `null` amount, due to unboxing a `null` `Double`.

This commit fixes the issue by adding a null check within the `mapToDouble` operation. If an amount is `null`, it is now treated as `0`, preventing the `NullPointerException` and ensuring the sum is calculated correctly.