### PR TITLE
Refactor the ExpenseReportApprovalView to display an editing form whe…

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportApprovalView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportApprovalView.java
@@ -4,8 +4,10 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
@@ -19,9 +21,16 @@ import com.vaadin.flow.component.grid.HeaderRow;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.splitlayout.SplitLayout;
 import com.vaadin.flow.component.textfield.NumberField;
+import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.binder.BeanValidationBinder;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 
@@ -29,43 +38,161 @@ import jakarta.annotation.security.RolesAllowed;
 import jakarta.persistence.criteria.Predicate;
 import uy.com.bay.utiles.data.ExpenseReport;
 import uy.com.bay.utiles.data.ExpenseReportStatus;
+import uy.com.bay.utiles.data.ExpenseRequestType;
+import uy.com.bay.utiles.data.Study;
+import uy.com.bay.utiles.data.Surveyor;
 import uy.com.bay.utiles.services.ExpenseReportService;
+import uy.com.bay.utiles.services.ExpenseRequestTypeService;
+import uy.com.bay.utiles.services.StudyService;
+import uy.com.bay.utiles.services.SurveyorService;
 import uy.com.bay.utiles.utils.FormattingUtils;
 import uy.com.bay.utiles.views.MainLayout;
 
 @PageTitle("Aprobar Rendiciones")
-@Route(value = "expense-reports-approval", layout = MainLayout.class)
+@Route(value = "expense-reports-approval/:expenseReportID?/:action?(edit)", layout = MainLayout.class)
 @RolesAllowed("GASTOS")
-public class ExpenseReportApprovalView extends Div {
+public class ExpenseReportApprovalView extends Div implements BeforeEnterObserver {
+
+	private final String EXPENSE_REPORT_ID = "expenseReportID";
+	private final String EXPENSE_REPORT_EDIT_ROUTE_TEMPLATE = "expense-reports-approval/%s/edit";
 
 	private final ExpenseReportService expenseReportService;
 	private final Grid<ExpenseReport> grid = new Grid<>(ExpenseReport.class, false);
 	private final Filters filters;
+	private Div editorLayoutDiv;
 
-	public ExpenseReportApprovalView(ExpenseReportService expenseReportService) {
+	private ComboBox<Study> study;
+	private ComboBox<Surveyor> surveyor;
+	private DatePicker date;
+	private NumberField amount;
+	private ComboBox<ExpenseRequestType> concept;
+	private TextArea obs;
+
+	private final Button cancel = new Button("Cancelar");
+	private final Button save = new Button("Guardar");
+	private final Button approve = new Button("Aprobar");
+	private final Button reject = new Button("Rechazar");
+
+	private final BeanValidationBinder<ExpenseReport> binder;
+	private ExpenseReport expenseReport;
+
+	public ExpenseReportApprovalView(ExpenseReportService expenseReportService, StudyService studyService,
+			SurveyorService surveyorService, ExpenseRequestTypeService expenseRequestTypeService) {
 		this.expenseReportService = expenseReportService;
 		this.filters = new Filters();
 		addClassName("expensereport-approval-view");
 		setSizeFull();
-		createGrid();
-		add(createToolbar(), grid);
+
+		SplitLayout splitLayout = new SplitLayout();
+		splitLayout.setSizeFull();
+		splitLayout.setSplitterPosition(80);
+
+		createEditorLayout(splitLayout, studyService, surveyorService, expenseRequestTypeService);
+		createGridLayout(splitLayout);
+		add(splitLayout);
+
+		binder = new BeanValidationBinder<>(ExpenseReport.class);
+		binder.bindInstanceFields(this);
+
+		cancel.addClickListener(e -> {
+			clearForm();
+			refreshGrid();
+			editorLayoutDiv.setVisible(false);
+		});
+
+		save.addClickListener(e -> {
+			try {
+				if (this.expenseReport == null) {
+					this.expenseReport = new ExpenseReport();
+				}
+				binder.writeBean(this.expenseReport);
+				expenseReportService.update(this.expenseReport);
+				clearForm();
+				refreshGrid();
+				Notification.show("ExpenseReport details stored.");
+				editorLayoutDiv.setVisible(false);
+				UI.getCurrent().navigate(ExpenseReportApprovalView.class);
+			} catch (ObjectOptimisticLockingFailureException exception) {
+				Notification n = Notification.show(
+						"Error updating the data. Somebody else has updated the record while you were making changes.");
+				n.setPosition(Notification.Position.MIDDLE);
+				n.addThemeVariants(NotificationVariant.LUMO_ERROR);
+			} catch (ValidationException validationException) {
+				Notification.show("Failed to update the data. Check again that all values are valid");
+			}
+		});
+
+		approve.addClickListener(e -> {
+			try {
+				if (this.expenseReport == null) {
+					Notification.show("No expense report selected.");
+					return;
+				}
+				binder.writeBean(this.expenseReport);
+				this.expenseReport.setExpenseStatus(ExpenseReportStatus.APROBADO);
+				this.expenseReport.setApprovalDate(new java.util.Date());
+				expenseReportService.update(this.expenseReport);
+				clearForm();
+				refreshGrid();
+				Notification.show("ExpenseReport approved.");
+				editorLayoutDiv.setVisible(false);
+				UI.getCurrent().navigate(ExpenseReportApprovalView.class);
+			} catch (ObjectOptimisticLockingFailureException exception) {
+				Notification n = Notification.show(
+						"Error updating the data. Somebody else has updated the record while you were making changes.");
+				n.setPosition(Notification.Position.MIDDLE);
+				n.addThemeVariants(NotificationVariant.LUMO_ERROR);
+			} catch (ValidationException validationException) {
+				Notification.show("Failed to update the data. Check again that all values are valid");
+			}
+		});
+
+		reject.addClickListener(e -> {
+			try {
+				if (this.expenseReport == null) {
+					Notification.show("No expense report selected.");
+					return;
+				}
+				binder.writeBean(this.expenseReport);
+				this.expenseReport.setExpenseStatus(ExpenseReportStatus.RECHAZADO);
+				expenseReportService.update(this.expenseReport);
+				clearForm();
+				refreshGrid();
+				Notification.show("ExpenseReport rejected.");
+				editorLayoutDiv.setVisible(false);
+				UI.getCurrent().navigate(ExpenseReportApprovalView.class);
+			} catch (ObjectOptimisticLockingFailureException exception) {
+				Notification n = Notification.show(
+						"Error updating the data. Somebody else has updated the record while you were making changes.");
+				n.setPosition(Notification.Position.MIDDLE);
+				n.addThemeVariants(NotificationVariant.LUMO_ERROR);
+			} catch (ValidationException validationException) {
+				Notification.show("Failed to update the data. Check again that all values are valid");
+			}
+		});
 	}
 
-	private HorizontalLayout createToolbar() {
-		Button approveButton = new Button("Aprobar rendiciones", event -> approveSelectedReports());
-		Button revokeButton = new Button("Rechazar rendiciones", event -> revokeSelectedReports());
-		approveButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
-		revokeButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+	private void createGridLayout(SplitLayout splitLayout) {
+		VerticalLayout wrapper = new VerticalLayout();
+		wrapper.setClassName("grid-wrapper");
+		wrapper.setSizeFull();
+		wrapper.setPadding(false);
+		wrapper.setSpacing(false);
 
-		HorizontalLayout toolbar = new HorizontalLayout(approveButton, revokeButton);
-		toolbar.setWidthFull();
-		toolbar.setAlignItems(FlexComponent.Alignment.BASELINE);
-		return toolbar;
-	}
-
-	private void createGrid() {
 		grid.addThemeVariants(GridVariant.LUMO_NO_BORDER, GridVariant.LUMO_ROW_STRIPES);
-		grid.setSelectionMode(Grid.SelectionMode.MULTI);
+		grid.setSelectionMode(Grid.SelectionMode.SINGLE);
+
+		grid.asSingleSelect().addValueChangeListener(event -> {
+			if (event.getValue() != null) {
+				editorLayoutDiv.setVisible(true);
+				populateForm(event.getValue());
+				UI.getCurrent().navigate(String.format(EXPENSE_REPORT_EDIT_ROUTE_TEMPLATE, event.getValue().getId()));
+			} else {
+				editorLayoutDiv.setVisible(false);
+				clearForm();
+				UI.getCurrent().navigate(ExpenseReportApprovalView.class);
+			}
+		});
 
 		Grid.Column<ExpenseReport> dateColumn = grid.addColumn(ExpenseReport::getDate).setHeader("Date")
 				.setSortable(true);
@@ -151,18 +278,91 @@ public class ExpenseReportApprovalView extends Div {
 
 		FooterRow footerRow = grid.appendFooterRow();
 		updateFooter(footerRow, studyColumn, amountColumn);
+
+		wrapper.add(grid);
+		wrapper.setFlexGrow(1, grid);
+		splitLayout.addToPrimary(wrapper);
 	}
 
-	private void approveSelectedReports() {
-		expenseReportService.approveReports(grid.getSelectedItems());
-		grid.getSelectionModel().deselectAll();
-		UI.getCurrent().getPage().reload();
+	private void createEditorLayout(SplitLayout splitLayout, StudyService studyService, SurveyorService surveyorService,
+			ExpenseRequestTypeService expenseRequestTypeService) {
+		editorLayoutDiv = new Div();
+		editorLayoutDiv.setClassName("editor-layout");
+		Div editorDiv = new Div();
+		editorDiv.setClassName("editor");
+		editorLayoutDiv.add(editorDiv);
+
+		com.vaadin.flow.component.formlayout.FormLayout formLayout = new com.vaadin.flow.component.formlayout.FormLayout();
+		study = new ComboBox<>("Estudio");
+		study.setItems(studyService.listAll());
+		study.setItemLabelGenerator(s -> s == null ? "" : s.getName());
+		surveyor = new ComboBox<>("Encuestador");
+		surveyor.setItems(surveyorService.listAll());
+		surveyor.setItemLabelGenerator(s -> s == null ? "" : s.getName());
+		date = new DatePicker("Fecha");
+		amount = new NumberField("Monto");
+		concept = new ComboBox<>("Concepto");
+		concept.setItems(expenseRequestTypeService.findAll());
+		concept.setItemLabelGenerator(ert -> ert == null ? "" : ert.getName());
+		obs = new TextArea("Observaciones");
+		formLayout.add(study, surveyor, date, amount, concept, obs);
+		editorDiv.add(formLayout);
+
+		createButtonLayout(editorDiv);
+		splitLayout.addToSecondary(editorLayoutDiv);
+		editorLayoutDiv.setVisible(false);
 	}
 
-	private void revokeSelectedReports() {
-		expenseReportService.revokeReports(grid.getSelectedItems());
-		grid.getSelectionModel().deselectAll();
-		UI.getCurrent().getPage().reload();
+	private void createButtonLayout(Div editorDiv) {
+		HorizontalLayout buttonLayout = new HorizontalLayout();
+		buttonLayout.setClassName("button-layout");
+		approve.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+		reject.addThemeVariants(ButtonVariant.LUMO_ERROR);
+		cancel.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+		save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+		buttonLayout.add(approve, reject, save, cancel);
+		editorDiv.add(buttonLayout);
+	}
+
+	@Override
+	public void beforeEnter(BeforeEnterEvent event) {
+		Optional<Long> expenseReportId = event.getRouteParameters().get(EXPENSE_REPORT_ID).map(Long::parseLong);
+		if (expenseReportId.isPresent()) {
+			Optional<ExpenseReport> expenseReportFromBackend = expenseReportService.get(expenseReportId.get());
+			if (expenseReportFromBackend.isPresent()) {
+				populateForm(expenseReportFromBackend.get());
+				editorLayoutDiv.setVisible(true);
+			} else {
+				Notification.show(
+						String.format("The requested expense report was not found, ID = %d", expenseReportId.get()),
+						3000, Notification.Position.BOTTOM_START);
+				refreshGrid();
+				event.forwardTo(ExpenseReportApprovalView.class);
+			}
+		}
+	}
+
+	private void refreshGrid() {
+		grid.select(null);
+		grid.getDataProvider().refreshAll();
+	}
+
+	private void clearForm() {
+		populateForm(null);
+	}
+
+	private void populateForm(ExpenseReport value) {
+		this.expenseReport = value;
+		binder.readBean(this.expenseReport);
+		if (value != null) {
+			approve.setEnabled(
+					value.getId() != null && value.getId() != 0 && value.getExpenseStatus() == ExpenseReportStatus.INGRESADO);
+			reject.setEnabled(
+					value.getId() != null && value.getId() != 0 && value.getExpenseStatus() == ExpenseReportStatus.INGRESADO);
+		} else {
+			approve.setEnabled(false);
+			reject.setEnabled(false);
+		}
 	}
 
 	private void updateFooter(FooterRow footerRow, Grid.Column<ExpenseReport> studyColumn,


### PR DESCRIPTION
…n a grid row is clicked.

This change refactors the `ExpenseReportApprovalView` to use a `SplitLayout`, showing a grid of expense reports and an editor form. When a user clicks on a row, the form is populated with the data from the selected report, allowing for editing, approval, or rejection.

This implementation is based on the existing `ExpensesView` and provides a more user-friendly way to manage expense report approvals.