### PR TITLE
Fix LazyInitializationException in ExpenseTransferViewDialog

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/ExpenseTransfer.java
+++ b/src/main/java/uy/com/bay/utiles/data/ExpenseTransfer.java
@@ -18,7 +18,7 @@ public class ExpenseTransfer extends AbstractEntity {
     @ManyToOne
     private Surveyor surveyor;
 
-    @OneToMany(mappedBy = "expenseTransfer", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "expenseTransfer", cascade = CascadeType.ALL)
     private List<ExpenseRequest> expenseRequests;
 
     @OneToMany(mappedBy = "expenseTransfer", cascade = CascadeType.ALL, fetch = FetchType.EAGER)

--- a/src/main/java/uy/com/bay/utiles/data/repository/ExpenseRequestRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/ExpenseRequestRepository.java
@@ -11,10 +11,14 @@ import uy.com.bay.utiles.data.ExpenseStatus;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 public interface ExpenseRequestRepository extends JpaRepository<ExpenseRequest, Long>, JpaSpecificationExecutor<ExpenseRequest> {
 
     List<ExpenseRequest> findAllByExpenseStatus(ExpenseStatus expenseStatus, Pageable pageable);
+
+    @Query("select er from ExpenseRequest er left join fetch er.expenseTransfer et left join fetch et.expenseRequests where er.id = :id")
+    Optional<ExpenseRequest> findByIdWithFullExpenseTransfer(@Param("id") Long id);
 
     @Modifying
     @Query("update ExpenseRequest er set er.expenseStatus = :status, er.aprovalDate = :aprovalDate where er.id in :ids")

--- a/src/main/java/uy/com/bay/utiles/services/ExpenseRequestService.java
+++ b/src/main/java/uy/com/bay/utiles/services/ExpenseRequestService.java
@@ -27,6 +27,11 @@ public class ExpenseRequestService {
         return repository.findById(id);
     }
 
+    @Transactional(readOnly = true)
+    public Optional<ExpenseRequest> getWithFullExpenseTransfer(Long id) {
+        return repository.findByIdWithFullExpenseTransfer(id);
+    }
+
     public ExpenseRequest update(ExpenseRequest entity) {
         return repository.save(entity);
     }

--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpensesView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpensesView.java
@@ -352,7 +352,8 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 	public void beforeEnter(BeforeEnterEvent event) {
 		Optional<Long> expenseId = event.getRouteParameters().get(EXPENSE_ID).map(Long::parseLong);
 		if (expenseId.isPresent()) {
-			Optional<ExpenseRequest> expenseRequestFromBackend = expenseRequestService.get(expenseId.get());
+			Optional<ExpenseRequest> expenseRequestFromBackend = expenseRequestService
+					.getWithFullExpenseTransfer(expenseId.get());
 			if (expenseRequestFromBackend.isPresent()) {
 				populateForm(expenseRequestFromBackend.get());
 				editorLayoutDiv.setVisible(true);


### PR DESCRIPTION
Introduced a new method `findByIdWithFullExpenseTransfer` in the `ExpenseRequestRepository` that uses a `JOIN FETCH` query to eagerly load the `expenseTransfer` and its associated `expenseRequests` collection.

The `ExpensesView` now uses this new method when loading an `ExpenseRequest`, ensuring that all required data is available to the view layer and preventing the `LazyInitializationException` that occurred when accessing the lazy collection outside of a transaction.