### PR TITLE
Fix compilation errors in ProyectosView, JournalEntryDialog, and Exce…

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/ExcelExportService.java
+++ b/src/main/java/uy/com/bay/utiles/services/ExcelExportService.java
@@ -15,6 +15,7 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.stereotype.Service;
 
 import uy.com.bay.utiles.data.JournalEntry;
+import uy.com.bay.utiles.data.Operation;
 
 @Service
 public class ExcelExportService {
@@ -39,9 +40,14 @@ public class ExcelExportService {
 				Row row = sheet.createRow(rowIdx++);
 				row.createCell(0).setCellValue(entry.getDate());
 				row.getCell(0).setCellStyle(dateCellStyle);
-				row.createCell(1).setCellValue(entry.getgetDebit());
-				row.createCell(2).setCellValue(entry.getCredit());
-				row.createCell(3).setCellValue(entry.getDescription());
+				if (entry.getOperation() == Operation.DEBITO) {
+					row.createCell(1).setCellValue(entry.getAmount());
+					row.createCell(2).setCellValue(0);
+				} else {
+					row.createCell(1).setCellValue(0);
+					row.createCell(2).setCellValue(entry.getAmount());
+				}
+				row.createCell(3).setCellValue(entry.getDetail());
 			}
 
 			workbook.write(out);

--- a/src/main/java/uy/com/bay/utiles/views/proyectos/JournalEntryDialog.java
+++ b/src/main/java/uy/com/bay/utiles/views/proyectos/JournalEntryDialog.java
@@ -49,7 +49,7 @@ public class JournalEntryDialog extends Dialog {
 		grid.addColumn("debit").setHeader("Debe");
 		grid.addColumn("credit").setHeader("Haber");
 		grid.addColumn("description").setHeader("Descripción");
-		grid.setItems(journalEntryService.getJournalEntries(proyecto));
+		grid.setItems(journalEntryService.findAllByStudy(proyecto));
 
 		Button closeButton = new Button("Cerrar", e -> close());
 
@@ -70,9 +70,11 @@ public class JournalEntryDialog extends Dialog {
 		SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMddHHmmss");
 		String filename = "journal_entries_" + proyecto.getName().replaceAll("\\s+", "_") + "_" + sdf.format(new Date())
 				+ ".xlsx";
-		return new StreamResource(filename, () -> {
+		return new StreamResource(filename, (outputStream, vaadinSession) -> {
 			try {
-				return excelExportService.exportJournalEntriesToExcel(journalEntryService.getJournalEntries(proyecto));
+				java.io.ByteArrayInputStream inputStream = excelExportService
+						.exportJournalEntriesToExcel(journalEntryService.findAllByStudy(proyecto));
+				inputStream.transferTo(outputStream);
 			} catch (IOException e) {
 				e.printStackTrace();
 			}

--- a/src/main/java/uy/com/bay/utiles/views/proyectos/ProyectosView.java
+++ b/src/main/java/uy/com/bay/utiles/views/proyectos/ProyectosView.java
@@ -84,17 +84,19 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 	private final ExpenseReportFileService expenseReportFileService;
 	private final ExpenseTransferFileService expenseTransferFileService;
 	private final FieldworkService fieldworkService;
+	private final uy.com.bay.utiles.services.ExcelExportService excelExportService;
 
 	public ProyectosView(StudyService proyectoService, JournalEntryService journalEntryService,
 			AlchemerSurveyResponseDataRepository alchemerSurveyResponseDataRepository,
 			ExpenseReportFileService expenseReportFileService, ExpenseTransferFileService expenseTransferFileService,
-			FieldworkService fieldworkService) {
+			FieldworkService fieldworkService, uy.com.bay.utiles.services.ExcelExportService excelExportService) {
 		this.proyectoService = proyectoService;
 		this.journalEntryService = journalEntryService;
 		this.fieldworkService = fieldworkService;
 		this.alchemerSurveyResponseDataRepository = alchemerSurveyResponseDataRepository;
 		this.expenseReportFileService = expenseReportFileService;
 		this.expenseTransferFileService = expenseTransferFileService;
+		this.excelExportService = excelExportService;
 		this.binder = new BeanValidationBinder<>(Study.class); // Moved initialization here
 		addClassNames("proyectos-view");
 


### PR DESCRIPTION
…lExportService

This commit addresses a series of Java compilation errors that arose from recent refactoring and dependency updates.

The following changes were made:
- In `ExcelExportService.java`, updated the Excel export logic to use `getAmount()`, `getOperation()`, and `getDetail()` from the `JournalEntry` entity, replacing the old, non-existent methods.
- In `JournalEntryDialog.java`, replaced the call to the non-existent `getJournalEntries` method with `findAllByStudy`. Also, updated the `StreamResource` creation to conform to the new Vaadin API, which requires a different lambda signature.
- In `ProyectosView.java`, injected the `ExcelExportService` dependency through the constructor to resolve an "unresolved variable" error.