### PR TITLE
Fix(JournalEntryGrid): Use setKey to identify grid column

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/surveyors/JournalEntryGrid.java
+++ b/src/main/java/uy/com/bay/utiles/views/surveyors/JournalEntryGrid.java
@@ -25,7 +25,7 @@ public class JournalEntryGrid extends Grid<JournalEntry> {
 		addColumn(JournalEntry::getAmount).setHeader("Amount");
 		addColumn(entry -> entry.getStudy() != null ? entry.getStudy().getName() : "").setHeader("Study");
 		addColumn(JournalEntry::getOperation).setHeader("Operation");
-		addColumn(entry -> "").setHeader("Saldo").setId("saldoColumn");
+		addColumn(entry -> "").setHeader("Saldo").setKey("saldoColumn");
 	}
 
 	public void setJournalEntries(Collection<JournalEntry> items) {


### PR DESCRIPTION
The JournalEntryGrid was using setId("saldoColumn") to identify a column. However, to retrieve a column using getColumnByKey, the column must be identified using setKey. This mismatch caused getColumnByKey to return null, leading to a NullPointerException when setRenderer was called on the null object.

This commit changes setId to setKey to correctly identify the column, which resolves the NullPointerException.