### PR TITLE
feat: Add custom access denied dialog

### DIFF
--- a/src/main/java/uy/com/bay/utiles/security/CustomViewAccessChecker.java
+++ b/src/main/java/uy/com/bay/utiles/security/CustomViewAccessChecker.java
@@ -1,5 +1,35 @@
 package uy.com.bay.utiles.security;
 
-public class CustomViewAccessChecker {
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.server.auth.AccessDeniedException;
+import com.vaadin.flow.server.auth.ViewAccessChecker;
+import org.springframework.stereotype.Component;
 
+@Component
+public class CustomViewAccessChecker extends ViewAccessChecker {
+
+    public CustomViewAccessChecker() {
+        super();
+    }
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        try {
+            super.beforeEnter(event);
+        } catch (AccessDeniedException e) {
+            showAccessDeniedDialog(event);
+        }
+    }
+
+    private void showAccessDeniedDialog(BeforeEnterEvent event) {
+        Dialog dialog = new Dialog();
+        dialog.add(new Text("No tiene permisos para acceder al módulo."));
+        Button closeButton = new Button("Cerrar", e -> dialog.close());
+        dialog.getFooter().add(closeButton);
+        dialog.open();
+        event.rerouteTo("");
+    }
 }


### PR DESCRIPTION
This commit introduces a custom `ViewAccessChecker` that displays a dialog with the message "no tiene permisos para acceder al módulo." when a user tries to access a view for which they don't have permission.

The `CustomViewAccessChecker` extends Vaadin's `ViewAccessChecker` and overrides the `beforeEnter` method to catch the `AccessDeniedException`. When the exception is caught, a dialog is displayed, and the user is rerouted to the home page.