### PR TITLE
Fix NullPointerException in approveReport

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/ExpenseReportService.java
+++ b/src/main/java/uy/com/bay/utiles/services/ExpenseReportService.java
@@ -77,7 +77,11 @@ public class ExpenseReportService {
 		report.setApprovalDate(new Date());
 		repository.save(report);
 		JournalEntry journalEntry = new JournalEntry();
-		journalEntry.setDetail("rendicion aprobada por el concepto " + report.getConcept().getName());
+		if (report.getConcept() != null) {
+			journalEntry.setDetail("rendicion aprobada por el concepto " + report.getConcept().getName());
+		} else {
+			journalEntry.setDetail("rendicion aprobada sin concepto");
+		}
 		journalEntry.setDate(new Date());
 		journalEntry.setOperation(Operation.DEBITO);
 		journalEntry.setAmount(report.getAmount());


### PR DESCRIPTION
A NullPointerException was occurring in the `approveReport` method of the `ExpenseReportService` class. This was caused by calling `.getName()` on a null `concept` object.

This change adds a null check to handle cases where the `ExpenseReport`'s concept is not set. If the concept is null, a default detail message is used for the journal entry.