### PR TITLE
Refactor: Apply system-wide number formatting and update JournalEntry…

### DIFF
--- a/src/main/java/uy/com/bay/utiles/utils/FormattingUtils.java
+++ b/src/main/java/uy/com/bay/utiles/utils/FormattingUtils.java
@@ -1,0 +1,21 @@
+package uy.com.bay.utiles.utils;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
+public class FormattingUtils {
+
+    private static final DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.getDefault());
+    private static final DecimalFormat formatter;
+
+    static {
+        symbols.setDecimalSeparator(',');
+        symbols.setGroupingSeparator('.');
+        formatter = new DecimalFormat("#,##0.00", symbols);
+    }
+
+    public static String formatAmount(double amount) {
+        return formatter.format(amount);
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportApprovalView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportApprovalView.java
@@ -23,6 +23,7 @@ import jakarta.annotation.security.RolesAllowed;
 import uy.com.bay.utiles.data.ExpenseReport;
 import uy.com.bay.utiles.data.ExpenseReportStatus;
 import uy.com.bay.utiles.services.ExpenseReportService;
+import uy.com.bay.utiles.utils.FormattingUtils;
 import uy.com.bay.utiles.views.MainLayout;
 
 @PageTitle("Aprobar Rendiciones")
@@ -68,7 +69,8 @@ public class ExpenseReportApprovalView extends Div {
 		}).setHeader("Surveyor").setSortable(true);
 		Grid.Column<ExpenseReport> studyColumn = grid.addColumn(report -> report.getStudy().getName())
 				.setHeader("Study").setSortable(true);
-		Grid.Column<ExpenseReport> amountColumn = grid.addColumn(ExpenseReport::getAmount).setHeader("Amount")
+		Grid.Column<ExpenseReport> amountColumn = grid
+				.addColumn(report -> FormattingUtils.formatAmount(report.getAmount())).setHeader("Amount")
 				.setSortable(true);
 		Grid.Column<ExpenseReport> conceptColumn = grid
 				.addColumn(report -> report.getConcept() != null ? report.getConcept().getName() : "")

--- a/src/main/java/uy/com/bay/utiles/views/proyectos/JournalEntryDialog.java
+++ b/src/main/java/uy/com/bay/utiles/views/proyectos/JournalEntryDialog.java
@@ -13,6 +13,7 @@ import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.services.ExpenseReportFileService;
 import uy.com.bay.utiles.services.ExpenseTransferFileService;
 import uy.com.bay.utiles.services.JournalEntryService;
+import uy.com.bay.utiles.utils.FormattingUtils;
 import uy.com.bay.utiles.views.expenses.ExpenseReportViewDialog;
 import uy.com.bay.utiles.views.expensetransfer.ExpenseTransferViewDialog;
 
@@ -77,7 +78,13 @@ public class JournalEntryDialog extends Dialog {
 			col.setAutoWidth(true); // Ajusta según contenido
 			col.setFlexGrow(0); // No se expande más allá de lo necesario
 		});
-		grid.addColumn(JournalEntry::getAmount).setHeader("Monto");
+		grid.addColumn(entry -> {
+			double amount = entry.getAmount();
+			if (entry.getOperation() == Operation.CREDITO) {
+				amount *= -1;
+			}
+			return FormattingUtils.formatAmount(amount);
+		}).setHeader("Monto");
 		grid.addColumn(entry -> entry.getSurveyor() != null ? entry.getSurveyor().getName() : "")
 				.setHeader("Encuestador");
 		grid.addColumn(JournalEntry::getOperation).setHeader("Operación");
@@ -101,8 +108,7 @@ public class JournalEntryDialog extends Dialog {
 			saldoMap.put(entry, runningSaldo.get());
 		}
 
-		grid.getColumnByKey("saldoColumn").setRenderer(new com.vaadin.flow.data.renderer.TextRenderer<>(entry -> {
-			return String.format("%.2f", saldoMap.get(entry));
-		}));
+		grid.getColumnByKey("saldoColumn").setRenderer(new com.vaadin.flow.data.renderer.TextRenderer<>(
+				entry -> FormattingUtils.formatAmount(saldoMap.get(entry))));
 	}
 }

--- a/src/main/java/uy/com/bay/utiles/views/proyectos/ProyectosView.java
+++ b/src/main/java/uy/com/bay/utiles/views/proyectos/ProyectosView.java
@@ -41,6 +41,7 @@ import uy.com.bay.utiles.data.service.FieldworkService;
 import uy.com.bay.utiles.services.ExpenseTransferFileService;
 import uy.com.bay.utiles.services.JournalEntryService;
 import uy.com.bay.utiles.services.StudyService;
+import uy.com.bay.utiles.utils.FormattingUtils;
 
 @PageTitle("Proyectos")
 @Route("/:proyectoID?/:action?(edit)")
@@ -356,8 +357,8 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 		this.proyecto = value;
 		binder.readBean(this.proyecto);
 		if (value != null) {
-			totalTransfered.setValue(String.valueOf(value.getTotalTransfered()));
-			totalReportedCost.setValue(String.valueOf(value.getTotalReportedCost()));
+			totalTransfered.setValue(FormattingUtils.formatAmount(value.getTotalTransfered()));
+			totalReportedCost.setValue(FormattingUtils.formatAmount(value.getTotalReportedCost()));
 		} else {
 			totalTransfered.setValue("");
 			totalReportedCost.setValue("");

--- a/src/main/java/uy/com/bay/utiles/views/surveyors/JournalEntryGrid.java
+++ b/src/main/java/uy/com/bay/utiles/views/surveyors/JournalEntryGrid.java
@@ -16,6 +16,7 @@ import uy.com.bay.utiles.data.Operation;
 import uy.com.bay.utiles.data.Source;
 import uy.com.bay.utiles.services.ExpenseReportFileService;
 import uy.com.bay.utiles.services.ExpenseTransferFileService;
+import uy.com.bay.utiles.utils.FormattingUtils;
 import uy.com.bay.utiles.views.expenses.ExpenseReportViewDialog;
 import uy.com.bay.utiles.views.expensetransfer.ExpenseTransferViewDialog;
 
@@ -40,7 +41,13 @@ public class JournalEntryGrid extends Grid<JournalEntry> {
 		SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
 		addColumn(entry -> sdf.format(entry.getDate())).setHeader("Fecha");
 		addComponentColumn(this::createDetailLink).setHeader("Detalle");
-		addColumn(JournalEntry::getAmount).setHeader("Monto");
+		addColumn(entry -> {
+			double amount = entry.getAmount();
+			if (entry.getOperation() == Operation.CREDITO) {
+				amount *= -1;
+			}
+			return FormattingUtils.formatAmount(amount);
+		}).setHeader("Monto");
 		addColumn(entry -> entry.getStudy() != null ? entry.getStudy().getName() : "").setHeader("Estudio");
 		addColumn(JournalEntry::getOperation).setHeader("Movimiento");
 		addColumn(entry -> "").setHeader("Saldo").setKey("saldoColumn");
@@ -85,8 +92,7 @@ public class JournalEntryGrid extends Grid<JournalEntry> {
 			saldoMap.put(entry, runningSaldo.get());
 		}
 
-		getColumnByKey("saldoColumn").setRenderer(new com.vaadin.flow.data.renderer.TextRenderer<>(entry -> {
-			return String.format("%.2f", saldoMap.get(entry));
-		}));
+		getColumnByKey("saldoColumn").setRenderer(new com.vaadin.flow.data.renderer.TextRenderer<>(
+				entry -> FormattingUtils.formatAmount(saldoMap.get(entry))));
 	}
 }


### PR DESCRIPTION
…Grid

This commit introduces two main changes:

1.  A new `FormattingUtils` class has been created to standardize number formatting across the application. This utility formats numbers to use a dot (.) as the thousands separator and a comma (,) as the decimal separator, as per the user's request.

2.  The `JournalEntryGrid` and `JournalEntryDialog` have been refactored to:
    - Display the 'Monto' (amount) with a negative sign for 'CREDITO' operations.
    - Use the new `FormattingUtils` to format the 'Monto' and 'Saldo' (balance) columns.

Additionally, other views (`ExpenseReportApprovalView` and `ProyectosView`) have been updated to use the new `FormattingUtils` for consistent number formatting throughout the system.