### PR TITLE
Refactor: Show balance in Surveyor edit form

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/surveyors/EncuestadoresView.java
+++ b/src/main/java/uy/com/bay/utiles/views/surveyors/EncuestadoresView.java
@@ -49,6 +49,7 @@ public class EncuestadoresView extends Div implements BeforeEnterObserver {
     private TextField lastName;
     private TextField ci;
     private TextField SurveyToGoId;
+    private TextField balance;
 
 
     private Button addButton;
@@ -264,7 +265,9 @@ public class EncuestadoresView extends Div implements BeforeEnterObserver {
         lastName = new TextField("Last Name");
         ci = new TextField("Ci");
         SurveyToGoId = new TextField("Survey To Go Id");
-        formLayout.add(firstName, lastName, ci, SurveyToGoId);
+        balance = new TextField("Balance");
+        balance.setReadOnly(true);
+        formLayout.add(firstName, lastName, ci, SurveyToGoId, balance);
 
         editorDiv.add(formLayout);
         createButtonLayout(this.editorLayoutDiv);


### PR DESCRIPTION
This commit adds the `balance` field to the `Surveyor` edit form in `EncuestadoresView`.

The `balance` field is displayed as a read-only text field.