### PR TITLE
Fix JpaSystemException in expense report filtering

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportsView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportsView.java
@@ -8,6 +8,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.time.LocalDate;
+import java.time.ZoneId;
 
 import org.springframework.data.jpa.domain.Specification;
 
@@ -381,11 +383,15 @@ public class ExpenseReportsView extends Div implements BeforeEnterObserver {
 						"%" + surveyorFilter.getValue().toLowerCase() + "%"));
 			}
 			if (dateFilter.getValue() != null) {
-				predicates.add(criteriaBuilder.equal(root.get("date"), dateFilter.getValue()));
+				LocalDate localDate = dateFilter.getValue();
+				Date startDate = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+				Date endDate = Date.from(localDate.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant());
+				predicates.add(criteriaBuilder.greaterThanOrEqualTo(root.get("date"), startDate));
+				predicates.add(criteriaBuilder.lessThan(root.get("date"), endDate));
 			}
 
 			if (amountFilter.getValue() != null) {
-				predicates.add(criteriaBuilder.equal(root.get("amount"), dateFilter.getValue()));
+				predicates.add(criteriaBuilder.equal(root.get("amount"), amountFilter.getValue()));
 			}
 			if (conceptFilter.getValue() != null && !conceptFilter.getValue().isEmpty()) {
 				predicates.add(criteriaBuilder.like(criteriaBuilder.lower(root.get("concept").get("name")),


### PR DESCRIPTION
- Resolves a `JpaSystemException` caused by a type mismatch between `java.time.LocalDate` from the date filter and the `java.util.Date` entity property. The fix implements a date range comparison to correctly filter by the selected day.
- Corrects a bug in the amount filter that was incorrectly comparing the amount to the date filter's value.