### PR TITLE
Fix LazyInitializationException in ExpenseTransferViewDialog

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/ExpenseRequestRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/ExpenseRequestRepository.java
@@ -11,14 +11,10 @@ import uy.com.bay.utiles.data.ExpenseStatus;
 
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 
 public interface ExpenseRequestRepository extends JpaRepository<ExpenseRequest, Long>, JpaSpecificationExecutor<ExpenseRequest> {
 
     List<ExpenseRequest> findAllByExpenseStatus(ExpenseStatus expenseStatus, Pageable pageable);
-
-    @Query("select er from ExpenseRequest er left join fetch er.expenseTransfer et left join fetch et.expenseRequests where er.id = :id")
-    Optional<ExpenseRequest> findByIdWithFullExpenseTransfer(@Param("id") Long id);
 
     @Modifying
     @Query("update ExpenseRequest er set er.expenseStatus = :status, er.aprovalDate = :aprovalDate where er.id in :ids")

--- a/src/main/java/uy/com/bay/utiles/services/ExpenseRequestService.java
+++ b/src/main/java/uy/com/bay/utiles/services/ExpenseRequestService.java
@@ -27,11 +27,6 @@ public class ExpenseRequestService {
         return repository.findById(id);
     }
 
-    @Transactional(readOnly = true)
-    public Optional<ExpenseRequest> getWithFullExpenseTransfer(Long id) {
-        return repository.findByIdWithFullExpenseTransfer(id);
-    }
-
     public ExpenseRequest update(ExpenseRequest entity) {
         return repository.save(entity);
     }

--- a/src/main/java/uy/com/bay/utiles/services/ExpenseTransferService.java
+++ b/src/main/java/uy/com/bay/utiles/services/ExpenseTransferService.java
@@ -1,8 +1,10 @@
 package uy.com.bay.utiles.services;
 
+import org.hibernate.Hibernate;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uy.com.bay.utiles.data.ExpenseTransfer;
 import uy.com.bay.utiles.data.repository.ExpenseTransferRepository;
 
@@ -19,6 +21,15 @@ public class ExpenseTransferService {
 
     public Optional<ExpenseTransfer> get(Long id) {
         return repository.findById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public ExpenseTransfer findByIdAndInitialize(Long id) {
+        ExpenseTransfer et = repository.findById(id).orElse(null);
+        if (et != null) {
+            Hibernate.initialize(et.getExpenseRequests());
+        }
+        return et;
     }
 
     public ExpenseTransfer update(ExpenseTransfer entity) {

--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpensesView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpensesView.java
@@ -49,6 +49,7 @@ import uy.com.bay.utiles.services.ExpenseRequestService;
 import uy.com.bay.utiles.services.ExpenseRequestTypeService;
 import uy.com.bay.utiles.services.StudyService;
 import uy.com.bay.utiles.services.SurveyorService;
+import uy.com.bay.utiles.services.ExpenseTransferService;
 import uy.com.bay.utiles.views.expensetransfer.ExpenseTransferViewDialog;
 
 @PageTitle("Solicitudes de Gastos")
@@ -82,16 +83,19 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 	private final StudyService studyService;
 	private final SurveyorService surveyorService;
 	private final ExpenseRequestTypeService expenseRequestTypeService;
+	private final ExpenseTransferService expenseTransferService;
 	private Div editorLayoutDiv;
 
 	private final Filters filters;
 
 	public ExpensesView(ExpenseRequestService expenseRequestService, StudyService studyService,
-			SurveyorService surveyorService, ExpenseRequestTypeService expenseRequestTypeService) {
+			SurveyorService surveyorService, ExpenseRequestTypeService expenseRequestTypeService,
+			ExpenseTransferService expenseTransferService) {
 		this.expenseRequestService = expenseRequestService;
 		this.studyService = studyService;
 		this.surveyorService = surveyorService;
 		this.expenseRequestTypeService = expenseRequestTypeService;
+		this.expenseTransferService = expenseTransferService;
 		addClassNames("expenses-view");
 
 		filters = new Filters();
@@ -339,7 +343,9 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 
 		viewTransferButton.addClickListener(e -> {
 			if (this.expenseRequest != null && this.expenseRequest.getExpenseTransfer() != null) {
-				ExpenseTransferViewDialog dialog = new ExpenseTransferViewDialog(this.expenseRequest.getExpenseTransfer());
+				uy.com.bay.utiles.data.ExpenseTransfer initializedTransfer = expenseTransferService
+						.findByIdAndInitialize(this.expenseRequest.getExpenseTransfer().getId());
+				ExpenseTransferViewDialog dialog = new ExpenseTransferViewDialog(initializedTransfer);
 				dialog.open();
 			} else {
 				Notification.show("No hay una transferencia asociada a esta solicitud.", 3000,
@@ -352,8 +358,7 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 	public void beforeEnter(BeforeEnterEvent event) {
 		Optional<Long> expenseId = event.getRouteParameters().get(EXPENSE_ID).map(Long::parseLong);
 		if (expenseId.isPresent()) {
-			Optional<ExpenseRequest> expenseRequestFromBackend = expenseRequestService
-					.getWithFullExpenseTransfer(expenseId.get());
+			Optional<ExpenseRequest> expenseRequestFromBackend = expenseRequestService.get(expenseId.get());
 			if (expenseRequestFromBackend.isPresent()) {
 				populateForm(expenseRequestFromBackend.get());
 				editorLayoutDiv.setVisible(true);


### PR DESCRIPTION
Adds a new method `findByIdAndInitialize` to `ExpenseTransferService` that explicitly initializes the `expenseRequests` collection on an `ExpenseTransfer` entity within a transaction.

The `ExpensesView` is updated to call this new service method before creating the `ExpenseTransferViewDialog`. This ensures the lazily-loaded collection is available to the view and prevents the `LazyInitializationException`.