### PR TITLE
Refactor JournalEntryDialog and related views

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/proyectos/ProyectosView.java
+++ b/src/main/java/uy/com/bay/utiles/views/proyectos/ProyectosView.java
@@ -36,6 +36,8 @@ import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
 import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.data.repository.AlchemerSurveyResponseDataRepository;
+import uy.com.bay.utiles.services.ExpenseReportFileService;
+import uy.com.bay.utiles.services.ExpenseTransferFileService;
 import uy.com.bay.utiles.services.JournalEntryService;
 import uy.com.bay.utiles.services.StudyService;
 
@@ -81,12 +83,17 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 	private final StudyService proyectoService;
 	private final JournalEntryService journalEntryService;
 	private final AlchemerSurveyResponseDataRepository alchemerSurveyResponseDataRepository;
+	private final ExpenseReportFileService expenseReportFileService;
+	private final ExpenseTransferFileService expenseTransferFileService;
 
 	public ProyectosView(StudyService proyectoService, JournalEntryService journalEntryService,
-			AlchemerSurveyResponseDataRepository alchemerSurveyResponseDataRepository) {
+			AlchemerSurveyResponseDataRepository alchemerSurveyResponseDataRepository,
+			ExpenseReportFileService expenseReportFileService, ExpenseTransferFileService expenseTransferFileService) {
 		this.proyectoService = proyectoService;
 		this.journalEntryService = journalEntryService;
 		this.alchemerSurveyResponseDataRepository = alchemerSurveyResponseDataRepository;
+		this.expenseReportFileService = expenseReportFileService;
+		this.expenseTransferFileService = expenseTransferFileService;
 		this.binder = new BeanValidationBinder<>(Study.class); // Moved initialization here
 		addClassNames("proyectos-view");
 
@@ -262,7 +269,8 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 
 		viewMovementsButton.addClickListener(e -> {
 			if (this.proyecto != null) {
-				JournalEntryDialog dialog = new JournalEntryDialog(this.proyecto, journalEntryService);
+				JournalEntryDialog dialog = new JournalEntryDialog(this.proyecto, journalEntryService,
+						expenseReportFileService, expenseTransferFileService);
 				dialog.open();
 			}
 		});


### PR DESCRIPTION
This refactoring introduces the following changes:

- In the JournalEntryDialog, the 'detail' column grid is now a link that opens a dialog based on the 'source' attribute of the JournalEntry entity.
- If the source is 'Rendición', a dialog with the expense report data is opened, similar to the ExpenseReportsView edit form.
- If the source is 'Transferencia', an ExpenseTransferViewDialog is opened with the transfer data.
- A 'Cerrar' (Close) button has been added to the footer of the JournalEntryDialog.

To support this, `ProyectosView` has been updated to inject and pass `ExpenseReportFileService` and `ExpenseTransferFileService` to the `JournalEntryDialog`.