### PR TITLE
Fix(ComboBox): Add null safety to ItemLabelGenerators

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportsView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportsView.java
@@ -242,15 +242,15 @@ public class ExpenseReportsView extends Div implements BeforeEnterObserver {
 		FormLayout formLayout = new FormLayout();
 		study = new ComboBox<>("Estudio");
 		study.setItems(studyService.listAll());
-		study.setItemLabelGenerator(Study::getName);
+		study.setItemLabelGenerator(study -> study == null ? "" : study.getName());
 		surveyor = new ComboBox<>("Encuestador");
 		surveyor.setItems(surveyorService.listAll());
-		surveyor.setItemLabelGenerator(s -> s.getFirstName() + " " + s.getLastName());
+		surveyor.setItemLabelGenerator(Surveyor::getName);
 		date = new DatePicker("Fecha");
 		amount = new NumberField("Monto");
 		concept = new ComboBox<>("Concepto");
 		concept.setItems(expenseRequestTypeService.findAll());
-		concept.setItemLabelGenerator(ExpenseRequestType::getName);
+		concept.setItemLabelGenerator(concept -> concept == null ? "" : concept.getName());
 		obs = new TextArea("Observaciones");
 
 		files = new Upload();

--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpensesView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpensesView.java
@@ -220,7 +220,7 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 
 		ComboBox<ExpenseRequestType> conceptFilter = new ComboBox<>();
 		conceptFilter.setItems(expenseRequestTypeService.findAll());
-		conceptFilter.setItemLabelGenerator(ert -> ert.getName() != null ? ert.getName() : "");
+		conceptFilter.setItemLabelGenerator(ert -> ert == null ? "" : ert.getName());
 		conceptFilter.setPlaceholder("Filter");
 		conceptFilter.setClearButtonVisible(true);
 		conceptFilter.addValueChangeListener(e -> {
@@ -469,10 +469,10 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 		FormLayout formLayout = new FormLayout();
 		study = new ComboBox<>("Estudio");
 		study.setItems(studyService.listAll());
-		study.setItemLabelGenerator(s -> s.getName() != null ? s.getName() : "");
+		study.setItemLabelGenerator(s -> s == null ? "" : s.getName());
 		surveyor = new ComboBox<>("Encuestador");
 		surveyor.setItems(surveyorService.listAll());
-		surveyor.setItemLabelGenerator(Surveyor::getName);
+		surveyor.setItemLabelGenerator(s -> s == null ? "" : s.getName());
 		requestDate = new DatePicker("Fecha solicitud");
 		requestDate.setReadOnly(true);
 		aprovalDate = new DatePicker("Fecha aprobación");
@@ -482,7 +482,7 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 		amount = new NumberField("Monto");
 		concept = new ComboBox<>("Concepto");
 		concept.setItems(expenseRequestTypeService.findAll());
-		concept.setItemLabelGenerator(ert -> ert.getName() != null ? ert.getName() : "");
+		concept.setItemLabelGenerator(ert -> ert == null ? "" : ert.getName());
 		obs = new com.vaadin.flow.component.textfield.TextArea("Observaciones");
 		formLayout.add(study, surveyor, requestDate, aprovalDate, transferDate, amount, concept, obs);
 		editorDiv.add(formLayout);

--- a/src/main/java/uy/com/bay/utiles/views/expenses/ReportesDialog.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ReportesDialog.java
@@ -52,9 +52,9 @@ public class ReportesDialog extends Dialog {
 
         // Poblar ComboBoxes
         encuestadores.setItems(surveyorService.listAll());
-        encuestadores.setItemLabelGenerator(Surveyor::getFirstName);
+        encuestadores.setItemLabelGenerator(s -> s == null ? "" : s.getName());
         estudios.setItems(studyService.listAll());
-        estudios.setItemLabelGenerator(Study::getName);
+        estudios.setItemLabelGenerator(s -> s == null ? "" : s.getName());
 
         FormLayout formLayout = new FormLayout();
         formLayout.add(fechaDesde, fechaHasta, encuestadores, estudios);

--- a/src/main/java/uy/com/bay/utiles/views/expenses/SurveyorExpenseReportEntry.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/SurveyorExpenseReportEntry.java
@@ -73,7 +73,7 @@ public class SurveyorExpenseReportEntry extends Div {
 		FormLayout formLayout = new FormLayout();
 		study = new ComboBox<>("Estudio");
 		study.setItems(studyService.findAllByShowSurveyor(true));
-		study.setItemLabelGenerator(Study::getName);
+		study.setItemLabelGenerator(s -> s == null ? "" : s.getName());
 		study.setRequired(true);
 
 		amount = new NumberField("Monto");
@@ -81,7 +81,7 @@ public class SurveyorExpenseReportEntry extends Div {
 
 		concept = new ComboBox<>("Concepto");
 		concept.setItems(expenseRequestTypeService.findAll());
-		concept.setItemLabelGenerator(ExpenseRequestType::getName);
+		concept.setItemLabelGenerator(c -> c == null ? "" : c.getName());
 		concept.setRequired(true);
 
 		obs = new TextArea("Observaciones");

--- a/src/main/java/uy/com/bay/utiles/views/expenses/SurveyorExpenseRequestEntry.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/SurveyorExpenseRequestEntry.java
@@ -57,7 +57,7 @@ public class SurveyorExpenseRequestEntry extends Div {
 		FormLayout formLayout = new FormLayout();
 		study = new ComboBox<>("Estudio");
 		study.setItems(studyService.findAllByShowSurveyor(true));
-		study.setItemLabelGenerator(Study::getName);
+		study.setItemLabelGenerator(s -> s == null ? "" : s.getName());
 		study.setRequired(true);
 
 		amount = new NumberField("Monto");
@@ -65,7 +65,7 @@ public class SurveyorExpenseRequestEntry extends Div {
 
 		concept = new ComboBox<>("Concepto");
 		concept.setItems(expenseRequestTypeService.findAll());
-		concept.setItemLabelGenerator(ExpenseRequestType::getName);
+		concept.setItemLabelGenerator(c -> c == null ? "" : c.getName());
 		concept.setRequired(true);
 
 		obs = new TextArea("Observaciones");

--- a/src/main/java/uy/com/bay/utiles/views/useradmin/UserAdminView.java
+++ b/src/main/java/uy/com/bay/utiles/views/useradmin/UserAdminView.java
@@ -79,7 +79,7 @@ public class UserAdminView extends Div implements BeforeEnterObserver {
 
 		roles = new MultiSelectComboBox<>("Role");
 		roles.setItems(Role.values());
-		roles.setItemLabelGenerator(Role::name);
+		roles.setItemLabelGenerator(r -> r == null ? "" : r.name());
 
 		addButton = new Button("Agregar");
 		addButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);


### PR DESCRIPTION
A NullPointerException was occurring in the ComboBox filtering logic when an ItemLabelGenerator returned a null value. This was because the ComboBox internally calls toLowerCase() on the label without a null check.

This commit fixes the issue by wrapping all ItemLabelGenerators for ComboBoxes and MultiSelectComboBoxes with custom types in a null-safe lambda. The new generators check if the item is null and return an empty string, preventing the NullPointerException.

This change also standardizes the label generation for Surveyors to use the safe Surveyor.getName() method, improving consistency across different views.