### PR TITLE
Fix NullPointerException in ExpenseReportApprovalView

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportApprovalView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportApprovalView.java
@@ -79,7 +79,7 @@ public class ExpenseReportApprovalView extends Div {
 
         // Fetch and set data
         List<ExpenseReport> reports = expenseReportService.findAllByExpenseStatus(ExpenseReportStatus.INGRESADO);
-        reports.sort(Comparator.comparing(ExpenseReport::getDate).reversed());
+        reports.sort(Comparator.comparing(ExpenseReport::getDate, Comparator.nullsFirst(Comparator.naturalOrder())).reversed());
         dataProvider = new ListDataProvider<>(reports);
         grid.setDataProvider(dataProvider);
 


### PR DESCRIPTION
A NullPointerException was occurring when sorting expense reports by date, due to some reports having a null date value.

This commit fixes the issue by using a Comparator that can handle null values. Specifically, it uses `Comparator.nullsFirst` to place null dates at the beginning of the list before reversing the order, effectively placing them at the end of the sorted list.