### PR TITLE
Fix NumberFormatException in AreasView

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/areas/AreasView.java
+++ b/src/main/java/uy/com/bay/utiles/views/areas/AreasView.java
@@ -129,16 +129,29 @@ public class AreasView extends Div implements BeforeEnterObserver {
 
 	@Override
 	public void beforeEnter(BeforeEnterEvent event) {
-		Optional<Long> areaId = event.getRouteParameters().get(AREA_ID).map(Long::parseLong);
-		if (areaId.isPresent()) {
-			Optional<Area> areaFromBackend = areaService.get(areaId.get());
-			if (areaFromBackend.isPresent()) {
-				populateForm(areaFromBackend.get());
+		Optional<String> areaIdParam = event.getRouteParameters().get(AREA_ID);
+		if (areaIdParam.isPresent()) {
+			String areaId = areaIdParam.get();
+			if ("new".equals(areaId)) {
+				clearForm();
+				grid.asSingleSelect().clear();
 			} else {
-				Notification.show(String.format("El area no fue encontrada, ID = %s", areaId.get()), 3000,
-						Notification.Position.BOTTOM_START);
-				refreshGrid();
-				event.forwardTo(AreasView.class);
+				try {
+					Optional<Area> areaFromBackend = areaService.get(Long.parseLong(areaId));
+					if (areaFromBackend.isPresent()) {
+						populateForm(areaFromBackend.get());
+					} else {
+						Notification.show(String.format("El area con id = '%s' no fue encontrada", areaId), 3000,
+								Notification.Position.BOTTOM_START);
+						refreshGrid();
+						event.forwardTo(AreasView.class);
+					}
+				} catch (NumberFormatException e) {
+					Notification.show(String.format("El id de area debe ser un numero. Id recibido: '%s'", areaId), 3000,
+							Notification.Position.BOTTOM_START);
+					refreshGrid();
+					event.forwardTo(AreasView.class);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The `beforeEnter` method in `AreasView` was attempting to parse the route parameter as a Long without handling the case where the parameter is the string "new". This caused a `NumberFormatException` when navigating to the view to create a new area.

This commit fixes the issue by:
- Retrieving the route parameter as a String.
- Checking if the parameter is "new" and, if so, preparing the view for a new entry by clearing the form and the grid selection.
- If the parameter is not "new", attempting to parse it as a Long within a try-catch block to handle invalid, non-numeric IDs gracefully.
- Preserving the existing behavior for valid numeric IDs and for cases where no ID is present.