### PR TITLE
feat: Add expense report generation feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,13 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- Apache POI for Excel generation -->
+    <dependency>
+        <groupId>org.apache.poi</groupId>
+        <artifactId>poi-ooxml</artifactId>
+        <version>5.2.3</version>
+    </dependency>
+
     <!-- Test -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/uy/com/bay/utiles/controllers/FileDownloadController.java
+++ b/src/main/java/uy/com/bay/utiles/controllers/FileDownloadController.java
@@ -5,21 +5,38 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import uy.com.bay.utiles.data.ExpenseTransferFile;
+import uy.com.bay.utiles.data.JournalEntry;
+import uy.com.bay.utiles.data.Study;
+import uy.com.bay.utiles.data.Surveyor;
+import uy.com.bay.utiles.services.ExcelReportGenerator;
 import uy.com.bay.utiles.services.ExpenseTransferFileService;
+import uy.com.bay.utiles.services.JournalEntryService;
+import uy.com.bay.utiles.services.StudyService;
+import uy.com.bay.utiles.services.SurveyorService;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/api/files")
 public class FileDownloadController {
 
     private final ExpenseTransferFileService expenseTransferFileService;
+    private final JournalEntryService journalEntryService;
+    private final SurveyorService surveyorService;
+    private final StudyService studyService;
 
-    public FileDownloadController(ExpenseTransferFileService expenseTransferFileService) {
+    public FileDownloadController(ExpenseTransferFileService expenseTransferFileService, JournalEntryService journalEntryService, SurveyorService surveyorService, StudyService studyService) {
         this.expenseTransferFileService = expenseTransferFileService;
+        this.journalEntryService = journalEntryService;
+        this.surveyorService = surveyorService;
+        this.studyService = studyService;
     }
 
     @GetMapping("/{fileId}")
@@ -33,6 +50,38 @@ public class FileDownloadController {
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file.getName() + "\"")
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .contentLength(file.getContent().length)
+                .body(resource);
+    }
+
+    @GetMapping("/report")
+    public ResponseEntity<Resource> downloadReport(
+            @RequestParam(required = false) String fechaDesde,
+            @RequestParam(required = false) String fechaHasta,
+            @RequestParam(required = false) List<Long> surveyorIds,
+            @RequestParam(required = false) List<Long> studyIds) throws IOException {
+
+        LocalDate desde = fechaDesde != null ? LocalDate.parse(fechaDesde) : null;
+        LocalDate hasta = fechaHasta != null ? LocalDate.parse(fechaHasta) : null;
+
+        Set<Surveyor> surveyors = new HashSet<>();
+        if (surveyorIds != null) {
+            surveyorIds.forEach(id -> surveyorService.get(id).ifPresent(surveyors::add));
+        }
+
+        Set<Study> studies = new HashSet<>();
+        if (studyIds != null) {
+            studyIds.forEach(id -> studyService.get(id).ifPresent(studies::add));
+        }
+
+        List<JournalEntry> journalEntries = journalEntryService.list(journalEntryService.createFilterSpecification(desde, hasta, surveyors, studies));
+
+        ByteArrayOutputStream baos = ExcelReportGenerator.generateExcel(journalEntries);
+        ByteArrayResource resource = new ByteArrayResource(baos.toByteArray());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=reporte_gastos.xlsx")
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .contentLength(baos.size())
                 .body(resource);
     }
 }

--- a/src/main/java/uy/com/bay/utiles/services/ExcelReportGenerator.java
+++ b/src/main/java/uy/com/bay/utiles/services/ExcelReportGenerator.java
@@ -1,0 +1,49 @@
+package uy.com.bay.utiles.services;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CreationHelper;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import uy.com.bay.utiles.data.JournalEntry;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+public class ExcelReportGenerator {
+
+    public static ByteArrayOutputStream generateExcel(List<JournalEntry> journalEntries) throws IOException {
+        try (XSSFWorkbook workbook = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            XSSFSheet sheet = workbook.createSheet("Reporte de Gastos");
+
+            // Header
+            Row headerRow = sheet.createRow(0);
+            String[] columns = {"Fecha", "Encuestador", "Estudio", "Monto"};
+            for (int i = 0; i < columns.length; i++) {
+                Cell cell = headerRow.createCell(i);
+                cell.setCellValue(columns[i]);
+            }
+
+            // Date cell style
+            CellStyle dateCellStyle = workbook.createCellStyle();
+            CreationHelper createHelper = workbook.getCreationHelper();
+            dateCellStyle.setDataFormat(createHelper.createDataFormat().getFormat("dd/MM/yyyy"));
+
+            // Data rows
+            int rowNum = 1;
+            for (JournalEntry entry : journalEntries) {
+                Row row = sheet.createRow(rowNum++);
+                row.createCell(0).setCellValue(entry.getDate());
+                row.getCell(0).setCellStyle(dateCellStyle);
+                row.createCell(1).setCellValue(entry.getSurveyor() != null ? entry.getSurveyor().getFirstName() : "");
+                row.createCell(2).setCellValue(entry.getStudy() != null ? entry.getStudy().getName() : "");
+                row.createCell(3).setCellValue(entry.getAmount());
+            }
+
+            workbook.write(out);
+            return out;
+        }
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/services/JournalEntryService.java
+++ b/src/main/java/uy/com/bay/utiles/services/JournalEntryService.java
@@ -1,7 +1,10 @@
 package uy.com.bay.utiles.services;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
 
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import uy.com.bay.utiles.data.JournalEntry;
@@ -28,5 +31,29 @@ public class JournalEntryService {
 
 	public List<JournalEntry> findAllByStudy(Study study) {
 		return repository.findAllByStudyOrderByDateAsc(study);
+	}
+
+	public List<JournalEntry> list(Specification<JournalEntry> filter) {
+		return repository.findAll(filter);
+	}
+
+	public Specification<JournalEntry> createFilterSpecification(LocalDate fechaDesde, LocalDate fechaHasta,
+			Set<Surveyor> surveyors, Set<Study> studies) {
+		return (root, query, criteriaBuilder) -> {
+			java.util.ArrayList<jakarta.persistence.criteria.Predicate> predicates = new java.util.ArrayList<>();
+			if (fechaDesde != null) {
+				predicates.add(criteriaBuilder.greaterThanOrEqualTo(root.get("date"), fechaDesde));
+			}
+			if (fechaHasta != null) {
+				predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("date"), fechaHasta));
+			}
+			if (surveyors != null && !surveyors.isEmpty()) {
+				predicates.add(root.get("surveyor").in(surveyors));
+			}
+			if (studies != null && !studies.isEmpty()) {
+				predicates.add(root.get("study").in(studies));
+			}
+			return criteriaBuilder.and(predicates.toArray(new jakarta.persistence.criteria.Predicate[0]));
+		};
 	}
 }

--- a/src/main/java/uy/com/bay/utiles/views/MainLayout.java
+++ b/src/main/java/uy/com/bay/utiles/views/MainLayout.java
@@ -30,6 +30,9 @@ import com.vaadin.flow.theme.lumo.LumoUtility;
 
 import uy.com.bay.utiles.data.User;
 import uy.com.bay.utiles.security.AuthenticatedUser;
+import uy.com.bay.utiles.services.StudyService;
+import uy.com.bay.utiles.services.SurveyorService;
+import uy.com.bay.utiles.views.expenses.ReportesDialog;
 
 /**
  * The main view is a top-level placeholder for other views.
@@ -43,10 +46,14 @@ public class MainLayout extends AppLayout {
 
 	private AuthenticatedUser authenticatedUser;
 	private AccessAnnotationChecker accessChecker;
+	private final SurveyorService surveyorService;
+	private final StudyService studyService;
 
-	public MainLayout(AuthenticatedUser authenticatedUser, AccessAnnotationChecker accessChecker) {
+	public MainLayout(AuthenticatedUser authenticatedUser, AccessAnnotationChecker accessChecker, SurveyorService surveyorService, StudyService studyService) {
 		this.authenticatedUser = authenticatedUser;
 		this.accessChecker = accessChecker;
+		this.surveyorService = surveyorService;
+		this.studyService = studyService;
 
 		setPrimarySection(Section.DRAWER);
 		addDrawerContent();
@@ -122,6 +129,14 @@ public class MainLayout extends AppLayout {
 		rendicionesItem.addItem(aprobarRendicionesItem);
 
 		gastosItem.addItem(rendicionesItem);
+
+		SideNavItem reportesNavItem = new SideNavItem("Reportes");
+		reportesNavItem.setPrefixComponent(new Icon("vaadin", "file-chart"));
+		reportesNavItem.getElement().addEventListener("click", e -> {
+			ReportesDialog dialog = new ReportesDialog(surveyorService, studyService);
+			dialog.open();
+		});
+		gastosItem.addItem(reportesNavItem);
 
 		SideNavItem surveyorPortalItem = new SideNavItem("Portal Encuestador");
 		surveyorPortalItem.setPrefixComponent(new Icon("vaadin", "user-card"));

--- a/src/main/java/uy/com/bay/utiles/views/expenses/ReportesDialog.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ReportesDialog.java
@@ -1,0 +1,74 @@
+package uy.com.bay.utiles.views.expenses;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.formlayout.FormLayout;
+import uy.com.bay.utiles.data.Study;
+import uy.com.bay.utiles.data.Surveyor;
+import uy.com.bay.utiles.services.StudyService;
+import uy.com.bay.utiles.services.SurveyorService;
+
+public class ReportesDialog extends Dialog {
+
+    private final DatePicker fechaDesde = new DatePicker("Fecha desde");
+    private final DatePicker fechaHasta = new DatePicker("Fecha hasta");
+    private final MultiSelectComboBox<Surveyor> encuestadores = new MultiSelectComboBox<>("Encuestadores");
+    private final MultiSelectComboBox<Study> estudios = new MultiSelectComboBox<>("Estudios");
+
+    private final Button descargar = new Button("Descargar");
+    private final Button cerrar = new Button("Cerrar");
+
+    private final SurveyorService surveyorService;
+    private final StudyService studyService;
+
+    public ReportesDialog(SurveyorService surveyorService, StudyService studyService) {
+        this.surveyorService = surveyorService;
+        this.studyService = studyService;
+
+        setHeaderTitle("Generar Reporte de Gastos");
+
+        // Configurar el formato de fecha
+        fechaDesde.setLocale(new java.util.Locale("es", "ES"));
+        fechaHasta.setLocale(new java.util.Locale("es", "ES"));
+
+        // Poblar ComboBoxes
+        encuestadores.setItems(surveyorService.listAll());
+        encuestadores.setItemLabelGenerator(Surveyor::getFirstName);
+        estudios.setItems(studyService.listAll());
+        estudios.setItemLabelGenerator(Study::getName);
+
+        FormLayout formLayout = new FormLayout();
+        formLayout.add(fechaDesde, fechaHasta, encuestadores, estudios);
+        add(formLayout);
+
+        getFooter().add(cerrar, descargar);
+        cerrar.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+        descargar.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+
+        cerrar.addClickListener(e -> close());
+        descargar.addClickListener(e -> downloadReport());
+    }
+
+    private void downloadReport() {
+        String url = "/api/files/report?";
+        StringBuilder params = new StringBuilder();
+
+        if (fechaDesde.getValue() != null) {
+            params.append("fechaDesde=").append(fechaDesde.getValue()).append("&");
+        }
+        if (fechaHasta.getValue() != null) {
+            params.append("fechaHasta=").append(fechaHasta.getValue()).append("&");
+        }
+        if (!encuestadores.getValue().isEmpty()) {
+            encuestadores.getValue().forEach(s -> params.append("surveyorIds=").append(s.getId()).append("&"));
+        }
+        if (!estudios.getValue().isEmpty()) {
+            estudios.getValue().forEach(s -> params.append("studyIds=").append(s.getId()).append("&"));
+        }
+
+        com.vaadin.flow.component.UI.getCurrent().getPage().open(url + params.toString(), "_blank");
+    }
+}


### PR DESCRIPTION
Adds a new feature to generate and download an Excel report of expenses based on specified filters.

- Creates a new 'Reporte' sub-item in the 'Gastos' side navigation menu.
- Clicking on 'Reporte' opens a dialog with filters for 'Fecha desde', 'Fecha hasta', 'Encuestadores', and 'Estudios'.
- The 'Descargar' button in the dialog triggers the generation and download of an Excel file with the filtered expense data.
- Implements a new API endpoint to handle the report generation.
- Adds Apache POI dependency for Excel file creation.