### PR TITLE
Fix: Resolve property name error in JournalEntryDialog

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/proyectos/JournalEntryDialog.java
+++ b/src/main/java/uy/com/bay/utiles/views/proyectos/JournalEntryDialog.java
@@ -11,8 +11,8 @@ import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.server.StreamResource;
-
 import uy.com.bay.utiles.data.JournalEntry;
+import uy.com.bay.utiles.data.Operation;
 import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.services.ExcelExportService;
 import uy.com.bay.utiles.services.ExpenseReportFileService;
@@ -46,9 +46,10 @@ public class JournalEntryDialog extends Dialog {
 
 		Grid<JournalEntry> grid = new Grid<>(JournalEntry.class, false);
 		grid.addColumn("date").setHeader("Fecha");
-		grid.addColumn("debit").setHeader("Debe");
-		grid.addColumn("credit").setHeader("Haber");
-		grid.addColumn("description").setHeader("Descripción");
+		grid.addColumn(entry -> entry.getOperation() == Operation.DEBITO ? entry.getAmount() : null).setHeader("Debe");
+		grid.addColumn(entry -> entry.getOperation() == Operation.CREDITO ? entry.getAmount() : null)
+				.setHeader("Haber");
+		grid.addColumn("detail").setHeader("Descripción");
 		grid.setItems(journalEntryService.findAllByStudy(proyecto));
 
 		Button closeButton = new Button("Cerrar", e -> close());


### PR DESCRIPTION
The JournalEntryDialog was throwing an IllegalArgumentException because it was trying to create grid columns for 'debit', 'credit', and 'description' properties, which do not exist in the JournalEntry entity.

This commit fixes the issue by:
- Replacing the direct property bindings for 'debit' and 'credit' with ValueProviders. The new logic checks the 'operation' field (DEBITO/CREDITO) and displays the 'amount' in the correct column.
- Correcting the 'description' column to use the existing 'detail' property.
- Importing the 'Operation' enum to be used in the ValueProvider logic.