### PR TITLE
Fix detached entity error in ExpenseTransferView

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/expensetransfer/ExpenseTransferView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expensetransfer/ExpenseTransferView.java
@@ -23,6 +23,7 @@ import uy.com.bay.utiles.data.ExpenseTransfer;
 import uy.com.bay.utiles.services.ExpenseRequestService;
 import uy.com.bay.utiles.views.MainLayout;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -124,24 +125,22 @@ public class ExpenseTransferView extends VerticalLayout {
 
     private void saveTransfer(ExpenseTransferDialog.SaveEvent event) {
         ExpenseTransfer expenseTransfer = event.getExpenseTransfer();
+        List<ExpenseRequest> requestsToUpdate = new ArrayList<>(expenseTransfer.getExpenseRequests());
         Date now = new Date();
+
         expenseTransfer.setTransferDate(now);
+        expenseTransfer.setExpenseRequests(new ArrayList<>());
+        expenseTransfer = expenseTransferService.save(expenseTransfer);
 
-        // 1. Save ExpenseTransfer with files
-        expenseTransferService.save(expenseTransfer);
-
-        // 2. Update ExpenseRequests
-        List<ExpenseRequest> requestsToUpdate = expenseTransfer.getExpenseRequests();
         for (ExpenseRequest request : requestsToUpdate) {
             request.setExpenseStatus(ExpenseStatus.TRANSFERIDO);
             request.setTransferDate(now);
+            request.setExpenseTransfer(expenseTransfer);
             expenseRequestService.update(request);
         }
 
-        // 3. Refresh grid
         refreshGrid();
 
-        // 4. Show notification
         Notification.show("Transferencia creada exitosamente.", 3000, Notification.Position.BOTTOM_START);
     }
 


### PR DESCRIPTION
The `saveTransfer` method was attempting to save a new `ExpenseTransfer` entity with a list of detached `ExpenseRequest` entities. This caused a `detached entity passed to persist` exception due to the `CascadeType.ALL` on the `expenseRequests` collection.

The fix is to change the persistence logic:
1.  Save the `ExpenseTransfer` object first with an empty list of requests to get a managed, persistent entity.
2.  Iterate through the `ExpenseRequest` objects, update their status, and associate them with the now-managed `ExpenseTransfer`.
3.  Save each updated `ExpenseRequest` individually.

This resolves the detached entity exception and also prevents the `ObjectOptimisticLockingFailureException` that was occurring as a downstream effect.