### PR TITLE
feat: Add footer with total amount to ExpensesView grid

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/ExpenseRequestRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/ExpenseRequestRepository.java
@@ -12,7 +12,7 @@ import uy.com.bay.utiles.data.ExpenseStatus;
 import java.util.Date;
 import java.util.List;
 
-public interface ExpenseRequestRepository extends JpaRepository<ExpenseRequest, Long>, JpaSpecificationExecutor<ExpenseRequest> {
+public interface ExpenseRequestRepository extends JpaRepository<ExpenseRequest, Long>, JpaSpecificationExecutor<ExpenseRequest>, ExpenseRequestRepositoryCustom {
 
     List<ExpenseRequest> findAllByExpenseStatus(ExpenseStatus expenseStatus, Pageable pageable);
 

--- a/src/main/java/uy/com/bay/utiles/data/repository/ExpenseRequestRepositoryCustom.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/ExpenseRequestRepositoryCustom.java
@@ -1,0 +1,8 @@
+package uy.com.bay.utiles.data.repository;
+
+import org.springframework.data.jpa.domain.Specification;
+import uy.com.bay.utiles.data.ExpenseRequest;
+
+public interface ExpenseRequestRepositoryCustom {
+    Double sumAmount(Specification<ExpenseRequest> spec);
+}

--- a/src/main/java/uy/com/bay/utiles/data/repository/ExpenseRequestRepositoryImpl.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/ExpenseRequestRepositoryImpl.java
@@ -1,0 +1,34 @@
+package uy.com.bay.utiles.data.repository;
+
+import org.springframework.data.jpa.domain.Specification;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import uy.com.bay.utiles.data.ExpenseRequest;
+
+public class ExpenseRequestRepositoryImpl implements ExpenseRequestRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public Double sumAmount(Specification<ExpenseRequest> spec) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Double> query = cb.createQuery(Double.class);
+        Root<ExpenseRequest> root = query.from(ExpenseRequest.class);
+
+        query.select(cb.coalesce(cb.sum(root.get("amount")), 0.0));
+
+        if (spec != null) {
+            Predicate predicate = spec.toPredicate(root, query, cb);
+            if (predicate != null) {
+                query.where(predicate);
+            }
+        }
+
+        return entityManager.createQuery(query).getSingleResult();
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/services/ExpenseRequestService.java
+++ b/src/main/java/uy/com/bay/utiles/services/ExpenseRequestService.java
@@ -64,4 +64,8 @@ public class ExpenseRequestService {
 	public void revokeRequests(List<Long> ids) {
 		repository.revokeRequests(ids, ExpenseStatus.RECHAZADO, new Date());
 	}
+
+	public Double sumAmount(Specification<ExpenseRequest> spec) {
+		return repository.sumAmount(spec);
+	}
 }

--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpensesView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpensesView.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.GridSortOrder;
 import com.vaadin.flow.component.grid.GridVariant;
 import com.vaadin.flow.component.grid.HeaderRow;
+import com.vaadin.flow.component.grid.FooterRow;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.notification.NotificationVariant;
@@ -147,6 +148,7 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 				.setAutoWidth(true).setSortable(true).setSortProperty("concept.name");
 		Grid.Column<ExpenseRequest> statusColumn = grid.addColumn(ExpenseRequest::getExpenseStatus).setHeader("Estado")
 				.setAutoWidth(true).setSortable(true).setSortProperty("expenseStatus");
+		FooterRow footerRow = grid.appendFooterRow();
 
 		grid.sort(List.of(new GridSortOrder<>(requestDateColumn, SortDirection.DESCENDING)));
 
@@ -159,6 +161,7 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 			Specification<ExpenseRequest> spec = createSpecification(filters);
 			return expenseRequestService.count(spec);
 		}));
+		updateFooter(footerRow, studyColumn, amountColumn);
 
 		HeaderRow headerRow = grid.appendHeaderRow();
 
@@ -169,6 +172,7 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 		studyFilter.addValueChangeListener(e -> {
 			filters.setStudyName(e.getValue());
 			grid.getDataProvider().refreshAll();
+			updateFooter(footerRow, studyColumn, amountColumn);
 		});
 		headerRow.getCell(studyColumn).setComponent(studyFilter);
 
@@ -179,6 +183,7 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 		surveyorFilter.addValueChangeListener(e -> {
 			filters.setSurveyorName(e.getValue());
 			grid.getDataProvider().refreshAll();
+			updateFooter(footerRow, studyColumn, amountColumn);
 		});
 		headerRow.getCell(surveyorColumn).setComponent(surveyorFilter);
 
@@ -187,6 +192,7 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 		requestDateFilter.addValueChangeListener(e -> {
 			filters.setRequestDate(e.getValue());
 			grid.getDataProvider().refreshAll();
+			updateFooter(footerRow, studyColumn, amountColumn);
 		});
 		headerRow.getCell(requestDateColumn).setComponent(requestDateFilter);
 
@@ -196,6 +202,7 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 		aprovalDateFilter.addValueChangeListener(e -> {
 			filters.setAprovalDate(e.getValue());
 			grid.getDataProvider().refreshAll();
+			updateFooter(footerRow, studyColumn, amountColumn);
 		});
 		headerRow.getCell(aprovalDateColumn).setComponent(aprovalDateFilter);
 
@@ -205,6 +212,7 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 		transferDateFilter.addValueChangeListener(e -> {
 			filters.setTransferDate(e.getValue());
 			grid.getDataProvider().refreshAll();
+			updateFooter(footerRow, studyColumn, amountColumn);
 		});
 		headerRow.getCell(transferDateColumn).setComponent(transferDateFilter);
 
@@ -215,6 +223,7 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 		amountFilter.addValueChangeListener(e -> {
 			filters.setAmount(e.getValue());
 			grid.getDataProvider().refreshAll();
+			updateFooter(footerRow, studyColumn, amountColumn);
 		});
 		headerRow.getCell(amountColumn).setComponent(amountFilter);
 
@@ -226,6 +235,7 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 		conceptFilter.addValueChangeListener(e -> {
 			filters.setConcept(e.getValue());
 			grid.getDataProvider().refreshAll();
+			updateFooter(footerRow, studyColumn, amountColumn);
 		});
 		headerRow.getCell(conceptColumn).setComponent(conceptFilter);
 
@@ -236,6 +246,7 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 		statusFilter.addValueChangeListener(e -> {
 			filters.setExpenseStatus(e.getValue());
 			grid.getDataProvider().refreshAll();
+			updateFooter(footerRow, studyColumn, amountColumn);
 		});
 		headerRow.getCell(statusColumn).setComponent(statusFilter);
 
@@ -628,5 +639,13 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 		public void setExpenseStatus(ExpenseStatus expenseStatus) {
 			this.expenseStatus = expenseStatus;
 		}
+	}
+
+	private void updateFooter(FooterRow footerRow, Grid.Column<ExpenseRequest> studyColumn,
+			Grid.Column<ExpenseRequest> amountColumn) {
+		Specification<ExpenseRequest> spec = createSpecification(filters);
+		Double total = expenseRequestService.sumAmount(spec);
+		footerRow.getCell(studyColumn).setText("TOTAL");
+		footerRow.getCell(amountColumn).setText(String.format("$%.2f", total));
 	}
 }


### PR DESCRIPTION
This commit refactors the ExpensesView grid to include a footer row.

The footer displays the text "TOTAL" in the "Estudio" column and the sum of all values in the "Monto" column.

The implementation includes:
- A custom Spring Data JPA repository method to calculate the sum of the amount with the current filters.
- A new method in the service layer to expose the sum calculation.
- An update to the ExpensesView to add the footer and keep it updated when filters change.