### PR TITLE
feat: Add inline editor to ExpensesAprovalView

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpensesAprovalView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpensesAprovalView.java
@@ -1,84 +1,227 @@
 package uy.com.bay.utiles.views.expenses;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import org.springframework.data.jpa.domain.Specification;
-
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.confirmdialog.ConfirmDialog;
 import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.grid.Grid;
-import com.vaadin.flow.component.grid.GridMultiSelectionModel;
-import com.vaadin.flow.component.grid.GridMultiSelectionModel.SelectAllCheckboxVisibility;
-import com.vaadin.flow.component.grid.FooterRow;
 import com.vaadin.flow.component.grid.GridVariant;
 import com.vaadin.flow.component.grid.HeaderRow;
+import com.vaadin.flow.component.grid.FooterRow;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.notification.Notification;
-import com.vaadin.flow.component.orderedlayout.FlexComponent;
+import com.vaadin.flow.component.notification.NotificationVariant;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.splitlayout.SplitLayout;
 import com.vaadin.flow.component.textfield.NumberField;
 import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.binder.BeanValidationBinder;
+import com.vaadin.flow.data.binder.ValidationException;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.value.ValueChangeMode;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
-
-import jakarta.annotation.security.PermitAll;
-import jakarta.annotation.security.RolesAllowed;
 import jakarta.persistence.criteria.Predicate;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import jakarta.annotation.security.RolesAllowed;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import uy.com.bay.utiles.data.ExpenseRequest;
 import uy.com.bay.utiles.data.ExpenseRequestType;
 import uy.com.bay.utiles.data.ExpenseStatus;
+import uy.com.bay.utiles.data.Study;
+import uy.com.bay.utiles.data.Surveyor;
 import uy.com.bay.utiles.services.ExpenseRequestService;
 import uy.com.bay.utiles.services.ExpenseRequestTypeService;
+import uy.com.bay.utiles.services.StudyService;
+import uy.com.bay.utiles.services.SurveyorService;
 
-@Route(value = "expenses-approval")
+@Route("expenses-approval/:expenseID?/:action?(edit)")
 @PageTitle("Aprobar Solicitudes de Gasto")
 @RolesAllowed("GASTOS")
-public class ExpensesAprovalView extends Div {
+public class ExpensesAprovalView extends Div implements BeforeEnterObserver {
 
-	private final ExpenseRequestService expenseRequestService;
-	private final ExpenseRequestTypeService expenseRequestTypeService;
+	private final String EXPENSE_ID = "expenseID";
+	private final String EXPENSE_EDIT_ROUTE_TEMPLATE = "expenses-approval/%s/edit";
 
 	private final Grid<ExpenseRequest> grid = new Grid<>(ExpenseRequest.class, false);
-	private final Set<ExpenseRequest> selectedRequests = new HashSet<>();
+
+	private ComboBox<Study> study;
+	private ComboBox<Surveyor> surveyor;
+	private DatePicker requestDate;
+	private DatePicker aprovalDate;
+	private NumberField amount;
+	private ComboBox<ExpenseRequestType> concept;
+	private com.vaadin.flow.component.textfield.TextArea obs;
+
+	private final Button cancel = new Button("Cancelar");
+	private final Button save = new Button("Guardar");
+	private final Button approve = new Button("Aprobar");
+	private final Button reject = new Button("Rechazar");
+	private final Button delete = new Button("Borrar");
+
+	private final BeanValidationBinder<ExpenseRequest> binder;
+	private ExpenseRequest expenseRequest;
+	private final ExpenseRequestService expenseRequestService;
+	private final ExpenseRequestTypeService expenseRequestTypeService;
+	private final StudyService studyService;
+	private final SurveyorService surveyorService;
+	private Div editorLayoutDiv;
+
 	private final Filters filters;
 
 	public ExpensesAprovalView(ExpenseRequestService expenseRequestService,
-			ExpenseRequestTypeService expenseRequestTypeService) {
+			ExpenseRequestTypeService expenseRequestTypeService, StudyService studyService,
+			SurveyorService surveyorService) {
 		this.expenseRequestService = expenseRequestService;
 		this.expenseRequestTypeService = expenseRequestTypeService;
+		this.studyService = studyService;
+		this.surveyorService = surveyorService;
 		this.filters = new Filters();
 
 		addClassName("expenses-aproval-view");
 		setHeight("100%");
 
-		Button approveButton = new Button("Aprobar solicitudes", event -> approveSelected());
-		Button revokeButton = new Button("Rechazar solicitudes", event -> revokeSelected());
-		approveButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
-		revokeButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+		SplitLayout splitLayout = new SplitLayout();
+		splitLayout.setSizeFull();
+		splitLayout.setSplitterPosition(80);
 
-		HorizontalLayout toolbar = new HorizontalLayout(approveButton, revokeButton);
-		toolbar.setWidthFull();
-		toolbar.setAlignItems(FlexComponent.Alignment.BASELINE);
+		createEditorLayout(splitLayout);
+		createGridLayout(splitLayout);
 
-		add(toolbar);
-		setupGrid();
-		add(grid);
+		add(splitLayout);
 
+		grid.setDataProvider(DataProvider.fromFilteringCallbacks(query -> {
+			Specification<ExpenseRequest> spec = createSpecification(filters);
+			return expenseRequestService
+					.list(com.vaadin.flow.spring.data.VaadinSpringDataHelpers.toSpringPageRequest(query), spec)
+					.stream();
+		}, query -> {
+			Specification<ExpenseRequest> spec = createSpecification(filters);
+			return expenseRequestService.count(spec);
+		}));
+
+		grid.asSingleSelect().addValueChangeListener(event -> {
+			if (event.getValue() != null) {
+				editorLayoutDiv.setVisible(true);
+				UI.getCurrent().navigate(String.format(EXPENSE_EDIT_ROUTE_TEMPLATE, event.getValue().getId()));
+			} else {
+				editorLayoutDiv.setVisible(false);
+				clearForm();
+				UI.getCurrent().navigate(ExpensesAprovalView.class);
+			}
+		});
+
+		binder = new BeanValidationBinder<>(ExpenseRequest.class);
+		binder.bindInstanceFields(this);
+
+		cancel.addClickListener(e -> {
+			clearForm();
+			refreshGrid();
+			editorLayoutDiv.setVisible(false);
+		});
+
+		save.addClickListener(e -> {
+			try {
+				if (this.expenseRequest == null) {
+					this.expenseRequest = new ExpenseRequest();
+				}
+				binder.writeBean(this.expenseRequest);
+				expenseRequestService.update(this.expenseRequest);
+				clearForm();
+				refreshGrid();
+				Notification.show("Detalles de la solicitud guardados.");
+				UI.getCurrent().navigate(ExpensesAprovalView.class);
+			} catch (ObjectOptimisticLockingFailureException exception) {
+				Notification n = Notification.show(
+						"Error updating the data. Somebody else has updated the record while you were making changes.");
+				n.setPosition(Notification.Position.MIDDLE);
+				n.addThemeVariants(NotificationVariant.LUMO_ERROR);
+			} catch (ValidationException validationException) {
+				Notification.show("Failed to update the data. Check again that all values are valid");
+			}
+		});
+
+		reject.addClickListener(e -> {
+			try {
+				if (this.expenseRequest == null) {
+					Notification.show("No expense request selected.");
+					return;
+				}
+				binder.writeBean(this.expenseRequest);
+				this.expenseRequest.setExpenseStatus(ExpenseStatus.RECHAZADO);
+				expenseRequestService.update(this.expenseRequest);
+				clearForm();
+				refreshGrid();
+				Notification.show("Solicitud de gasto rechazada.");
+				UI.getCurrent().navigate(ExpensesAprovalView.class);
+			} catch (ObjectOptimisticLockingFailureException | ValidationException exception) {
+				Notification.show("Error al rechazar la solicitud.").addThemeVariants(NotificationVariant.LUMO_ERROR);
+			}
+		});
+
+		approve.addClickListener(e -> {
+			try {
+				if (this.expenseRequest == null) {
+					Notification.show("No expense request selected.");
+					return;
+				}
+				binder.writeBean(this.expenseRequest);
+				this.expenseRequest.setExpenseStatus(ExpenseStatus.APROBADO);
+				this.expenseRequest.setAprovalDate(new Date());
+				expenseRequestService.update(this.expenseRequest);
+				clearForm();
+				refreshGrid();
+				Notification.show("Solicitud de gasto aprobada.");
+				UI.getCurrent().navigate(ExpensesAprovalView.class);
+			} catch (ObjectOptimisticLockingFailureException | ValidationException exception) {
+				Notification.show("Error al aprobar la solicitud.").addThemeVariants(NotificationVariant.LUMO_ERROR);
+			}
+		});
+
+		delete.addClickListener(e -> {
+			if (this.expenseRequest != null && this.expenseRequest.getId() != null) {
+				ConfirmDialog dialog = new ConfirmDialog();
+				dialog.setHeader("Confirmar borrado");
+				dialog.setText("¿Está seguro de que desea borrar esta solicitud? Esta acción no se puede deshacer.");
+				dialog.setCancelable(true);
+				dialog.setConfirmText("Borrar");
+				dialog.setConfirmButtonTheme("error primary");
+				dialog.addConfirmListener(event -> {
+					try {
+						expenseRequestService.delete(this.expenseRequest.getId());
+						clearForm();
+						refreshGrid();
+						Notification.show("Solicitud de gasto borrada exitosamente.", 3000,
+								Notification.Position.BOTTOM_START);
+						UI.getCurrent().navigate(ExpensesAprovalView.class);
+					} catch (Exception ex) {
+						Notification.show("Error al borrar el concepto: " + ex.getMessage(), 5000,
+								Notification.Position.MIDDLE).addThemeVariants(NotificationVariant.LUMO_ERROR);
+					}
+				});
+				dialog.open();
+			}
+		});
 	}
 
-	private void setupGrid() {
+	private void createGridLayout(SplitLayout splitLayout) {
+		Div wrapper = new Div();
+		wrapper.setClassName("grid-wrapper");
+		wrapper.setWidthFull();
+		splitLayout.addToPrimary(wrapper);
+		wrapper.add(grid);
+
 		grid.addThemeVariants(GridVariant.LUMO_NO_BORDER, GridVariant.LUMO_ROW_STRIPES);
-		grid.setSelectionMode(Grid.SelectionMode.MULTI);
-		((GridMultiSelectionModel<ExpenseRequest>) grid.getSelectionModel())
-				.setSelectAllCheckboxVisibility(SelectAllCheckboxVisibility.VISIBLE);
+		grid.setSelectionMode(Grid.SelectionMode.SINGLE);
 
 		Grid.Column<ExpenseRequest> studyColumn = grid
 				.addColumn(er -> er.getStudy() != null ? er.getStudy().getName() : "").setHeader("Estudio")
@@ -98,21 +241,6 @@ public class ExpensesAprovalView extends Div {
 		Grid.Column<ExpenseRequest> conceptColumn = grid
 				.addColumn(er -> er.getConcept() != null ? er.getConcept().getName() : "").setHeader("Concepto")
 				.setAutoWidth(true).setSortable(true).setSortProperty("concept.name");
-
-		grid.asMultiSelect().addValueChangeListener(event -> {
-			selectedRequests.clear();
-			selectedRequests.addAll(event.getValue());
-		});
-
-		grid.setDataProvider(DataProvider.fromFilteringCallbacks(query -> {
-			Specification<ExpenseRequest> spec = createSpecification(filters);
-			return expenseRequestService
-					.list(com.vaadin.flow.spring.data.VaadinSpringDataHelpers.toSpringPageRequest(query), spec)
-					.stream();
-		}, query -> {
-			Specification<ExpenseRequest> spec = createSpecification(filters);
-			return expenseRequestService.count(spec);
-		}));
 
 		FooterRow footerRow = grid.appendFooterRow();
 		updateFooter(footerRow, studyColumn, amountColumn);
@@ -149,7 +277,6 @@ public class ExpensesAprovalView extends Div {
 			grid.getDataProvider().refreshAll();
 			updateFooter(footerRow, studyColumn, amountColumn);
 		});
-
 		headerRow.getCell(requestDateColumn).setComponent(requestDateFilter);
 
 		NumberField amountFilter = new NumberField();
@@ -174,7 +301,90 @@ public class ExpensesAprovalView extends Div {
 			updateFooter(footerRow, studyColumn, amountColumn);
 		});
 		headerRow.getCell(conceptColumn).setComponent(conceptFilter);
+	}
 
+	@Override
+	public void beforeEnter(BeforeEnterEvent event) {
+		Optional<Long> expenseId = event.getRouteParameters().get(EXPENSE_ID).map(Long::parseLong);
+		if (expenseId.isPresent()) {
+			Optional<ExpenseRequest> expenseRequestFromBackend = expenseRequestService.get(expenseId.get());
+			if (expenseRequestFromBackend.isPresent()) {
+				populateForm(expenseRequestFromBackend.get());
+			} else {
+				Notification.show(
+						String.format("The requested expense request was not found, ID = %d", expenseId.get()), 3000,
+						Notification.Position.BOTTOM_START);
+				refreshGrid();
+				event.forwardTo(ExpensesAprovalView.class);
+			}
+		}
+	}
+
+	private void createEditorLayout(SplitLayout splitLayout) {
+		editorLayoutDiv = new Div();
+		editorLayoutDiv.setClassName("editor-layout");
+		Div editorDiv = new Div();
+		editorDiv.setClassName("editor");
+		editorLayoutDiv.add(editorDiv);
+		FormLayout formLayout = new FormLayout();
+		study = new ComboBox<>("Estudio");
+		study.setItems(studyService.listAll());
+		study.setItemLabelGenerator(s -> s == null ? "" : s.getName());
+		surveyor = new ComboBox<>("Encuestador");
+		surveyor.setItems(surveyorService.listAll());
+		surveyor.setItemLabelGenerator(s -> s == null ? "" : s.getName());
+		requestDate = new DatePicker("Fecha solicitud");
+		requestDate.setReadOnly(true);
+		aprovalDate = new DatePicker("Fecha aprobación");
+		aprovalDate.setReadOnly(true);
+		amount = new NumberField("Monto");
+		concept = new ComboBox<>("Concepto");
+		concept.setItems(expenseRequestTypeService.findAll());
+		concept.setItemLabelGenerator(ert -> ert == null ? "" : ert.getName());
+		obs = new com.vaadin.flow.component.textfield.TextArea("Observaciones");
+		formLayout.add(study, surveyor, requestDate, aprovalDate, amount, concept, obs);
+		editorDiv.add(formLayout);
+		createButtonLayout(editorLayoutDiv);
+		splitLayout.addToSecondary(editorLayoutDiv);
+		editorLayoutDiv.setVisible(false);
+	}
+
+	private void createButtonLayout(Div editorLayoutDiv) {
+		HorizontalLayout buttonLayout = new HorizontalLayout();
+		buttonLayout.setClassName("button-layout");
+		cancel.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+		save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+		delete.addThemeVariants(ButtonVariant.LUMO_ERROR);
+		approve.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+		reject.addThemeVariants(ButtonVariant.LUMO_ERROR);
+		buttonLayout.add(save, cancel, approve, reject, delete);
+		editorLayoutDiv.add(buttonLayout);
+	}
+
+	private void refreshGrid() {
+		grid.select(null);
+		grid.getDataProvider().refreshAll();
+	}
+
+	private void clearForm() {
+		populateForm(null);
+	}
+
+	private void populateForm(ExpenseRequest value) {
+		this.expenseRequest = value;
+		binder.readBean(this.expenseRequest);
+		if (value != null) {
+			boolean isIngresado = value.getId() != null && value.getExpenseStatus() == ExpenseStatus.INGRESADO;
+			approve.setEnabled(isIngresado);
+			reject.setEnabled(isIngresado);
+			save.setEnabled(true);
+			delete.setEnabled(true);
+		} else {
+			approve.setEnabled(false);
+			reject.setEnabled(false);
+			save.setEnabled(false);
+			delete.setEnabled(false);
+		}
 	}
 
 	private void updateFooter(FooterRow footerRow, Grid.Column<ExpenseRequest> studyColumn,
@@ -215,40 +425,6 @@ public class ExpensesAprovalView extends Div {
 
 			return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
 		};
-	}
-
-	private void approveSelected() {
-		if (selectedRequests.isEmpty()) {
-			Notification.show("No hay solicitudes seleccionadas.");
-			return;
-		}
-
-		List<Long> ids = new ArrayList<>();
-		for (ExpenseRequest request : selectedRequests) {
-			ids.add(request.getId());
-		}
-		expenseRequestService.approveRequests(ids);
-
-		Notification.show("Solicitudes aprobadas exitosamente.");
-		grid.getDataProvider().refreshAll();
-		grid.asMultiSelect().clear();
-	}
-
-	private void revokeSelected() {
-		if (selectedRequests.isEmpty()) {
-			Notification.show("No hay solicitudes seleccionadas.");
-			return;
-		}
-
-		List<Long> ids = new ArrayList<>();
-		for (ExpenseRequest request : selectedRequests) {
-			ids.add(request.getId());
-		}
-		expenseRequestService.revokeRequests(ids);
-
-		Notification.show("Solicitudes rechazads.");
-		grid.getDataProvider().refreshAll();
-		grid.asMultiSelect().clear();
 	}
 
 	private static class Filters {


### PR DESCRIPTION
Refactor ExpensesAprovalView to include an inline editor form.

This change refactors the ExpensesAprovalView to use a master-detail pattern, similar to the existing ExpensesView.

- Replaced the multi-select grid and bulk action buttons with a single-select grid and an inline editor form in a SplitLayout.
- Clicking a row in the grid now opens an editor form for that specific expense request.
- The editor form allows for editing, saving, approving, rejecting, and deleting the request.
- The view now supports URL routing to directly open an expense for editing.