### PR TITLE
feat: Add expense movements dialog to surveyor view

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/JournalEntryRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/JournalEntryRepository.java
@@ -1,8 +1,14 @@
 package uy.com.bay.utiles.data.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
 import uy.com.bay.utiles.data.JournalEntry;
+import uy.com.bay.utiles.data.Surveyor;
 
 public interface JournalEntryRepository extends JpaRepository<JournalEntry, Long>, JpaSpecificationExecutor<JournalEntry> {
+
+	List<JournalEntry> findAllBySurveyorOrderByDateAsc(Surveyor surveyor);
 }

--- a/src/main/java/uy/com/bay/utiles/services/JournalEntryService.java
+++ b/src/main/java/uy/com/bay/utiles/services/JournalEntryService.java
@@ -1,7 +1,11 @@
 package uy.com.bay.utiles.services;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
+
 import uy.com.bay.utiles.data.JournalEntry;
+import uy.com.bay.utiles.data.Surveyor;
 import uy.com.bay.utiles.data.repository.JournalEntryRepository;
 
 @Service
@@ -15,5 +19,9 @@ public class JournalEntryService {
 
 	public JournalEntry save(JournalEntry entity) {
 		return repository.save(entity);
+	}
+
+	public List<JournalEntry> findBySurveyor(Surveyor surveyor) {
+		return repository.findAllBySurveyorOrderByDateAsc(surveyor);
 	}
 }

--- a/src/main/java/uy/com/bay/utiles/views/surveyors/JournalEntryGrid.java
+++ b/src/main/java/uy/com/bay/utiles/views/surveyors/JournalEntryGrid.java
@@ -1,0 +1,53 @@
+package uy.com.bay.utiles.views.surveyors;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.vaadin.flow.component.grid.Grid;
+
+import uy.com.bay.utiles.data.JournalEntry;
+import uy.com.bay.utiles.data.Operation;
+
+public class JournalEntryGrid extends Grid<JournalEntry> {
+
+	public JournalEntryGrid() {
+		super(JournalEntry.class, false);
+		setColumns();
+	}
+
+	private void setColumns() {
+		SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
+		addColumn(entry -> sdf.format(entry.getDate())).setHeader("Date");
+		addColumn(JournalEntry::getDetail).setHeader("Detail");
+		addColumn(JournalEntry::getAmount).setHeader("Amount");
+		addColumn(entry -> entry.getStudy() != null ? entry.getStudy().getName() : "").setHeader("Study");
+		addColumn(JournalEntry::getOperation).setHeader("Operation");
+		addColumn(entry -> "").setHeader("Saldo").setId("saldoColumn");
+	}
+
+	public void setJournalEntries(Collection<JournalEntry> items) {
+		super.setItems(items);
+
+		java.util.Map<JournalEntry, Double> saldoMap = new java.util.HashMap<>();
+		AtomicReference<Double> runningSaldo = new AtomicReference<>(0.0);
+
+		List<JournalEntry> sortedItems = new ArrayList<>(items);
+
+		for (JournalEntry entry : sortedItems) {
+			double amount = entry.getAmount();
+			if (entry.getOperation() == Operation.DEBITO) {
+				runningSaldo.updateAndGet(v -> v - amount);
+			} else {
+				runningSaldo.updateAndGet(v -> v + amount);
+			}
+			saldoMap.put(entry, runningSaldo.get());
+		}
+
+		getColumnByKey("saldoColumn").setRenderer(new com.vaadin.flow.data.renderer.TextRenderer<>(entry -> {
+			return String.format("%.2f", saldoMap.get(entry));
+		}));
+	}
+}


### PR DESCRIPTION
- Adds a 'View Expense Movements' button to the surveyor edit form.
- Clicking the button opens a dialog with a grid of journal entries for the selected surveyor.
- The grid displays Date, Detail, Amount, Study, Operation, and a calculated running Balance.
- Adds a method to JournalEntryRepository to fetch entries by surveyor, ordered by date.
- Adds a corresponding service method in JournalEntryService.
- Creates a new JournalEntryGrid component to encapsulate the grid logic.