### PR TITLE
Fix: Handle LocalDate to Timestamp conversion in expense filter

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpensesView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpensesView.java
@@ -1,6 +1,7 @@
 package uy.com.bay.utiles.views.expenses;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -425,13 +426,25 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 				predicates.add(criteriaBuilder.or(surveyorFirstName, surveyorLastName));
 			}
 			if (filters.getRequestDate() != null) {
-				predicates.add(criteriaBuilder.equal(root.get("requestDate"), filters.getRequestDate()));
+				LocalDate date = filters.getRequestDate();
+				Date startDate = Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant());
+				Date endDate = Date.from(date.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant());
+				predicates.add(criteriaBuilder.greaterThanOrEqualTo(root.get("requestDate"), startDate));
+				predicates.add(criteriaBuilder.lessThan(root.get("requestDate"), endDate));
 			}
 			if (filters.getAprovalDate() != null) {
-				predicates.add(criteriaBuilder.equal(root.get("aprovalDate"), filters.getAprovalDate()));
+				LocalDate date = filters.getAprovalDate();
+				Date startDate = Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant());
+				Date endDate = Date.from(date.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant());
+				predicates.add(criteriaBuilder.greaterThanOrEqualTo(root.get("aprovalDate"), startDate));
+				predicates.add(criteriaBuilder.lessThan(root.get("aprovalDate"), endDate));
 			}
 			if (filters.getTransferDate() != null) {
-				predicates.add(criteriaBuilder.equal(root.get("transferDate"), filters.getTransferDate()));
+				LocalDate date = filters.getTransferDate();
+				Date startDate = Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant());
+				Date endDate = Date.from(date.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant());
+				predicates.add(criteriaBuilder.greaterThanOrEqualTo(root.get("transferDate"), startDate));
+				predicates.add(criteriaBuilder.lessThan(root.get("transferDate"), endDate));
 			}
 			if (filters.getAmount() != null) {
 				predicates.add(criteriaBuilder.equal(root.get("amount"), filters.getAmount()));


### PR DESCRIPTION
The previous code caused a JpaSystemException when filtering expenses by date. This was due to an attempt to directly compare a `java.time.LocalDate` from the filter with a `java.util.Date` field in the `ExpenseRequest` entity, which is mapped to a timestamp in the database.

This commit fixes the issue by changing the query logic in `ExpensesView`. Instead of using `criteriaBuilder.equal`, it now creates a date range for the selected day (from the start of the day to the start of the next day) and uses `greaterThanOrEqualTo` and `lessThan` to filter for any records that fall within that day. This correctly handles the comparison between a date-only filter and a timestamp database column.