### PR TITLE
feat(expenses): Add SurveyorExpenseRequestEntry view

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/MainLayout.java
+++ b/src/main/java/uy/com/bay/utiles/views/MainLayout.java
@@ -128,6 +128,9 @@ public class MainLayout extends AppLayout {
 		SideNavItem rendirGastoItem = new SideNavItem("Rendir gasto", "surveyor-expense-report");
 		rendirGastoItem.setPrefixComponent(new Icon("vaadin", "file-add"));
 		surveyorPortalItem.addItem(rendirGastoItem);
+		SideNavItem solicitarGastoItem = new SideNavItem("Solicitud de gastos", "surveyor-expense-request");
+		solicitarGastoItem.setPrefixComponent(new Icon("vaadin", "money-request"));
+		surveyorPortalItem.addItem(solicitarGastoItem);
 		nav.addItem(surveyorPortalItem);
 
 

--- a/src/main/java/uy/com/bay/utiles/views/expenses/SurveyorExpenseRequestEntry.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/SurveyorExpenseRequestEntry.java
@@ -1,0 +1,106 @@
+package uy.com.bay.utiles.views.expenses;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.notification.NotificationVariant;
+import com.vaadin.flow.component.textfield.NumberField;
+import com.vaadin.flow.component.textfield.TextArea;
+import com.vaadin.flow.data.binder.BeanValidationBinder;
+import com.vaadin.flow.data.binder.ValidationException;
+import com.vaadin.flow.router.Route;
+import jakarta.annotation.security.PermitAll;
+import uy.com.bay.utiles.data.ExpenseRequest;
+import uy.com.bay.utiles.data.ExpenseRequestType;
+import uy.com.bay.utiles.data.ExpenseStatus;
+import uy.com.bay.utiles.data.Study;
+import uy.com.bay.utiles.security.AuthenticatedUser;
+import uy.com.bay.utiles.services.ExpenseRequestService;
+import uy.com.bay.utiles.services.ExpenseRequestTypeService;
+import uy.com.bay.utiles.services.StudyService;
+import uy.com.bay.utiles.services.SurveyorService;
+import uy.com.bay.utiles.views.MainLayout;
+
+import java.util.Date;
+
+@Route(value = "surveyor-expense-request", layout = MainLayout.class)
+@PermitAll
+public class SurveyorExpenseRequestEntry extends Div {
+
+    private ComboBox<Study> study;
+    private NumberField amount;
+    private ComboBox<ExpenseRequestType> concept;
+    private TextArea obs;
+    private BeanValidationBinder<ExpenseRequest> binder;
+
+    private final StudyService studyService;
+    private final ExpenseRequestTypeService expenseRequestTypeService;
+    private final ExpenseRequestService expenseRequestService;
+    private final AuthenticatedUser authenticatedUser;
+    private final SurveyorService surveyorService;
+
+    public SurveyorExpenseRequestEntry(StudyService studyService, ExpenseRequestTypeService expenseRequestTypeService,
+                                       ExpenseRequestService expenseRequestService, AuthenticatedUser authenticatedUser,
+                                       SurveyorService surveyorService) {
+        this.studyService = studyService;
+        this.expenseRequestTypeService = expenseRequestTypeService;
+        this.expenseRequestService = expenseRequestService;
+        this.authenticatedUser = authenticatedUser;
+        this.surveyorService = surveyorService;
+
+        addClassName("surveyor-expense-request-entry-view");
+
+        FormLayout formLayout = new FormLayout();
+        study = new ComboBox<>("Estudio");
+        study.setItems(studyService.findAllByShowSurveyor(true));
+        study.setItemLabelGenerator(Study::getName);
+        study.setRequired(true);
+
+        amount = new NumberField("Monto");
+        amount.setRequiredIndicatorVisible(true);
+
+        concept = new ComboBox<>("Concepto");
+        concept.setItems(expenseRequestTypeService.findAll());
+        concept.setItemLabelGenerator(ExpenseRequestType::getName);
+        concept.setRequired(true);
+
+        obs = new TextArea("Observaciones");
+
+        Button saveButton = new Button("Guardar");
+        saveButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+
+        formLayout.add(study, amount, concept, obs, saveButton);
+        add(formLayout);
+
+        binder = new BeanValidationBinder<>(ExpenseRequest.class);
+        binder.bindInstanceFields(this);
+
+        saveButton.addClickListener(event -> {
+            try {
+                ExpenseRequest expenseRequest = new ExpenseRequest();
+                binder.writeBean(expenseRequest);
+                authenticatedUser.get().ifPresent(user -> {
+                    surveyorService.findByName(user.getUsername()).ifPresent(expenseRequest::setSurveyor);
+                });
+                expenseRequest.setRequestDate(new Date());
+                expenseRequest.setExpenseStatus(ExpenseStatus.INGRESADO);
+
+                expenseRequestService.update(expenseRequest);
+
+                Notification.show("Solicitud enviada exitosamente", 3000, Notification.Position.BOTTOM_START);
+                clearForm();
+            } catch (ValidationException e) {
+                Notification.show("Por favor, complete todos los campos requeridos.", 3000, Notification.Position.BOTTOM_START)
+                        .addThemeVariants(NotificationVariant.LUMO_ERROR);
+            }
+        });
+    }
+
+    private void clearForm() {
+        binder.readBean(new ExpenseRequest());
+        obs.clear();
+    }
+}


### PR DESCRIPTION
I've introduced the new `SurveyorExpenseRequestEntry` view, which allows surveyors to submit expense requests.

The view includes a form with fields for study, amount, concept, and observations. On submission, a new `ExpenseRequest` entity is created with the appropriate data, including the surveyor, request date, and status.

The new view is accessible from the 'Portal Encuestador' side navigation menu.