### PR TITLE
Fix LazyInitializationException in ExpenseTransferViewDialog

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/ExpenseTransfer.java
+++ b/src/main/java/uy/com/bay/utiles/data/ExpenseTransfer.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
@@ -20,7 +21,7 @@ public class ExpenseTransfer extends AbstractEntity {
     @OneToMany(mappedBy = "expenseTransfer", cascade = CascadeType.ALL)
     private List<ExpenseRequest> expenseRequests;
 
-    @OneToMany(mappedBy = "expenseTransfer", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "expenseTransfer", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private List<ExpenseTransferFile> files;
 
     public Date getTransferDate() {


### PR DESCRIPTION
The `files` collection in the `ExpenseTransfer` entity was being lazily initialized. This caused a `LazyInitializationException` when the collection was accessed in the `ExpenseTransferViewDialog` after the Hibernate session was closed.

This commit changes the fetch type of the `files` collection to `EAGER` to ensure that the collection is loaded along with the `ExpenseTransfer` entity, preventing the exception.