### PR TITLE
feat: Add GanttView to visualize Fieldwork entities

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/FieldworkRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/FieldworkRepository.java
@@ -16,4 +16,6 @@ public interface FieldworkRepository extends JpaRepository<Fieldwork, Long>, Jpa
 	Optional<Fieldwork> findByDoobloId(String doobloId);
 
 	List<Fieldwork> findAllByStudy(Study study);
+
+	List<Fieldwork> findAllByEndPlannedDateBetween(java.time.LocalDate startDate, java.time.LocalDate endDate);
 }

--- a/src/main/java/uy/com/bay/utiles/services/GanttService.java
+++ b/src/main/java/uy/com/bay/utiles/services/GanttService.java
@@ -1,0 +1,24 @@
+package uy.com.bay.utiles.services;
+
+import org.springframework.stereotype.Service;
+import uy.com.bay.utiles.data.Fieldwork;
+import uy.com.bay.utiles.data.repository.FieldworkRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+public class GanttService {
+
+    private final FieldworkRepository fieldworkRepository;
+
+    public GanttService(FieldworkRepository fieldworkRepository) {
+        this.fieldworkRepository = fieldworkRepository;
+    }
+
+    public List<Fieldwork> getFieldworks() {
+        LocalDate today = LocalDate.now();
+        LocalDate sixMonthsFromNow = today.plusMonths(6);
+        return fieldworkRepository.findAllByEndPlannedDateBetween(today, sixMonthsFromNow);
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/views/MainLayout.java
+++ b/src/main/java/uy/com/bay/utiles/views/MainLayout.java
@@ -95,6 +95,9 @@ public class MainLayout extends AppLayout {
 		SideNavItem listarSolicitudesItem = new SideNavItem("Solicitudes de campo", "fieldworks");
 		listarSolicitudesItem.setPrefixComponent(new Icon("vaadin", "list"));
 		proyectosItem.addItem(listarSolicitudesItem);
+		SideNavItem ganttItem = new SideNavItem("Gantt", "gantt");
+		ganttItem.setPrefixComponent(new Icon("vaadin", "chart-timeline"));
+		proyectosItem.addItem(ganttItem);
 		nav.addItem(proyectosItem);
 
 		List<MenuEntry> menuEntries = MenuConfiguration.getMenuEntries();

--- a/src/main/java/uy/com/bay/utiles/views/gantt/GanttView.java
+++ b/src/main/java/uy/com/bay/utiles/views/gantt/GanttView.java
@@ -1,0 +1,69 @@
+package uy.com.bay.utiles.views.gantt;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.progressbar.ProgressBar;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.PageTitle;
+import jakarta.annotation.security.PermitAll;
+import org.vaadin.tltv.gantt.Gantt;
+import org.vaadin.tltv.gantt.model.Step;
+import org.vaadin.tltv.gantt.model.SubStep;
+import uy.com.bay.utiles.data.Fieldwork;
+import uy.com.bay.utiles.data.Study;
+import uy.com.bay.utiles.services.GanttService;
+import uy.com.bay.utiles.views.MainLayout;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Route(value = "gantt", layout = MainLayout.class)
+@PageTitle("Gantt")
+@PermitAll
+public class GanttView extends Div {
+
+    private final GanttService ganttService;
+
+    public GanttView(GanttService ganttService) {
+        this.ganttService = ganttService;
+        addClassName("gantt-view");
+        setSizeFull();
+        Gantt gantt = createGantt();
+        add(gantt);
+    }
+
+    private Gantt createGantt() {
+        Gantt gantt = new Gantt();
+        gantt.setHeightFull();
+
+        List<Fieldwork> fieldworks = ganttService.getFieldworks();
+        Map<Study, List<Fieldwork>> fieldworksByStudy = fieldworks.stream()
+                .collect(Collectors.groupingBy(Fieldwork::getStudy));
+
+        fieldworksByStudy.forEach((study, fieldworkList) -> {
+            Step studyStep = new Step();
+            studyStep.setCaption(study.getName());
+            gantt.addStep(studyStep);
+
+            fieldworkList.forEach(fieldwork -> {
+                SubStep subStep = new SubStep();
+                subStep.setCaption(fieldwork.getType().toString());
+                subStep.setStartDate(fieldwork.getInitPlannedDate().atStartOfDay());
+                subStep.setEndDate(fieldwork.getEndPlannedDate().atStartOfDay());
+
+                if (fieldwork.getGoalQuantity() != null && fieldwork.getGoalQuantity() > 0 && fieldwork.getCompleted() != null) {
+                    ProgressBar progressBar = new ProgressBar();
+                    double progress = (double) fieldwork.getCompleted() / fieldwork.getGoalQuantity();
+                    progressBar.setValue(progress);
+                    subStep.add(progressBar);
+                }
+
+                studyStep.addSubStep(subStep);
+            });
+        });
+
+        return gantt;
+    }
+}


### PR DESCRIPTION
This commit introduces a new GanttView that displays Fieldwork entities in a Gantt chart.

The view fetches all Fieldwork entities with an endPlannedDate within the next 6 months and groups them by Study. Each Study is represented as a step in the Gantt chart, and each Fieldwork as a sub-step.

A progress bar is included in each sub-step to show the completion percentage of the Fieldwork.