### PR TITLE
Refactor: Add 'Cerrar' and 'Crear' buttons to FieldworkDialog

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
+++ b/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
@@ -189,7 +189,9 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 				event.forwardTo(FieldworksView.class);
 			}
 		} else {
-			event.getLocation().getQueryParameters().get("studyId").stream().findFirst().ifPresent(studyId -> {
+			Optional.ofNullable(event.getLocation().getQueryParameters().getParameters().get("studyId"))
+				.flatMap(list -> list.stream().findFirst())
+				.ifPresent(studyId -> {
 				try {
 					Optional<Study> study = studyService.get(Long.parseLong(studyId));
 					if (study.isPresent()) {


### PR DESCRIPTION
This commit refactors the FieldworkDialog to include 'Cerrar' (Close) and 'Crear' (Create) buttons.

- The 'Cerrar' button closes the dialog.
- The 'Crear' button navigates to the FieldworksView, pre-populating a new fieldwork with the study from the dialog's context. This is achieved by passing the studyId as a query parameter.

The FieldworksView has been updated to handle this new query parameter, ensuring a seamless user experience for creating new fieldworks directly from the study context. A fix for handling query parameters has also been included.