### PR TITLE
feat: Add 'View Transfer' button and dialog to ExpensesView

### DIFF
--- a/src/main/java/uy/com/bay/utiles/controllers/FileDownloadController.java
+++ b/src/main/java/uy/com/bay/utiles/controllers/FileDownloadController.java
@@ -1,0 +1,38 @@
+package uy.com.bay.utiles.controllers;
+
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uy.com.bay.utiles.data.ExpenseTransferFile;
+import uy.com.bay.utiles.services.ExpenseTransferFileService;
+
+@RestController
+@RequestMapping("/api/files")
+public class FileDownloadController {
+
+    private final ExpenseTransferFileService expenseTransferFileService;
+
+    public FileDownloadController(ExpenseTransferFileService expenseTransferFileService) {
+        this.expenseTransferFileService = expenseTransferFileService;
+    }
+
+    @GetMapping("/{fileId}")
+    public ResponseEntity<Resource> downloadFile(@PathVariable Long fileId) {
+        ExpenseTransferFile file = expenseTransferFileService.get(fileId)
+                .orElseThrow(() -> new RuntimeException("File not found with id " + fileId));
+
+        ByteArrayResource resource = new ByteArrayResource(file.getContent());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file.getName() + "\"")
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .contentLength(file.getContent().length)
+                .body(resource);
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/views/expensetransfer/ExpenseTransferViewDialog.java
+++ b/src/main/java/uy/com/bay/utiles/views/expensetransfer/ExpenseTransferViewDialog.java
@@ -1,0 +1,52 @@
+package uy.com.bay.utiles.views.expensetransfer;
+
+import com.vaadin.flow.component.html.Anchor;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import uy.com.bay.utiles.data.ExpenseTransfer;
+import uy.com.bay.utiles.data.ExpenseTransferFile;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.textfield.NumberField;
+
+import java.util.List;
+
+public class ExpenseTransferViewDialog extends Dialog {
+
+    public ExpenseTransferViewDialog(ExpenseTransfer expenseTransfer) {
+        setHeaderTitle("Detalles de la Transferencia");
+
+        FormLayout formLayout = new FormLayout();
+        DatePicker transferDate = new DatePicker("Fecha de Transferencia");
+        transferDate.setValue(new java.sql.Date(expenseTransfer.getTransferDate().getTime()).toLocalDate());
+        transferDate.setReadOnly(true);
+
+        NumberField amount = new NumberField("Monto");
+        amount.setValue(expenseTransfer.getAmount());
+        amount.setReadOnly(true);
+
+        formLayout.add(transferDate, amount);
+        add(formLayout);
+
+        List<ExpenseTransferFile> files = expenseTransfer.getFiles();
+        if (files != null && !files.isEmpty()) {
+            VerticalLayout filesLayout = new VerticalLayout();
+            filesLayout.setSpacing(false);
+            filesLayout.setPadding(false);
+
+            com.vaadin.flow.component.html.H4 filesHeader = new com.vaadin.flow.component.html.H4("Archivos adjuntos");
+            filesLayout.add(filesHeader);
+
+            for (ExpenseTransferFile file : files) {
+                String downloadUrl = "/api/files/" + file.getId();
+                Anchor downloadLink = new Anchor(downloadUrl, file.getName());
+                downloadLink.setTarget("_blank");
+                filesLayout.add(downloadLink);
+            }
+            add(filesLayout);
+        }
+
+        setCloseOnEsc(true);
+        setCloseOnOutsideClick(true);
+    }
+}


### PR DESCRIPTION
This commit introduces a new 'View Transfer' button in the ExpenseRequest edit form within ExpensesView. The button is enabled only when the expense status is 'TRANSFERIDO' or 'RENDIDO'.

When clicked, a new dialog opens, displaying the details of the associated ExpenseTransfer, including the transfer date, amount, and a list of downloadable files.

A new FileDownloadController has been added to handle file downloads securely.