### PR TITLE
Refactor ExpenseRequest and ExpenseTransfer relationship

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/ExpenseRequest.java
+++ b/src/main/java/uy/com/bay/utiles/data/ExpenseRequest.java
@@ -29,6 +29,9 @@ public class ExpenseRequest extends AbstractEntity {
 
     private String obs;
 
+    @ManyToOne
+    private ExpenseTransfer expenseTransfer;
+
     public String getObs() {
         return obs;
     }
@@ -99,5 +102,13 @@ public class ExpenseRequest extends AbstractEntity {
 
     public void setExpenseStatus(ExpenseStatus expenseStatus) {
         this.expenseStatus = expenseStatus;
+    }
+
+    public ExpenseTransfer getExpenseTransfer() {
+        return expenseTransfer;
+    }
+
+    public void setExpenseTransfer(ExpenseTransfer expenseTransfer) {
+        this.expenseTransfer = expenseTransfer;
     }
 }

--- a/src/main/java/uy/com/bay/utiles/data/ExpenseTransfer.java
+++ b/src/main/java/uy/com/bay/utiles/data/ExpenseTransfer.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
 @Entity
@@ -13,7 +14,10 @@ public class ExpenseTransfer extends AbstractEntity {
     private Date transferDate;
     private Double amount;
 
-    @OneToMany
+    @ManyToOne
+    private Surveyor surveyor;
+
+    @OneToMany(mappedBy = "expenseTransfer", cascade = CascadeType.ALL)
     private List<ExpenseRequest> expenseRequests;
 
     @OneToMany(mappedBy = "expenseTransfer", cascade = CascadeType.ALL)
@@ -49,5 +53,13 @@ public class ExpenseTransfer extends AbstractEntity {
 
     public void setFiles(List<ExpenseTransferFile> files) {
         this.files = files;
+    }
+
+    public Surveyor getSurveyor() {
+        return surveyor;
+    }
+
+    public void setSurveyor(Surveyor surveyor) {
+        this.surveyor = surveyor;
     }
 }


### PR DESCRIPTION
- Add a ManyToOne relationship from ExpenseRequest to ExpenseTransfer.
- Make the relationship bidirectional.
- Update the save method in ExpenseTransferDialog to validate that all selected ExpenseRequest entities have the same surveyor.
- Link the ExpenseRequest entities to the ExpenseTransfer entity when saving.