### PR TITLE
Fix LazyInitializationException for expenseRequests collection

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/ExpenseTransfer.java
+++ b/src/main/java/uy/com/bay/utiles/data/ExpenseTransfer.java
@@ -18,7 +18,7 @@ public class ExpenseTransfer extends AbstractEntity {
     @ManyToOne
     private Surveyor surveyor;
 
-    @OneToMany(mappedBy = "expenseTransfer", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "expenseTransfer", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private List<ExpenseRequest> expenseRequests;
 
     @OneToMany(mappedBy = "expenseTransfer", cascade = CascadeType.ALL, fetch = FetchType.EAGER)


### PR DESCRIPTION
Changed the fetch type for the `expenseRequests` collection in the `ExpenseTransfer` entity from LAZY to EAGER.

This resolves a `org.hibernate.LazyInitializationException` that occurred when accessing the collection in `ExpenseTransferViewDialog` after the Hibernate session was closed.