### PR TITLE
feat: Add footer with total to expense views

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportsView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportsView.java
@@ -37,6 +37,7 @@ import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.component.upload.MultiFileReceiver;
 import com.vaadin.flow.component.upload.Upload;
+import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.data.binder.BeanValidationBinder;
 import com.vaadin.flow.data.binder.ValidationException;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
@@ -143,8 +144,8 @@ public class ExpenseReportsView extends Div implements BeforeEnterObserver {
 						.list(VaadinSpringDataHelpers.toSpringPageRequest(query), createFilterSpecification()).stream(),
 				query -> (int) expenseReportService.count(createFilterSpecification())));
 
-		FooterRow footerRow = grid.appendFooterRow();
-		updateFooter(footerRow, grid.getColumnByKey("study"), grid.getColumnByKey("amount"));
+		grid.appendFooterRow();
+		updateFooter();
 
 		grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
 
@@ -327,11 +328,13 @@ public class ExpenseReportsView extends Div implements BeforeEnterObserver {
 		studyFilter = new TextField();
 		studyFilter.setPlaceholder("Estudio...");
 		studyFilter.setClearButtonVisible(true);
+		studyFilter.setValueChangeMode(ValueChangeMode.LAZY);
 		studyFilter.addValueChangeListener(e -> refreshGrid());
 
 		surveyorFilter = new TextField();
 		surveyorFilter.setPlaceholder("Encuestador...");
 		surveyorFilter.setClearButtonVisible(true);
+		surveyorFilter.setValueChangeMode(ValueChangeMode.LAZY);
 		surveyorFilter.addValueChangeListener(e -> refreshGrid());
 
 		dateFilter = new DatePicker();
@@ -342,11 +345,13 @@ public class ExpenseReportsView extends Div implements BeforeEnterObserver {
 		amountFilter = new NumberField();
 		amountFilter.setPlaceholder("Monto..");
 		amountFilter.setClearButtonVisible(true);
+		amountFilter.setValueChangeMode(ValueChangeMode.LAZY);
 		amountFilter.addValueChangeListener(e -> refreshGrid());
 
 		conceptFilter = new TextField();
 		conceptFilter.setPlaceholder("Concepto...");
 		conceptFilter.setClearButtonVisible(true);
+		conceptFilter.setValueChangeMode(ValueChangeMode.LAZY);
 		conceptFilter.addValueChangeListener(e -> refreshGrid());
 
 		statusFilter = new ComboBox<>();
@@ -408,12 +413,15 @@ public class ExpenseReportsView extends Div implements BeforeEnterObserver {
 	private void refreshGrid() {
 		grid.select(null);
 		grid.getDataProvider().refreshAll();
-		FooterRow footerRow = grid.getFooterRows().get(0);
-		updateFooter(footerRow, grid.getColumnByKey("study"), grid.getColumnByKey("amount"));
+		if (grid.getFooterRows().size() > 0) {
+			updateFooter();
+		}
 	}
 
-	private void updateFooter(FooterRow footerRow, Grid.Column<ExpenseReport> studyColumn,
-			Grid.Column<ExpenseReport> amountColumn) {
+	private void updateFooter() {
+		FooterRow footerRow = grid.getFooterRows().get(0);
+		Grid.Column<ExpenseReport> studyColumn = grid.getColumnByKey("study");
+		Grid.Column<ExpenseReport> amountColumn = grid.getColumnByKey("amount");
 		Specification<ExpenseReport> spec = createFilterSpecification();
 		Double total = expenseReportService.sumAmount(spec);
 		footerRow.getCell(studyColumn).setText("TOTAL");

--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpensesAprovalView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpensesAprovalView.java
@@ -277,7 +277,7 @@ public class ExpensesAprovalView extends Div implements BeforeEnterObserver {
 		grid.setHeightFull();
 		Grid.Column<ExpenseRequest> studyColumn = grid
 				.addColumn(er -> er.getStudy() != null ? er.getStudy().getName() : "").setHeader("Estudio")
-				.setAutoWidth(true).setSortable(true).setSortProperty("study.name");
+				.setAutoWidth(true).setSortable(true).setSortProperty("study.name").setKey("study");
 		Grid.Column<ExpenseRequest> surveyorColumn = grid
 				.addColumn(er -> er.getSurveyor() != null
 						? er.getSurveyor().getFirstName() + " " + er.getSurveyor().getLastName()
@@ -289,13 +289,13 @@ public class ExpensesAprovalView extends Div implements BeforeEnterObserver {
 						: "")
 				.setHeader("Solicitado").setAutoWidth(true).setSortable(true).setSortProperty("requestDate");
 		Grid.Column<ExpenseRequest> amountColumn = grid.addColumn(ExpenseRequest::getAmount).setHeader("Monto")
-				.setAutoWidth(true).setSortable(true).setSortProperty("amount");
+				.setAutoWidth(true).setSortable(true).setSortProperty("amount").setKey("amount");
 		Grid.Column<ExpenseRequest> conceptColumn = grid
 				.addColumn(er -> er.getConcept() != null ? er.getConcept().getName() : "").setHeader("Concepto")
 				.setAutoWidth(true).setSortable(true).setSortProperty("concept.name");
 
-		FooterRow footerRow = grid.appendFooterRow();
-		updateFooter(footerRow, studyColumn, amountColumn);
+		grid.appendFooterRow();
+		updateFooter();
 
 		HeaderRow headerRow = grid.appendHeaderRow();
 
@@ -305,8 +305,7 @@ public class ExpensesAprovalView extends Div implements BeforeEnterObserver {
 		studyFilter.setValueChangeMode(ValueChangeMode.LAZY);
 		studyFilter.addValueChangeListener(e -> {
 			filters.setStudyName(e.getValue());
-			grid.getDataProvider().refreshAll();
-			updateFooter(footerRow, studyColumn, amountColumn);
+			refreshGrid();
 		});
 		headerRow.getCell(studyColumn).setComponent(studyFilter);
 
@@ -316,8 +315,7 @@ public class ExpensesAprovalView extends Div implements BeforeEnterObserver {
 		surveyorFilter.setValueChangeMode(ValueChangeMode.LAZY);
 		surveyorFilter.addValueChangeListener(e -> {
 			filters.setSurveyorName(e.getValue());
-			grid.getDataProvider().refreshAll();
-			updateFooter(footerRow, studyColumn, amountColumn);
+			refreshGrid();
 		});
 		headerRow.getCell(surveyorColumn).setComponent(surveyorFilter);
 
@@ -326,8 +324,7 @@ public class ExpensesAprovalView extends Div implements BeforeEnterObserver {
 		requestDateFilter.setClearButtonVisible(true);
 		requestDateFilter.addValueChangeListener(e -> {
 			filters.setRequestDate(e.getValue());
-			grid.getDataProvider().refreshAll();
-			updateFooter(footerRow, studyColumn, amountColumn);
+			refreshGrid();
 		});
 		headerRow.getCell(requestDateColumn).setComponent(requestDateFilter);
 
@@ -337,8 +334,7 @@ public class ExpensesAprovalView extends Div implements BeforeEnterObserver {
 		amountFilter.setValueChangeMode(ValueChangeMode.LAZY);
 		amountFilter.addValueChangeListener(e -> {
 			filters.setAmount(e.getValue());
-			grid.getDataProvider().refreshAll();
-			updateFooter(footerRow, studyColumn, amountColumn);
+			refreshGrid();
 		});
 		headerRow.getCell(amountColumn).setComponent(amountFilter);
 
@@ -349,8 +345,7 @@ public class ExpensesAprovalView extends Div implements BeforeEnterObserver {
 		conceptFilter.setClearButtonVisible(true);
 		conceptFilter.addValueChangeListener(e -> {
 			filters.setConcept(e.getValue());
-			grid.getDataProvider().refreshAll();
-			updateFooter(footerRow, studyColumn, amountColumn);
+			refreshGrid();
 		});
 		headerRow.getCell(conceptColumn).setComponent(conceptFilter);
 	}
@@ -416,6 +411,9 @@ public class ExpensesAprovalView extends Div implements BeforeEnterObserver {
 	private void refreshGrid() {
 		grid.select(null);
 		grid.getDataProvider().refreshAll();
+		if (grid.getFooterRows().size() > 0) {
+			updateFooter();
+		}
 	}
 
 	private void clearForm() {
@@ -439,8 +437,10 @@ public class ExpensesAprovalView extends Div implements BeforeEnterObserver {
 		}
 	}
 
-	private void updateFooter(FooterRow footerRow, Grid.Column<ExpenseRequest> studyColumn,
-			Grid.Column<ExpenseRequest> amountColumn) {
+	private void updateFooter() {
+		FooterRow footerRow = grid.getFooterRows().get(0);
+		Grid.Column<ExpenseRequest> studyColumn = grid.getColumnByKey("study");
+		Grid.Column<ExpenseRequest> amountColumn = grid.getColumnByKey("amount");
 		Specification<ExpenseRequest> spec = createSpecification(filters);
 		Double total = expenseRequestService.sumAmount(spec);
 		footerRow.getCell(studyColumn).setText("TOTAL");


### PR DESCRIPTION
This commit adds a footer row to the grids in `ExpensesAprovalView` and `ExpenseReportsView`.

The footer displays "TOTAL" in the "Estudio" column and the sum of the "Monto" column, which is calculated based on the current filters.

This addresses the user's request to have a summary of the total amount in the expense views.