### PR TITLE
Refactor populateForm to prevent BindingException

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportsView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportsView.java
@@ -377,26 +377,25 @@ public class ExpenseReportsView extends Div implements BeforeEnterObserver {
 
 	private void populateForm(ExpenseReport value) {
 		this.expenseReport = value;
-		study.setItems(studies);
-		surveyor.setItems(surveyors);
-		concept.setItems(expenseRequestTypes);
-		if (value != null) {
-			if (value.getStudy() != null && !studies.contains(value.getStudy())) {
-				List<Study> items = new ArrayList<>(this.studies);
-				items.add(value.getStudy());
-				study.setItems(items);
-			}
-			if (value.getSurveyor() != null && !surveyors.contains(value.getSurveyor())) {
-				List<Surveyor> items = new ArrayList<>(this.surveyors);
-				items.add(value.getSurveyor());
-				surveyor.setItems(items);
-			}
-			if (value.getConcept() != null && !expenseRequestTypes.contains(value.getConcept())) {
-				List<ExpenseRequestType> items = new ArrayList<>(this.expenseRequestTypes);
-				items.add(value.getConcept());
-				concept.setItems(items);
-			}
+
+		List<Study> studyItems = new ArrayList<>(this.studies);
+		if (value != null && value.getStudy() != null && !studyItems.contains(value.getStudy())) {
+			studyItems.add(value.getStudy());
 		}
+		study.setItems(studyItems);
+
+		List<Surveyor> surveyorItems = new ArrayList<>(this.surveyors);
+		if (value != null && value.getSurveyor() != null && !surveyorItems.contains(value.getSurveyor())) {
+			surveyorItems.add(value.getSurveyor());
+		}
+		surveyor.setItems(surveyorItems);
+
+		List<ExpenseRequestType> conceptItems = new ArrayList<>(this.expenseRequestTypes);
+		if (value != null && value.getConcept() != null && !conceptItems.contains(value.getConcept())) {
+			conceptItems.add(value.getConcept());
+		}
+		concept.setItems(conceptItems);
+
 		binder.readBean(this.expenseReport);
 		comprobantes.setEnabled(value != null && value.getFiles() != null && !value.getFiles().isEmpty());
 	}


### PR DESCRIPTION
The `populateForm` method in `ExpenseReportsView` could throw a `com.vaadin.flow.data.binder.BindingException` caused by an `IllegalStateException` when setting a value on a ComboBox without items.

This occurred because the ComboBox's items were not guaranteed to be fully populated before the binder tried to set a value on them, especially when editing an existing entity with a value not present in the initial item list.

The method has been refactored to build a complete list of items for each ComboBox, including the item from the bound bean if necessary, before setting the items on the component. This ensures that the binder can always find the item to be set, resolving the exception.