### PR TITLE
feat: Add footer with total amount to ExpenseReportsView grid

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/ExpenseReportRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/ExpenseReportRepository.java
@@ -7,7 +7,7 @@ import uy.com.bay.utiles.data.ExpenseReportStatus;
 
 import java.util.List;
 
-public interface ExpenseReportRepository extends JpaRepository<ExpenseReport, Long>, JpaSpecificationExecutor<ExpenseReport> {
+public interface ExpenseReportRepository extends JpaRepository<ExpenseReport, Long>, JpaSpecificationExecutor<ExpenseReport>, ExpenseReportRepositoryCustom {
 
     List<ExpenseReport> findAllByExpenseStatus(ExpenseReportStatus status);
 }

--- a/src/main/java/uy/com/bay/utiles/data/repository/ExpenseReportRepositoryCustom.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/ExpenseReportRepositoryCustom.java
@@ -1,0 +1,8 @@
+package uy.com.bay.utiles.data.repository;
+
+import org.springframework.data.jpa.domain.Specification;
+import uy.com.bay.utiles.data.ExpenseReport;
+
+public interface ExpenseReportRepositoryCustom {
+    Double sumAmount(Specification<ExpenseReport> spec);
+}

--- a/src/main/java/uy/com/bay/utiles/data/repository/ExpenseReportRepositoryImpl.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/ExpenseReportRepositoryImpl.java
@@ -1,0 +1,34 @@
+package uy.com.bay.utiles.data.repository;
+
+import org.springframework.data.jpa.domain.Specification;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import uy.com.bay.utiles.data.ExpenseReport;
+
+public class ExpenseReportRepositoryImpl implements ExpenseReportRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public Double sumAmount(Specification<ExpenseReport> spec) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Double> query = cb.createQuery(Double.class);
+        Root<ExpenseReport> root = query.from(ExpenseReport.class);
+
+        query.select(cb.coalesce(cb.sum(root.get("amount")), 0.0));
+
+        if (spec != null) {
+            Predicate predicate = spec.toPredicate(root, query, cb);
+            if (predicate != null) {
+                query.where(predicate);
+            }
+        }
+
+        return entityManager.createQuery(query).getSingleResult();
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/services/ExpenseReportService.java
+++ b/src/main/java/uy/com/bay/utiles/services/ExpenseReportService.java
@@ -110,4 +110,8 @@ public class ExpenseReportService {
 	public int count() {
 		return (int) repository.count();
 	}
+
+	public Double sumAmount(Specification<ExpenseReport> spec) {
+		return repository.sumAmount(spec);
+	}
 }

--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportsView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportsView.java
@@ -20,6 +20,7 @@ import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.FooterRow;
 import com.vaadin.flow.component.grid.GridVariant;
 import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.Div;
@@ -139,6 +140,9 @@ public class ExpenseReportsView extends Div implements BeforeEnterObserver {
 				query -> expenseReportService
 						.list(VaadinSpringDataHelpers.toSpringPageRequest(query), createFilterSpecification()).stream(),
 				query -> (int) expenseReportService.count(createFilterSpecification())));
+
+		FooterRow footerRow = grid.appendFooterRow();
+		updateFooter(footerRow, grid.getColumnByKey("study"), grid.getColumnByKey("amount"));
 
 		grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
 
@@ -398,6 +402,16 @@ public class ExpenseReportsView extends Div implements BeforeEnterObserver {
 	private void refreshGrid() {
 		grid.select(null);
 		grid.getDataProvider().refreshAll();
+		FooterRow footerRow = grid.getFooterRows().get(0);
+		updateFooter(footerRow, grid.getColumnByKey("study"), grid.getColumnByKey("amount"));
+	}
+
+	private void updateFooter(FooterRow footerRow, Grid.Column<ExpenseReport> studyColumn,
+			Grid.Column<ExpenseReport> amountColumn) {
+		Specification<ExpenseReport> spec = createFilterSpecification();
+		Double total = expenseReportService.sumAmount(spec);
+		footerRow.getCell(studyColumn).setText("TOTAL");
+		footerRow.getCell(amountColumn).setText(String.format("$%.2f", total));
 	}
 
 	private void clearForm() {


### PR DESCRIPTION
This commit refactors the ExpenseReportsView grid to include a footer row, consistent with the functionality added to other expense-related views.

The footer displays the text "TOTAL" in the "Estudio" column and the sum of all values in the "Monto" column for the currently displayed and filtered rows.

The implementation includes:
- A new custom repository and service method to calculate the sum of the amount for ExpenseReport entities.
- An update to the ExpenseReportsView to display and dynamically update the footer total when filters are changed.