### PR TITLE
fix(expensetransfer): Prevent NullPointerException in save

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/expensetransfer/ExpenseTransferDialog.java
+++ b/src/main/java/uy/com/bay/utiles/views/expensetransfer/ExpenseTransferDialog.java
@@ -101,8 +101,13 @@ public class ExpenseTransferDialog extends Dialog {
 				return;
 			}
 			Surveyor firstSurveyor = selectedRequests.iterator().next().getSurveyor();
+			if (firstSurveyor == null) {
+				Notification.show("La solicitud de gasto seleccionada no tiene un encuestador asignado.", 3000,
+						Position.MIDDLE);
+				return;
+			}
 			for (ExpenseRequest request : selectedRequests) {
-				if (!request.getSurveyor().equals(firstSurveyor)) {
+				if (!firstSurveyor.equals(request.getSurveyor())) {
 					Notification.show("Solo se pueden crear transferencias vinculando a un mismo encuestador", 3000,
 							Position.MIDDLE);
 


### PR DESCRIPTION
When saving an ExpenseTransfer, a NullPointerException could occur if any of the selected ExpenseRequests had a null surveyor.

This was caused by calling .equals() on a null reference.

This commit adds a null check for the first surveyor and then uses a safe comparison method within the loop to prevent the NPE, ensuring all selected requests belong to the same, non-null surveyor. A user-facing notification is also added to inform the user about the issue.