### PR TITLE
feat: Add Area entity and AreasView

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/Area.java
+++ b/src/main/java/uy/com/bay/utiles/data/Area.java
@@ -1,5 +1,17 @@
 package uy.com.bay.utiles.data;
 
-public enum Area {
-	CORPORATIVO, DS, OP, OTRA
+import jakarta.persistence.Entity;
+
+@Entity
+public class Area extends AbstractEntity {
+
+    private String nombre;
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
 }

--- a/src/main/java/uy/com/bay/utiles/data/repository/AreaRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/AreaRepository.java
@@ -1,0 +1,8 @@
+package uy.com.bay.utiles.data.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import uy.com.bay.utiles.data.Area;
+
+public interface AreaRepository extends JpaRepository<Area, Long>, JpaSpecificationExecutor<Area> {
+}

--- a/src/main/java/uy/com/bay/utiles/services/AreaService.java
+++ b/src/main/java/uy/com/bay/utiles/services/AreaService.java
@@ -1,0 +1,47 @@
+package uy.com.bay.utiles.services;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import uy.com.bay.utiles.data.Area;
+import uy.com.bay.utiles.data.repository.AreaRepository;
+
+@Service
+public class AreaService {
+
+    private final AreaRepository repository;
+
+    public AreaService(AreaRepository repository) {
+        this.repository = repository;
+    }
+
+    public Optional<Area> get(Long id) {
+        return repository.findById(id);
+    }
+
+    public Area save(Area entity) {
+        return repository.save(entity);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+
+    public Page<Area> list(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+    public Page<Area> list(Pageable pageable, Specification<Area> filter) {
+        return repository.findAll(filter, pageable);
+    }
+
+    public int count() {
+        return (int) repository.count();
+    }
+
+    public java.util.List<Area> listAll() {
+        return repository.findAll();
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/views/areas/AreasView.java
+++ b/src/main/java/uy/com/bay/utiles/views/areas/AreasView.java
@@ -1,0 +1,205 @@
+package uy.com.bay.utiles.views.areas;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.GridVariant;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.notification.Notification.Position;
+import com.vaadin.flow.component.notification.NotificationVariant;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.splitlayout.SplitLayout;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.binder.BeanValidationBinder;
+import com.vaadin.flow.data.binder.ValidationException;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.spring.data.VaadinSpringDataHelpers;
+import jakarta.annotation.security.RolesAllowed;
+import org.springframework.data.domain.PageRequest;
+import java.util.Optional;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.vaadin.lineawesome.LineAwesomeIconUrl;
+import uy.com.bay.utiles.data.Area;
+import uy.com.bay.utiles.services.AreaService;
+
+@PageTitle("Areas")
+@Route(value = "areas/:areaID?/:action?(edit)")
+@RolesAllowed("ADMIN")
+@Menu(order = 1, icon = LineAwesomeIconUrl.ADDRESS_BOOK_SOLID)
+public class AreasView extends Div implements BeforeEnterObserver {
+
+    private final String AREA_ID = "areaID";
+    private final String AREA_EDIT_ROUTE_TEMPLATE = "areas/%s/edit";
+
+    private final Grid<Area> grid = new Grid<>(Area.class, false);
+
+    private TextField nombre;
+
+    private final Button cancel = new Button("Cancelar");
+    private final Button save = new Button("Guardar");
+    private final Button delete = new Button("Eliminar");
+
+    private final BeanValidationBinder<Area> binder;
+
+    private Area area;
+
+    private final AreaService areaService;
+
+    public AreasView(AreaService areaService) {
+        this.areaService = areaService;
+        addClassNames("areas-view");
+
+        // Create UI
+        SplitLayout splitLayout = new SplitLayout();
+
+        createGridLayout(splitLayout);
+        createEditorLayout(splitLayout);
+
+        add(splitLayout);
+
+        // Configure Grid
+        grid.addColumn("nombre").setAutoWidth(true);
+        grid.setItems(query -> areaService.list(
+                PageRequest.of(query.getPage(), query.getPageSize()))
+                .stream());
+        grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
+
+        // when a row is selected or deselected, populate form
+        grid.asSingleSelect().addValueChangeListener(event -> {
+            if (event.getValue() != null) {
+                UI.getCurrent().navigate(String.format(AREA_EDIT_ROUTE_TEMPLATE, event.getValue().getId()));
+            } else {
+                clearForm();
+                UI.getCurrent().navigate(AreasView.class);
+            }
+        });
+
+        // Configure Form
+        binder = new BeanValidationBinder<>(Area.class);
+        binder.bindInstanceFields(this);
+
+        cancel.addClickListener(e -> {
+            clearForm();
+            refreshGrid();
+        });
+
+        save.addClickListener(e -> {
+            try {
+                if (this.area == null) {
+                    this.area = new Area();
+                }
+                binder.writeBean(this.area);
+                areaService.save(this.area);
+                clearForm();
+                refreshGrid();
+                Notification.show("Area guardada.");
+                UI.getCurrent().navigate(AreasView.class);
+            } catch (ObjectOptimisticLockingFailureException exception) {
+                Notification n = Notification.show(
+                        "Error al guardar el area. Alguien mas la ha modificado.");
+                n.setPosition(Position.MIDDLE);
+                n.addThemeVariants(NotificationVariant.LUMO_ERROR);
+            } catch (ValidationException validationException) {
+                Notification.show("Fallo al guardar el area. Verifique que todos los valores son validos.");
+            }
+        });
+
+        delete.addClickListener(e -> {
+            if (this.area != null && this.area.getId() != null) {
+                try {
+                    areaService.delete(this.area.getId());
+                    clearForm();
+                    refreshGrid();
+                    Notification.show("Area eliminada.");
+                    UI.getCurrent().navigate(AreasView.class);
+                } catch (Exception ex) {
+                    Notification.show("Error al eliminar el area: " + ex.getMessage(), 5000,
+                            Notification.Position.MIDDLE).addThemeVariants(NotificationVariant.LUMO_ERROR);
+                }
+            }
+        });
+    }
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        Optional<Long> areaId = event.getRouteParameters().get(AREA_ID).map(Long::parseLong);
+        if (areaId.isPresent()) {
+            Optional<Area> areaFromBackend = areaService.get(areaId.get());
+            if (areaFromBackend.isPresent()) {
+                populateForm(areaFromBackend.get());
+            } else {
+                Notification.show(
+                        String.format("El area no fue encontrada, ID = %s", areaId.get()),
+                        3000, Notification.Position.BOTTOM_START);
+                refreshGrid();
+                event.forwardTo(AreasView.class);
+            }
+        }
+    }
+
+    private void createEditorLayout(SplitLayout splitLayout) {
+        Div editorLayoutDiv = new Div();
+        editorLayoutDiv.setClassName("editor-layout");
+
+        Div editorDiv = new Div();
+        editorDiv.setClassName("editor");
+        editorLayoutDiv.add(editorDiv);
+
+        FormLayout formLayout = new FormLayout();
+        nombre = new TextField("Nombre");
+        formLayout.add(nombre);
+
+        editorDiv.add(formLayout);
+        createButtonLayout(editorLayoutDiv);
+
+        splitLayout.addToSecondary(editorLayoutDiv);
+    }
+
+    private void createButtonLayout(Div editorLayoutDiv) {
+        HorizontalLayout buttonLayout = new HorizontalLayout();
+        buttonLayout.setClassName("button-layout");
+        cancel.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+        save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        delete.addThemeVariants(ButtonVariant.LUMO_ERROR);
+        buttonLayout.add(save, cancel, delete);
+        editorLayoutDiv.add(buttonLayout);
+    }
+
+    private void createGridLayout(SplitLayout splitLayout) {
+        Div wrapper = new Div();
+        wrapper.setClassName("grid-wrapper");
+
+        Button createAreaButton = new Button("Crear Area");
+        createAreaButton.addClickListener(e -> {
+            clearForm();
+            UI.getCurrent().navigate(String.format(AREA_EDIT_ROUTE_TEMPLATE, "new"));
+        });
+
+        HorizontalLayout topLayout = new HorizontalLayout();
+        topLayout.add(createAreaButton);
+
+        wrapper.add(topLayout, grid);
+        splitLayout.addToPrimary(wrapper);
+    }
+
+    private void refreshGrid() {
+        grid.select(null);
+        grid.getDataProvider().refreshAll();
+    }
+
+    private void clearForm() {
+        populateForm(null);
+    }
+
+    private void populateForm(Area value) {
+        this.area = value;
+        binder.readBean(this.area);
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
+++ b/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
@@ -74,10 +74,12 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 
 	private final FieldworkService fieldworkService;
 	private final StudyService studyService;
+	private final uy.com.bay.utiles.services.AreaService areaService;
 
-	public FieldworksView(FieldworkService fieldworkService, StudyService studyService) {
+	public FieldworksView(FieldworkService fieldworkService, StudyService studyService, uy.com.bay.utiles.services.AreaService areaService) {
 		this.fieldworkService = fieldworkService;
 		this.studyService = studyService;
+		this.areaService = areaService;
 		addClassNames("fieldworks-view");
 
 		// Create UI
@@ -216,7 +218,8 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 		type = new ComboBox<>("Tipo");
 		type.setItems(FieldworkType.values());
 		area = new ComboBox<>("Area");
-		area.setItems(Area.values());
+		area.setItems(areaService.listAll());
+		area.setItemLabelGenerator(Area::getNombre);
 		formLayout.add(study, doobloId, alchemerId, initPlannedDate, endPlannedDate, goalQuantity, completed, obs,
 				status, type, area);
 


### PR DESCRIPTION
This commit introduces a new `Area` entity and a corresponding `AreasView` for managing areas.

The `Area` entity has a single `nombre` field. The `AreasView` provides a grid to list all areas and a form to create, edit, and delete them.

The existing `Area` enum has been refactored to a JPA entity, and the `FieldworksView` has been updated to use the new `AreaService` to avoid breaking existing functionality.