### PR TITLE
refactor(reports): Server-side Excel report generation

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/ExcelReportGenerator.java
+++ b/src/main/java/uy/com/bay/utiles/services/ExcelReportGenerator.java
@@ -6,10 +6,16 @@ import org.apache.poi.ss.usermodel.CreationHelper;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
 import uy.com.bay.utiles.data.JournalEntry;
+import uy.com.bay.utiles.data.Study;
+import uy.com.bay.utiles.data.Surveyor;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 public class ExcelReportGenerator {
@@ -18,32 +24,84 @@ public class ExcelReportGenerator {
         try (XSSFWorkbook workbook = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             XSSFSheet sheet = workbook.createSheet("Reporte de Gastos");
 
-            // Header
-            Row headerRow = sheet.createRow(0);
-            String[] columns = {"Fecha", "Encuestador", "Estudio", "Monto"};
-            for (int i = 0; i < columns.length; i++) {
-                Cell cell = headerRow.createCell(i);
-                cell.setCellValue(columns[i]);
+            List<String> headers = new ArrayList<>();
+            List<Field> journalEntryFields = getFields(JournalEntry.class);
+            for (Field field : journalEntryFields) {
+                headers.add("JournalEntry." + field.getName());
+            }
+            List<Field> studyFields = getFields(Study.class);
+            for (Field field : studyFields) {
+                headers.add("Study." + field.getName());
+            }
+            List<Field> surveyorFields = getFields(Surveyor.class);
+            for (Field field : surveyorFields) {
+                headers.add("Surveyor." + field.getName());
             }
 
-            // Date cell style
+            Row headerRow = sheet.createRow(0);
+            for (int i = 0; i < headers.size(); i++) {
+                Cell cell = headerRow.createCell(i);
+                cell.setCellValue(headers.get(i));
+            }
+
             CellStyle dateCellStyle = workbook.createCellStyle();
             CreationHelper createHelper = workbook.getCreationHelper();
             dateCellStyle.setDataFormat(createHelper.createDataFormat().getFormat("dd/MM/yyyy"));
 
-            // Data rows
             int rowNum = 1;
             for (JournalEntry entry : journalEntries) {
                 Row row = sheet.createRow(rowNum++);
-                row.createCell(0).setCellValue(entry.getDate());
-                row.getCell(0).setCellStyle(dateCellStyle);
-                row.createCell(1).setCellValue(entry.getSurveyor() != null ? entry.getSurveyor().getFirstName() : "");
-                row.createCell(2).setCellValue(entry.getStudy() != null ? entry.getStudy().getName() : "");
-                row.createCell(3).setCellValue(entry.getAmount());
+                int cellNum = 0;
+
+                for (Field field : journalEntryFields) {
+                    cellNum = writeFieldToCell(entry, field, row, cellNum, dateCellStyle);
+                }
+                for (Field field : studyFields) {
+                    cellNum = writeFieldToCell(entry.getStudy(), field, row, cellNum, dateCellStyle);
+                }
+                for (Field field : surveyorFields) {
+                    cellNum = writeFieldToCell(entry.getSurveyor(), field, row, cellNum, dateCellStyle);
+                }
             }
 
             workbook.write(out);
             return out;
         }
+    }
+
+    private static List<Field> getFields(Class<?> clazz) {
+        List<Field> fields = new ArrayList<>();
+        while (clazz != null) {
+            for (Field field : clazz.getDeclaredFields()) {
+                if (!java.lang.reflect.Modifier.isStatic(field.getModifiers())) {
+                    fields.add(field);
+                }
+            }
+            clazz = clazz.getSuperclass();
+        }
+        return fields;
+    }
+
+    private static int writeFieldToCell(Object entity, Field field, Row row, int cellNum, CellStyle dateCellStyle) {
+        Cell cell = row.createCell(cellNum++);
+        if (entity == null) {
+            cell.setCellValue("");
+            return cellNum;
+        }
+        try {
+            field.setAccessible(true);
+            Object value = field.get(entity);
+            if (value instanceof Date) {
+                cell.setCellValue((Date) value);
+                cell.setCellStyle(dateCellStyle);
+            } else if (value != null) {
+                cell.setCellValue(value.toString());
+            } else {
+                cell.setCellValue("");
+            }
+        } catch (IllegalAccessException e) {
+            cell.setCellValue("Error");
+        }
+        return cellNum;
     }
 }

--- a/src/main/java/uy/com/bay/utiles/views/MainLayout.java
+++ b/src/main/java/uy/com/bay/utiles/views/MainLayout.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.theme.lumo.LumoUtility;
 
 import uy.com.bay.utiles.data.User;
 import uy.com.bay.utiles.security.AuthenticatedUser;
+import uy.com.bay.utiles.services.JournalEntryService;
 import uy.com.bay.utiles.services.StudyService;
 import uy.com.bay.utiles.services.SurveyorService;
 import uy.com.bay.utiles.views.expenses.ReportesDialog;
@@ -48,12 +49,15 @@ public class MainLayout extends AppLayout {
 	private AccessAnnotationChecker accessChecker;
 	private final SurveyorService surveyorService;
 	private final StudyService studyService;
+	private final JournalEntryService journalEntryService;
 
-	public MainLayout(AuthenticatedUser authenticatedUser, AccessAnnotationChecker accessChecker, SurveyorService surveyorService, StudyService studyService) {
+	public MainLayout(AuthenticatedUser authenticatedUser, AccessAnnotationChecker accessChecker,
+			SurveyorService surveyorService, StudyService studyService, JournalEntryService journalEntryService) {
 		this.authenticatedUser = authenticatedUser;
 		this.accessChecker = accessChecker;
 		this.surveyorService = surveyorService;
 		this.studyService = studyService;
+		this.journalEntryService = journalEntryService;
 
 		setPrimarySection(Section.DRAWER);
 		addDrawerContent();
@@ -133,7 +137,7 @@ public class MainLayout extends AppLayout {
 		SideNavItem reportesNavItem = new SideNavItem("Reportes");
 		reportesNavItem.setPrefixComponent(new Icon("vaadin", "file-chart"));
 		reportesNavItem.getElement().addEventListener("click", e -> {
-			ReportesDialog dialog = new ReportesDialog(surveyorService, studyService);
+			ReportesDialog dialog = new ReportesDialog(surveyorService, studyService, journalEntryService);
 			dialog.open();
 		});
 		gastosItem.addItem(reportesNavItem);


### PR DESCRIPTION
Refactored the `downloadReport` method in `ReportesDialog` to generate the Excel report on the server side.

- Replaced the previous implementation that was incorrectly calling a non-existent API endpoint.
- The new implementation now fetches `JournalEntry` entities from the database based on user-selected filters (date range, surveyors, studies).
- A new `ExcelReportGenerator` class has been introduced to handle the Excel file creation. This class uses reflection to dynamically generate columns and populate data from `JournalEntry` and its related `Study` and `Surveyor` entities, ensuring all attributes are included as requested.
- The generated Excel file is then made available for download to the user directly from the UI using Vaadin's `StreamResource`.
- Injected `JournalEntryService` into `ReportesDialog` through `MainLayout` to enable data fetching.