### PR TITLE
Fix SurveyorRepository query for findByName

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/SurveyorRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/SurveyorRepository.java
@@ -3,10 +3,14 @@ package uy.com.bay.utiles.data;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.Optional;
 
 public interface SurveyorRepository extends JpaRepository<Surveyor, Long>, JpaSpecificationExecutor<Surveyor> {
     Optional<Surveyor> findBySurveyToGoId(String surveyToGoId);
     Optional<Surveyor> findByFirstName(String firstName);
-    Optional<Surveyor> findByName(String name);
+    @Query("SELECT s FROM Surveyor s WHERE s.firstName || ' ' || s.lastName = :name")
+    Optional<Surveyor> findByName(@Param("name") String name);
 }


### PR DESCRIPTION
The application was failing to start due to a `QueryCreationException`. This was caused by the `findByName` method in `SurveyorRepository`, which was trying to query by a `name` attribute that does not exist in the `Surveyor` entity. The `Surveyor` entity has a `getName` method, but it is annotated with `@Transient`, so it is not a persistent attribute.

This commit fixes the issue by adding a `@Query` annotation to the `findByName` method. The query now concatenates the `firstName` and `lastName` fields to search for the full name, which was the intended behavior.