### PR TITLE
Refactor: Add area attribute to Fieldwork entity

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/Area.java
+++ b/src/main/java/uy/com/bay/utiles/data/Area.java
@@ -1,0 +1,5 @@
+package uy.com.bay.utiles.data;
+
+public enum Area {
+	CORPORATIVO, DS, OP, OTRA
+}

--- a/src/main/java/uy/com/bay/utiles/data/Fieldwork.java
+++ b/src/main/java/uy/com/bay/utiles/data/Fieldwork.java
@@ -28,6 +28,17 @@ public class Fieldwork extends AbstractEntity {
 	@Enumerated(EnumType.STRING)
 	private FieldworkType type;
 
+	@Enumerated(EnumType.STRING)
+	private Area area;
+
+	public Area getArea() {
+		return area;
+	}
+
+	public void setArea(Area area) {
+		this.area = area;
+	}
+
 	public Study getStudy() {
 		return study;
 	}

--- a/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
+++ b/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.spring.data.VaadinSpringDataHelpers;
 import jakarta.annotation.security.RolesAllowed;
 import org.springframework.data.jpa.domain.Specification;
+import uy.com.bay.utiles.data.Area;
 import uy.com.bay.utiles.data.Fieldwork;
 import uy.com.bay.utiles.data.FieldworkStatus;
 import uy.com.bay.utiles.data.FieldworkType;
@@ -54,6 +55,7 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 	private TextField obs;
 	private ComboBox<FieldworkStatus> status;
 	private ComboBox<FieldworkType> type;
+	private ComboBox<Area> area;
 
 	private ComboBox<Study> studyFilter;
 	private ComboBox<FieldworkStatus> statusFilter;
@@ -95,6 +97,7 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 		grid.addColumn("completed").setHeader("Completadas").setAutoWidth(true);
 		grid.addColumn("status").setHeader("Estado").setAutoWidth(true);
 		grid.addColumn("type").setHeader("Tipo").setAutoWidth(true);
+		grid.addColumn("area").setHeader("Area").setAutoWidth(true);
 
 		grid.setItems(query -> {
 			Specification<Fieldwork> spec = (root, q, cb) -> {
@@ -199,8 +202,10 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 		status.setItems(FieldworkStatus.values());
 		type = new ComboBox<>("Tipo");
 		type.setItems(FieldworkType.values());
+		area = new ComboBox<>("Area");
+		area.setItems(Area.values());
 		formLayout.add(study, initPlannedDate, endPlannedDate, initDate, endDate, goalQuantity, completed, obs, status,
-				type);
+				type, area);
 
 		editorDiv.add(formLayout);
 		createButtonLayout(this.editorLayoutDiv);


### PR DESCRIPTION
This commit adds a new 'area' attribute to the Fieldwork entity. The 'area' attribute is an enumeration with the following possible values:
- CORPORATIVO
- DS
- OP
- OTRA

The attribute has been made visible in the FieldworksView grid and in the entity's edit form.