### PR TITLE
Fix BindingException when editing an expense report.

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportsView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportsView.java
@@ -230,6 +230,8 @@ public class ExpenseReportsView extends Div implements BeforeEnterObserver {
 		this.expenseRequestTypes = expenseRequestTypeService.findAll();
 		concept.setItems(this.expenseRequestTypes);
 		concept.setItemLabelGenerator(ExpenseRequestType::getName);
+		expenseStatus = new ComboBox<>("Estado");
+		expenseStatus.setItems(ExpenseReportStatus.values());
 
 		files = new Upload();
 		// files.setMaxFileSize(20480);
@@ -264,7 +266,8 @@ public class ExpenseReportsView extends Div implements BeforeEnterObserver {
 			comprobantes.setEnabled(true);
 		});
 
-		formLayout.add(study, surveyor, date, amount, concept, new Label("Subir comprobantes"), files, comprobantes);
+		formLayout.add(study, surveyor, date, amount, concept, expenseStatus, new Label("Subir comprobantes"), files,
+				comprobantes);
 		editorDiv.add(formLayout);
 		createButtonLayout(editorLayoutDiv);
 		splitLayout.addToSecondary(editorLayoutDiv);


### PR DESCRIPTION
An IllegalStateException was thrown because the `expenseStatus` ComboBox was being bound to the data model before it was initialized and populated with items.

This change initializes the `expenseStatus` ComboBox in the `createEditorLayout` method and adds it to the form, ensuring it is ready before `binder.readBean()` is called.