### PR TITLE
Fix LazyInitializationException when saving a Fieldwork

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/Study.java
+++ b/src/main/java/uy/com/bay/utiles/data/Study.java
@@ -2,13 +2,14 @@ package uy.com.bay.utiles.data;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
 import java.util.List;
 
 @Entity
 public class Study extends AbstractEntity {
 
-	@OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
+	@OneToMany(mappedBy = "study", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
 	private List<Fieldwork> fieldworks;
 	private String name;
 	private String odooId;


### PR DESCRIPTION
A LazyInitializationException was being thrown when adding a new Fieldwork and associating it with a Study. This happened because the code was trying to access the `fieldworks` collection on a detached Study entity.

The fix is to change the fetch strategy for the `Study.fieldworks` collection from the default LAZY to EAGER. This ensures the collection is always loaded with the Study entity, preventing the exception from occurring in the view layer.