### PR TITLE
fix: Register CustomViewAccessChecker

### DIFF
--- a/src/main/java/uy/com/bay/utiles/config/ApplicationServiceInitListener.java
+++ b/src/main/java/uy/com/bay/utiles/config/ApplicationServiceInitListener.java
@@ -1,0 +1,21 @@
+package uy.com.bay.utiles.config;
+
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uy.com.bay.utiles.security.CustomViewAccessChecker;
+
+@Component
+public class ApplicationServiceInitListener implements VaadinServiceInitListener {
+
+    @Autowired
+    private CustomViewAccessChecker accessChecker;
+
+    @Override
+    public void serviceInit(ServiceInitEvent event) {
+        event.getSource().addUIInitListener(uiInitEvent -> {
+            uiInitEvent.getUI().addBeforeEnterListener(accessChecker);
+        });
+    }
+}


### PR DESCRIPTION
This commit fixes an issue where the `CustomViewAccessChecker` was not being used, causing the default access denied page to be shown instead of the custom dialog.

A `VaadinServiceInitListener` is introduced to register the `CustomViewAccessChecker` for each UI instance. This ensures that the custom access denied logic is always used.