### PR TITLE
feat: Refactor Study and ProyectosView for Fieldwork integration

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/Study.java
+++ b/src/main/java/uy/com/bay/utiles/data/Study.java
@@ -1,10 +1,15 @@
 package uy.com.bay.utiles.data;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import java.util.List;
 
 @Entity
 public class Study extends AbstractEntity {
 
+	@OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
+	private List<Fieldwork> fieldworks;
 	private String name;
 	private String odooId;
 	private String obs;
@@ -63,4 +68,11 @@ public class Study extends AbstractEntity {
 		this.obs = obs;
 	}
 
+	public List<Fieldwork> getFieldworks() {
+		return fieldworks;
+	}
+
+	public void setFieldworks(List<Fieldwork> fieldworks) {
+		this.fieldworks = fieldworks;
+	}
 }

--- a/src/main/java/uy/com/bay/utiles/data/repository/FieldworkRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/FieldworkRepository.java
@@ -6,9 +6,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import uy.com.bay.utiles.data.Fieldwork;
+import uy.com.bay.utiles.data.Study;
+
+import java.util.List;
 
 public interface FieldworkRepository extends JpaRepository<Fieldwork, Long>, JpaSpecificationExecutor<Fieldwork> {
 	Optional<Fieldwork> findByAlchemerId(String alchemerId);
 
 	Optional<Fieldwork> findByDoobloId(String doobloId);
+
+	List<Fieldwork> findAllByStudy(Study study);
 }

--- a/src/main/java/uy/com/bay/utiles/data/service/FieldworkService.java
+++ b/src/main/java/uy/com/bay/utiles/data/service/FieldworkService.java
@@ -5,8 +5,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import uy.com.bay.utiles.data.Fieldwork;
+import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.data.repository.FieldworkRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -40,5 +42,9 @@ public class FieldworkService {
 
     public int count() {
         return (int) repository.count();
+    }
+
+    public List<Fieldwork> findAllByStudy(Study study) {
+        return repository.findAllByStudy(study);
     }
 }

--- a/src/main/java/uy/com/bay/utiles/views/proyectos/FieldworkDialog.java
+++ b/src/main/java/uy/com/bay/utiles/views/proyectos/FieldworkDialog.java
@@ -1,0 +1,31 @@
+package uy.com.bay.utiles.views.proyectos;
+
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import uy.com.bay.utiles.data.Fieldwork;
+import uy.com.bay.utiles.data.Study;
+import uy.com.bay.utiles.data.service.FieldworkService;
+
+public class FieldworkDialog extends Dialog {
+
+    public FieldworkDialog(Study study, FieldworkService fieldworkService) {
+        setHeaderTitle("Solicitudes de Campo para: " + study.getName());
+
+        Grid<Fieldwork> grid = new Grid<>(Fieldwork.class, false);
+        grid.addColumn("type").setHeader("Tipo").setAutoWidth(true);
+        grid.addColumn("area").setHeader("Area").setAutoWidth(true);
+        grid.addColumn("status").setHeader("Estado").setAutoWidth(true);
+        grid.addColumn("initPlannedDate").setHeader("Fecha inicio planificada").setAutoWidth(true);
+        grid.addColumn("endPlannedDate").setHeader("Fecha fin planificada").setAutoWidth(true);
+        grid.addColumn("goalQuantity").setHeader("Encuestas objetivo").setAutoWidth(true);
+
+        grid.setItems(fieldworkService.findAllByStudy(study));
+
+        VerticalLayout layout = new VerticalLayout(grid);
+        add(layout);
+
+        setCloseOnEsc(true);
+        setCloseOnOutsideClick(true);
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/views/proyectos/ProyectosView.java
+++ b/src/main/java/uy/com/bay/utiles/views/proyectos/ProyectosView.java
@@ -37,6 +37,7 @@ import jakarta.annotation.security.RolesAllowed;
 import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.data.repository.AlchemerSurveyResponseDataRepository;
 import uy.com.bay.utiles.services.ExpenseReportFileService;
+import uy.com.bay.utiles.data.service.FieldworkService;
 import uy.com.bay.utiles.services.ExpenseTransferFileService;
 import uy.com.bay.utiles.services.JournalEntryService;
 import uy.com.bay.utiles.services.StudyService;
@@ -70,6 +71,7 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 	private final Button save = new Button("Save");
 	private Button deleteButton; // Added deleteButton declaration
 	private Button viewMovementsButton;
+	private Button viewFieldworksButton;
 
 	private final BeanValidationBinder<Study> binder;
 
@@ -81,12 +83,15 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 	private final AlchemerSurveyResponseDataRepository alchemerSurveyResponseDataRepository;
 	private final ExpenseReportFileService expenseReportFileService;
 	private final ExpenseTransferFileService expenseTransferFileService;
+	private final FieldworkService fieldworkService;
 
 	public ProyectosView(StudyService proyectoService, JournalEntryService journalEntryService,
 			AlchemerSurveyResponseDataRepository alchemerSurveyResponseDataRepository,
-			ExpenseReportFileService expenseReportFileService, ExpenseTransferFileService expenseTransferFileService) {
+			ExpenseReportFileService expenseReportFileService, ExpenseTransferFileService expenseTransferFileService,
+			FieldworkService fieldworkService) {
 		this.proyectoService = proyectoService;
 		this.journalEntryService = journalEntryService;
+		this.fieldworkService = fieldworkService;
 		this.alchemerSurveyResponseDataRepository = alchemerSurveyResponseDataRepository;
 		this.expenseReportFileService = expenseReportFileService;
 		this.expenseTransferFileService = expenseTransferFileService;
@@ -105,6 +110,9 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 
 		viewMovementsButton = new Button("Ver movimientos de gastos");
 		viewMovementsButton.setEnabled(false);
+
+		viewFieldworksButton = new Button("Ver solicitudes de campo");
+		viewFieldworksButton.setEnabled(false);
 
 		nameFilter = new TextField();
 		nameFilter.setPlaceholder("Nombre...");
@@ -245,6 +253,13 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 				dialog.open();
 			}
 		});
+
+		viewFieldworksButton.addClickListener(e -> {
+			if (this.proyecto != null) {
+				FieldworkDialog dialog = new FieldworkDialog(this.proyecto, fieldworkService);
+				dialog.open();
+			}
+		});
 	}
 
 	@Override
@@ -289,6 +304,7 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 
 		editorDiv.add(formLayout);
 		editorDiv.add(viewMovementsButton);
+		editorDiv.add(viewFieldworksButton);
 		createButtonLayout(this.editorLayoutDiv);
 
 		splitLayout.addToSecondary(this.editorLayoutDiv);
@@ -354,6 +370,9 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 		}
 		if (this.viewMovementsButton != null) {
 			this.viewMovementsButton.setEnabled(value != null && value.getId() != null);
+		}
+		if (this.viewFieldworksButton != null) {
+			this.viewFieldworksButton.setEnabled(value != null && value.getId() != null);
 		}
 	}
 }


### PR DESCRIPTION
This commit introduces a one-to-many relationship from the Study entity to the Fieldwork entity and adds UI components to view related fieldworks.

Key changes:
- Updated `Study.java` to include a `List<Fieldwork> fieldworks` with a `@OneToMany` relationship.
- Added `findAllByStudy(Study study)` method to `FieldworkRepository` and `FieldworkService` to fetch fieldwork entities associated with a specific study.
- Created `FieldworkDialog.java`, a new Vaadin Dialog component that displays a grid of `Fieldwork` entities. The grid shows key details like type, area, status, and planned dates.
- Modified `ProyectosView.java` to:
  - Inject `FieldworkService`.
  - Add a "Ver solicitudes de campo" button to the study editor form.
  - Implement a click listener that opens the `FieldworkDialog` populated with data for the selected study.
  - Ensure the button's enabled/disabled state is managed correctly, consistent with other form buttons.

These changes fulfill the user's request to view fieldwork solicitations directly from the project editing interface, improving usability and data accessibility.