### PR TITLE
feat: Add Fieldwork entity and view

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/Fieldwork.java
+++ b/src/main/java/uy/com/bay/utiles/data/Fieldwork.java
@@ -1,0 +1,110 @@
+package uy.com.bay.utiles.data;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
+
+@Entity
+public class Fieldwork extends AbstractEntity {
+
+    @ManyToOne
+    @JoinColumn(name = "study_id")
+    private Study study;
+
+    private LocalDate initPlannedDate;
+    private LocalDate endPlannedDate;
+    private LocalDate initDate;
+    private LocalDate endDate;
+    private Integer goalQuantity;
+    private Integer completed;
+    private String obse;
+
+    @Enumerated(EnumType.STRING)
+    private FieldworkStatus status;
+
+    @Enumerated(EnumType.STRING)
+    private FieldworkType type;
+
+    public Study getStudy() {
+        return study;
+    }
+
+    public void setStudy(Study study) {
+        this.study = study;
+    }
+
+    public LocalDate getInitPlannedDate() {
+        return initPlannedDate;
+    }
+
+    public void setInitPlannedDate(LocalDate initPlannedDate) {
+        this.initPlannedDate = initPlannedDate;
+    }
+
+    public LocalDate getEndPlannedDate() {
+        return endPlannedDate;
+    }
+
+    public void setEndPlannedDate(LocalDate endPlannedDate) {
+        this.endPlannedDate = endPlannedDate;
+    }
+
+    public LocalDate getInitDate() {
+        return initDate;
+    }
+
+    public void setInitDate(LocalDate initDate) {
+        this.initDate = initDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    public Integer getGoalQuantity() {
+        return goalQuantity;
+    }
+
+    public void setGoalQuantity(Integer goalQuantity) {
+        this.goalQuantity = goalQuantity;
+    }
+
+    public Integer getCompleted() {
+        return completed;
+    }
+
+    public void setCompleted(Integer completed) {
+        this.completed = completed;
+    }
+
+    public String getObse() {
+        return obse;
+    }
+
+    public void setObse(String obse) {
+        this.obse = obse;
+    }
+
+    public FieldworkStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(FieldworkStatus status) {
+        this.status = status;
+    }
+
+    public FieldworkType getType() {
+        return type;
+    }
+
+    public void setType(FieldworkType type) {
+        this.type = type;
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/data/FieldworkStatus.java
+++ b/src/main/java/uy/com/bay/utiles/data/FieldworkStatus.java
@@ -1,0 +1,5 @@
+package uy.com.bay.utiles.data;
+
+public enum FieldworkStatus {
+    INGRESADO, APROBADO, ACTIVO, FINALIZADO
+}

--- a/src/main/java/uy/com/bay/utiles/data/FieldworkType.java
+++ b/src/main/java/uy/com/bay/utiles/data/FieldworkType.java
@@ -1,0 +1,5 @@
+package uy.com.bay.utiles.data;
+
+public enum FieldworkType {
+    TELEFONICO, CALLE, ENTREVISTAS, WEB
+}

--- a/src/main/java/uy/com/bay/utiles/data/repository/FieldworkRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/FieldworkRepository.java
@@ -1,0 +1,8 @@
+package uy.com.bay.utiles.data.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import uy.com.bay.utiles.data.Fieldwork;
+
+public interface FieldworkRepository extends JpaRepository<Fieldwork, Long>, JpaSpecificationExecutor<Fieldwork> {
+}

--- a/src/main/java/uy/com/bay/utiles/data/service/FieldworkService.java
+++ b/src/main/java/uy/com/bay/utiles/data/service/FieldworkService.java
@@ -1,0 +1,44 @@
+package uy.com.bay.utiles.data.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import uy.com.bay.utiles.data.Fieldwork;
+import uy.com.bay.utiles.data.repository.FieldworkRepository;
+
+import java.util.Optional;
+
+@Service
+public class FieldworkService {
+
+    private final FieldworkRepository repository;
+
+    public FieldworkService(FieldworkRepository repository) {
+        this.repository = repository;
+    }
+
+    public Optional<Fieldwork> get(Long id) {
+        return repository.findById(id);
+    }
+
+    public Fieldwork save(Fieldwork entity) {
+        return repository.save(entity);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+
+    public Page<Fieldwork> list(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+    public Page<Fieldwork> list(Pageable pageable, Specification<Fieldwork> filter) {
+        return repository.findAll(filter, pageable);
+    }
+
+    public int count() {
+        return (int) repository.count();
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/views/MainLayout.java
+++ b/src/main/java/uy/com/bay/utiles/views/MainLayout.java
@@ -154,6 +154,13 @@ public class MainLayout extends AppLayout {
 		
 		nav.addItem(surveyorPortalItem);
 
+		SideNavItem solicitudesCampoItem = new SideNavItem("Solicitudes de campo");
+		solicitudesCampoItem.setPrefixComponent(new Icon("vaadin", "clipboard-text"));
+		SideNavItem listarSolicitudesItem = new SideNavItem("Listar Solicitudes", "fieldworks");
+		listarSolicitudesItem.setPrefixComponent(new Icon("vaadin", "list"));
+		solicitudesCampoItem.addItem(listarSolicitudesItem);
+		nav.addItem(solicitudesCampoItem);
+
 
 		SideNavItem settingsItem = new SideNavItem("Configuración");
 		settingsItem.setPrefixComponent(new Icon("vaadin", "cog"));

--- a/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
+++ b/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
@@ -1,0 +1,273 @@
+package uy.com.bay.utiles.views.fieldworks;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.GridVariant;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.orderedlayout.FlexComponent.JustifyContentMode;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.splitlayout.SplitLayout;
+import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.binder.BeanValidationBinder;
+import com.vaadin.flow.data.binder.ValidationException;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.spring.data.VaadinSpringDataHelpers;
+import jakarta.annotation.security.RolesAllowed;
+import org.springframework.data.jpa.domain.Specification;
+import uy.com.bay.utiles.data.Fieldwork;
+import uy.com.bay.utiles.data.FieldworkStatus;
+import uy.com.bay.utiles.data.FieldworkType;
+import uy.com.bay.utiles.data.Study;
+import uy.com.bay.utiles.data.service.FieldworkService;
+import uy.com.bay.utiles.services.StudyService;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+@Route("fieldworks/:fieldworkID?/:action?(edit)")
+@RolesAllowed("ADMIN")
+public class FieldworksView extends Div implements BeforeEnterObserver {
+
+    private final String FIELDWORK_ID = "fieldworkID";
+    private final String FIELDWORK_EDIT_ROUTE_TEMPLATE = "fieldworks/%s/edit";
+
+    private final Grid<Fieldwork> grid = new Grid<>(Fieldwork.class, false);
+
+    private ComboBox<Study> study;
+    private DatePicker initPlannedDate;
+    private DatePicker endPlannedDate;
+    private DatePicker initDate;
+    private DatePicker endDate;
+    private IntegerField goalQuantity;
+    private IntegerField completed;
+    private TextField obse;
+    private ComboBox<FieldworkStatus> status;
+    private ComboBox<FieldworkType> type;
+
+    private ComboBox<Study> studyFilter;
+    private ComboBox<FieldworkStatus> statusFilter;
+    private ComboBox<FieldworkType> typeFilter;
+
+    private final Button cancel = new Button("Cancelar");
+    private final Button save = new Button("Guardar");
+    private final Button delete = new Button("Eliminar");
+
+    private final BeanValidationBinder<Fieldwork> binder;
+
+    private Fieldwork fieldwork;
+    private Div editorLayoutDiv;
+
+    private final FieldworkService fieldworkService;
+    private final StudyService studyService;
+
+    public FieldworksView(FieldworkService fieldworkService, StudyService studyService) {
+        this.fieldworkService = fieldworkService;
+        this.studyService = studyService;
+        addClassNames("fieldworks-view");
+
+        // Create UI
+        SplitLayout splitLayout = new SplitLayout();
+
+        createGridLayout(splitLayout);
+        createEditorLayout(splitLayout);
+
+        add(splitLayout);
+
+        // Configure Grid
+        grid.addColumn(fieldwork -> fieldwork.getStudy() != null ? fieldwork.getStudy().getName() : "").setHeader("Estudio").setAutoWidth(true);
+        grid.addColumn("initPlannedDate").setHeader("Fecha Planificada Inicio").setAutoWidth(true);
+        grid.addColumn("endPlannedDate").setHeader("Fecha Planificada Fin").setAutoWidth(true);
+        grid.addColumn("initDate").setHeader("Fecha Inicio").setAutoWidth(true);
+        grid.addColumn("endDate").setHeader("Fecha Fin").setAutoWidth(true);
+        grid.addColumn("goalQuantity").setHeader("Cantidad Objetivo").setAutoWidth(true);
+        grid.addColumn("completed").setHeader("Completadas").setAutoWidth(true);
+        grid.addColumn("status").setHeader("Estado").setAutoWidth(true);
+        grid.addColumn("type").setHeader("Tipo").setAutoWidth(true);
+
+        grid.setItems(query -> {
+            Specification<Fieldwork> spec = (root, q, cb) -> {
+                return cb.and();
+            };
+            if (studyFilter.getValue() != null) {
+                spec = spec.and((root, q, cb) -> cb.equal(root.get("study"), studyFilter.getValue()));
+            }
+            if (statusFilter.getValue() != null) {
+                spec = spec.and((root, q, cb) -> cb.equal(root.get("status"), statusFilter.getValue()));
+            }
+            if (typeFilter.getValue() != null) {
+                spec = spec.and((root, q, cb) -> cb.equal(root.get("type"), typeFilter.getValue()));
+            }
+            return fieldworkService.list(VaadinSpringDataHelpers.toSpringPageRequest(query), spec).stream();
+        });
+        grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
+
+        // when a row is selected or deselected, populate form
+        grid.asSingleSelect().addValueChangeListener(event -> {
+            if (event.getValue() != null) {
+                UI.getCurrent().navigate(String.format(FIELDWORK_EDIT_ROUTE_TEMPLATE, event.getValue().getId()));
+            } else {
+                clearForm();
+                UI.getCurrent().navigate(FieldworksView.class);
+            }
+        });
+
+        // Configure Form
+        binder = new BeanValidationBinder<>(Fieldwork.class);
+        binder.bindInstanceFields(this);
+
+        cancel.addClickListener(e -> {
+            clearForm();
+            refreshGrid();
+        });
+
+        save.addClickListener(e -> {
+            try {
+                if (this.fieldwork == null) {
+                    this.fieldwork = new Fieldwork();
+                }
+                binder.writeBean(this.fieldwork);
+                fieldworkService.save(this.fieldwork);
+                clearForm();
+                refreshGrid();
+                Notification.show("Solicitud de campo guardada.");
+                UI.getCurrent().navigate(FieldworksView.class);
+            } catch (ValidationException validationException) {
+                Notification.show("No se pudo guardar la solicitud. Verifique los campos.");
+            }
+        });
+
+        delete.addClickListener(e -> {
+            if (this.fieldwork != null) {
+                fieldworkService.delete(this.fieldwork.getId());
+                clearForm();
+                refreshGrid();
+                Notification.show("Solicitud de campo eliminada.");
+                UI.getCurrent().navigate(FieldworksView.class);
+            }
+        });
+    }
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        Optional<Long> fieldworkId = event.getRouteParameters().get(FIELDWORK_ID).map(Long::parseLong);
+        if (fieldworkId.isPresent()) {
+            Optional<Fieldwork> fieldworkFromBackend = fieldworkService.get(fieldworkId.get());
+            if (fieldworkFromBackend.isPresent()) {
+                populateForm(fieldworkFromBackend.get());
+            } else {
+                Notification.show(
+                        String.format("La solicitud de campo con id = %s no fue encontrada", fieldworkId.get()), 3000,
+                        Notification.Position.BOTTOM_START);
+                refreshGrid();
+                event.forwardTo(FieldworksView.class);
+            }
+        }
+    }
+
+    private void createEditorLayout(SplitLayout splitLayout) {
+        this.editorLayoutDiv = new Div();
+        this.editorLayoutDiv.setClassName("editor-layout");
+
+        Div editorDiv = new Div();
+        editorDiv.setClassName("editor");
+        this.editorLayoutDiv.add(editorDiv);
+
+        FormLayout formLayout = new FormLayout();
+        study = new ComboBox<>("Estudio");
+        study.setItems(studyService.listAll());
+        study.setItemLabelGenerator(Study::getName);
+        initPlannedDate = new DatePicker("Fecha Planificada Inicio");
+        endPlannedDate = new DatePicker("Fecha Planificada Fin");
+        initDate = new DatePicker("Fecha Inicio");
+        endDate = new DatePicker("Fecha Fin");
+        goalQuantity = new IntegerField("Cantidad Objetivo");
+        completed = new IntegerField("Completadas");
+        obse = new TextField("Observaciones");
+        status = new ComboBox<>("Estado");
+        status.setItems(FieldworkStatus.values());
+        type = new ComboBox<>("Tipo");
+        type.setItems(FieldworkType.values());
+        formLayout.add(study, initPlannedDate, endPlannedDate, initDate, endDate, goalQuantity, completed, obse, status, type);
+
+        editorDiv.add(formLayout);
+        createButtonLayout(this.editorLayoutDiv);
+
+        splitLayout.addToSecondary(this.editorLayoutDiv);
+        this.editorLayoutDiv.setVisible(false);
+    }
+
+    private void createButtonLayout(Div editorLayoutDiv) {
+        HorizontalLayout buttonLayout = new HorizontalLayout();
+        buttonLayout.setClassName("button-layout");
+        save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        delete.addThemeVariants(ButtonVariant.LUMO_ERROR);
+        buttonLayout.add(save, delete, cancel);
+        editorLayoutDiv.add(buttonLayout);
+    }
+
+    private void createGridLayout(SplitLayout splitLayout) {
+        Div wrapper = new Div();
+        wrapper.setClassName("grid-wrapper");
+        splitLayout.addToPrimary(wrapper);
+
+        H2 title = new H2("Solicitudes de Campo");
+        Button addButton = new Button("Agregar Solicitud");
+        addButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        addButton.addClickListener(e -> {
+            clearForm();
+            this.fieldwork = new Fieldwork();
+            binder.readBean(this.fieldwork);
+            this.editorLayoutDiv.setVisible(true);
+        });
+
+        HorizontalLayout topLayout = new HorizontalLayout(title, addButton);
+        topLayout.setWidth("100%");
+        topLayout.setJustifyContentMode(JustifyContentMode.BETWEEN);
+
+        studyFilter = new ComboBox<>("Estudio");
+        studyFilter.setItems(studyService.listAll());
+        studyFilter.setItemLabelGenerator(Study::getName);
+        studyFilter.setClearButtonVisible(true);
+        studyFilter.addValueChangeListener(e -> refreshGrid());
+
+        statusFilter = new ComboBox<>("Estado");
+        statusFilter.setItems(FieldworkStatus.values());
+        statusFilter.setClearButtonVisible(true);
+        statusFilter.addValueChangeListener(e -> refreshGrid());
+
+        typeFilter = new ComboBox<>("Tipo");
+        typeFilter.setItems(FieldworkType.values());
+        typeFilter.setClearButtonVisible(true);
+        typeFilter.addValueChangeListener(e -> refreshGrid());
+
+        HorizontalLayout filterLayout = new HorizontalLayout(studyFilter, statusFilter, typeFilter);
+        filterLayout.setWidth("100%");
+
+        wrapper.add(topLayout, filterLayout, grid);
+    }
+
+    private void refreshGrid() {
+        grid.select(null);
+        grid.getDataProvider().refreshAll();
+    }
+
+    private void clearForm() {
+        populateForm(null);
+    }
+
+    private void populateForm(Fieldwork value) {
+        this.fieldwork = value;
+        binder.readBean(this.fieldwork);
+        this.editorLayoutDiv.setVisible(value != null);
+    }
+}


### PR DESCRIPTION
This commit introduces the new `Fieldwork` entity with all its attributes, including enums for status and type, and a relationship with the `Study` entity.

It also adds a new `FieldworksView` that allows listing, creating, editing, and deleting `Fieldwork` entities. The view includes server-side filtering for the main columns.

A new navigation item 'Solicitudes de campo' has been added to the main layout to access the new view.