### PR TITLE
Refactor save transfer logic

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/JournalEntryRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/JournalEntryRepository.java
@@ -1,0 +1,7 @@
+package uy.com.bay.utiles.data;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface JournalEntryRepository extends JpaRepository<JournalEntry, Long>, JpaSpecificationExecutor<JournalEntry> {
+}

--- a/src/main/java/uy/com/bay/utiles/services/JournalEntryService.java
+++ b/src/main/java/uy/com/bay/utiles/services/JournalEntryService.java
@@ -1,0 +1,19 @@
+package uy.com.bay.utiles.services;
+
+import org.springframework.stereotype.Service;
+import uy.com.bay.utiles.data.JournalEntry;
+import uy.com.bay.utiles.data.JournalEntryRepository;
+
+@Service
+public class JournalEntryService {
+
+    private final JournalEntryRepository repository;
+
+    public JournalEntryService(JournalEntryRepository repository) {
+        this.repository = repository;
+    }
+
+    public JournalEntry save(JournalEntry entity) {
+        return repository.save(entity);
+    }
+}


### PR DESCRIPTION
This refactoring modifies the `saveTransfer` method in `ExpenseTransferView` to perform the following actions for each `ExpenseRequest` after an `ExpenseTransfer` is successfully created:

- Creates a `JournalEntry` with details about the transfer.
- Updates the `balance` attribute of the associated `Surveyor`.
- Updates the `debt` and `totalCost` attributes of the associated `Study`.

A new `JournalEntryService` and `JournalEntryRepository` were created to support this new functionality. The required services (`JournalEntryService`, `SurveyorService`, `StudyService`) have been injected into `ExpenseTransferView`.