### PR TITLE
Fix(JournalEntryGrid): Replace Anchor with Button for detail view

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportViewDialog.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportViewDialog.java
@@ -1,0 +1,94 @@
+package uy.com.bay.utiles.views.expenses;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Anchor;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.textfield.NumberField;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.server.StreamResource;
+import uy.com.bay.utiles.data.ExpenseReport;
+import uy.com.bay.utiles.data.ExpenseReportFile;
+import uy.com.bay.utiles.services.ExpenseReportFileService;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ExpenseReportViewDialog extends Dialog {
+
+    private final ExpenseReport expenseReport;
+    private final ExpenseReportFileService expenseReportFileService;
+    private Grid<ExpenseReportFile> filesGrid;
+    private List<ExpenseReportFile> files;
+
+    public ExpenseReportViewDialog(ExpenseReport expenseReport, ExpenseReportFileService expenseReportFileService) {
+        this.expenseReport = expenseReport;
+        this.expenseReportFileService = expenseReportFileService;
+        this.files = new ArrayList<>(expenseReport.getFiles());
+
+        setHeaderTitle("Detalles de la Rendición");
+
+        FormLayout formLayout = new FormLayout();
+
+        TextField study = new TextField("Estudio");
+        study.setValue(expenseReport.getStudy() != null ? expenseReport.getStudy().getName() : "");
+        study.setReadOnly(true);
+
+        TextField surveyor = new TextField("Encuestador");
+        surveyor.setValue(expenseReport.getSurveyor() != null ? expenseReport.getSurveyor().getFirstName() + " " + expenseReport.getSurveyor().getLastName() : "");
+        surveyor.setReadOnly(true);
+
+        DatePicker date = new DatePicker("Fecha");
+        if (expenseReport.getDate() != null) {
+            date.setValue(new java.sql.Date(expenseReport.getDate().getTime()).toLocalDate());
+        }
+        date.setReadOnly(true);
+
+        NumberField amount = new NumberField("Monto");
+        amount.setValue(expenseReport.getAmount());
+        amount.setReadOnly(true);
+
+        TextField concept = new TextField("Concepto");
+        concept.setValue(expenseReport.getConcept() != null ? expenseReport.getConcept().getName() : "");
+        concept.setReadOnly(true);
+
+        formLayout.add(study, surveyor, date, amount, concept);
+        add(formLayout);
+
+        if (files != null && !files.isEmpty()) {
+            VerticalLayout filesLayout = new VerticalLayout();
+            filesLayout.setSpacing(false);
+            filesLayout.setPadding(false);
+
+            com.vaadin.flow.component.html.H4 filesHeader = new com.vaadin.flow.component.html.H4("Archivos adjuntos");
+            filesLayout.add(filesHeader);
+
+            filesGrid = new Grid<>(ExpenseReportFile.class, false);
+            filesGrid.setItems(files);
+            filesGrid.addColumn(ExpenseReportFile::getName).setHeader("Nombre");
+
+            filesGrid.addComponentColumn(file -> {
+                Button downloadButton = new Button("Descargar");
+                StreamResource resource = new StreamResource(file.getName(),
+                        () -> new ByteArrayInputStream(file.getContent()));
+                Anchor downloadLink = new Anchor(resource, "");
+                downloadLink.getElement().setAttribute("download", true);
+                downloadLink.add(downloadButton);
+                return downloadLink;
+            }).setHeader("Acciones");
+            filesGrid.setAllRowsVisible(true);
+            filesLayout.add(filesGrid);
+            add(filesLayout);
+        }
+
+        Button closeButton = new Button("Cerrar", e -> close());
+        getFooter().add(closeButton);
+
+        setCloseOnEsc(true);
+        setCloseOnOutsideClick(true);
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/views/surveyors/EncuestadoresView.java
+++ b/src/main/java/uy/com/bay/utiles/views/surveyors/EncuestadoresView.java
@@ -36,6 +36,8 @@ import uy.com.bay.utiles.data.JournalEntry;
 import uy.com.bay.utiles.data.Operation;
 import uy.com.bay.utiles.data.Source;
 import uy.com.bay.utiles.data.Surveyor;
+import uy.com.bay.utiles.services.ExpenseReportFileService;
+import uy.com.bay.utiles.services.ExpenseTransferFileService;
 import uy.com.bay.utiles.services.JournalEntryService;
 import uy.com.bay.utiles.services.SurveyorService;
 
@@ -77,10 +79,16 @@ public class EncuestadoresView extends Div implements BeforeEnterObserver {
 
 	private final SurveyorService encuestadorService;
 	private final JournalEntryService journalEntryService;
+	private final ExpenseTransferFileService expenseTransferFileService;
+	private final ExpenseReportFileService expenseReportFileService;
 
-	public EncuestadoresView(SurveyorService encuestadorService, JournalEntryService journalEntryService) {
+	public EncuestadoresView(SurveyorService encuestadorService, JournalEntryService journalEntryService,
+			ExpenseTransferFileService expenseTransferFileService,
+			ExpenseReportFileService expenseReportFileService) {
 		this.encuestadorService = encuestadorService;
 		this.journalEntryService = journalEntryService;
+		this.expenseTransferFileService = expenseTransferFileService;
+		this.expenseReportFileService = expenseReportFileService;
 		this.binder = new BeanValidationBinder<>(Surveyor.class); // Moved initialization here
 		addClassNames("encuestadores-view");
 
@@ -363,7 +371,7 @@ public class EncuestadoresView extends Div implements BeforeEnterObserver {
 			dialog.setWidth("80%");
 			dialog.setHeaderTitle("Movimientos de Gasto");
 
-			JournalEntryGrid grid = new JournalEntryGrid();
+			JournalEntryGrid grid = new JournalEntryGrid(expenseTransferFileService, expenseReportFileService);
 			grid.setJournalEntries(journalEntryService.findBySurveyor(this.encuestador));
 
 			dialog.add(grid);

--- a/src/main/java/uy/com/bay/utiles/views/surveyors/JournalEntryGrid.java
+++ b/src/main/java/uy/com/bay/utiles/views/surveyors/JournalEntryGrid.java
@@ -7,25 +7,60 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.vaadin.flow.component.grid.Grid;
-
+import com.vaadin.flow.component.html.Anchor;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
 import uy.com.bay.utiles.data.JournalEntry;
 import uy.com.bay.utiles.data.Operation;
+import uy.com.bay.utiles.data.Source;
+import uy.com.bay.utiles.services.ExpenseReportFileService;
+import uy.com.bay.utiles.services.ExpenseTransferFileService;
+import uy.com.bay.utiles.views.expenses.ExpenseReportViewDialog;
+import uy.com.bay.utiles.views.expensetransfer.ExpenseTransferViewDialog;
 
 public class JournalEntryGrid extends Grid<JournalEntry> {
 
-	public JournalEntryGrid() {
+	private final ExpenseTransferFileService expenseTransferFileService;
+	private final ExpenseReportFileService expenseReportFileService;
+
+	public JournalEntryGrid(ExpenseTransferFileService expenseTransferFileService,
+			ExpenseReportFileService expenseReportFileService) {
 		super(JournalEntry.class, false);
+		this.expenseTransferFileService = expenseTransferFileService;
+		this.expenseReportFileService = expenseReportFileService;
 		setColumns();
 	}
 
 	private void setColumns() {
 		SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
 		addColumn(entry -> sdf.format(entry.getDate())).setHeader("Date");
-		addColumn(JournalEntry::getDetail).setHeader("Detail");
+		addComponentColumn(this::createDetailLink).setHeader("Detail");
 		addColumn(JournalEntry::getAmount).setHeader("Amount");
 		addColumn(entry -> entry.getStudy() != null ? entry.getStudy().getName() : "").setHeader("Study");
 		addColumn(JournalEntry::getOperation).setHeader("Operation");
 		addColumn(entry -> "").setHeader("Saldo").setKey("saldoColumn");
+	}
+
+	private Button createDetailLink(JournalEntry entry) {
+		Button link = new Button(entry.getDetail());
+		link.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE);
+		if (entry.getSource() != null) {
+			if (entry.getSource() == Source.RENDICION && entry.getExpenseReport() != null) {
+				link.addClickListener(e -> {
+					ExpenseReportViewDialog dialog = new ExpenseReportViewDialog(entry.getExpenseReport(),
+							expenseReportFileService);
+					dialog.open();
+				});
+			} else if (entry.getSource() == Source.TRANSFERENCIA && entry.getTransfer() != null) {
+				link.addClickListener(e -> {
+					ExpenseTransferViewDialog dialog = new ExpenseTransferViewDialog(entry.getTransfer(),
+							expenseTransferFileService);
+					dialog.open();
+				});
+			}
+		}
+		return link;
 	}
 
 	public void setJournalEntries(Collection<JournalEntry> items) {


### PR DESCRIPTION
The `JournalEntryGrid` was using an `Anchor` component to show a link to the detail view of a journal entry. However, `Anchor` components do not have a click listener, which was causing a compilation error.

This commit replaces the `Anchor` with a `Button` component styled to look like a link. This fixes the compilation error and ensures the detail view can be opened when the user clicks on the detail text.