### PR TITLE
Refactor: Add 'Cerrar' and 'Crear' buttons to FieldworkDialog

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
+++ b/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
@@ -188,6 +188,23 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 				refreshGrid();
 				event.forwardTo(FieldworksView.class);
 			}
+		} else {
+			event.getLocation().getQueryParameters().get("studyId").stream().findFirst().ifPresent(studyId -> {
+				try {
+					Optional<Study> study = studyService.get(Long.parseLong(studyId));
+					if (study.isPresent()) {
+						clearForm();
+						this.fieldwork = new Fieldwork();
+						this.fieldwork.setStudy(study.get());
+						binder.readBean(this.fieldwork);
+						this.editorLayoutDiv.setVisible(true);
+					} else {
+						Notification.show("El estudio no fue encontrado.", 3000, Notification.Position.BOTTOM_START);
+					}
+				} catch (NumberFormatException e) {
+					Notification.show("Id de estudio invalido.", 3000, Notification.Position.BOTTOM_START);
+				}
+			});
 		}
 	}
 

--- a/src/main/java/uy/com/bay/utiles/views/proyectos/FieldworkDialog.java
+++ b/src/main/java/uy/com/bay/utiles/views/proyectos/FieldworkDialog.java
@@ -1,12 +1,18 @@
 package uy.com.bay.utiles.views.proyectos;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.QueryParameters;
 import uy.com.bay.utiles.data.Fieldwork;
 import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.data.service.FieldworkService;
+import uy.com.bay.utiles.views.fieldworks.FieldworksView;
+
+import java.util.Collections;
 
 public class FieldworkDialog extends Dialog {
 
@@ -27,7 +33,16 @@ public class FieldworkDialog extends Dialog {
 			UI.getCurrent().navigate("fieldworks/" + event.getItem().getId() + "/edit");
 			close();
 		});
-		VerticalLayout layout = new VerticalLayout(grid);
+
+		Button closeButton = new Button("Cerrar", e -> close());
+		Button createButton = new Button("Crear", e -> {
+			QueryParameters params = QueryParameters.simple(Collections.singletonMap("studyId", study.getId().toString()));
+			UI.getCurrent().navigate(FieldworksView.class, params);
+			close();
+		});
+
+		HorizontalLayout buttonLayout = new HorizontalLayout(createButton, closeButton);
+		VerticalLayout layout = new VerticalLayout(grid, buttonLayout);
 		add(layout);
 
 		setCloseOnEsc(true);


### PR DESCRIPTION
This commit refactors the FieldworkDialog to include 'Cerrar' (Close) and 'Crear' (Create) buttons.

- The 'Cerrar' button closes the dialog.
- The 'Crear' button navigates to the FieldworksView, pre-populating a new fieldwork with the study from the dialog's context. This is achieved by passing the studyId as a query parameter.

The FieldworksView has been updated to handle this new query parameter, ensuring a seamless user experience for creating new fieldworks directly from the study context.