### PR TITLE
feat: Add fieldwork details dialog on Gantt step click

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/gantt/FieldworkDetailsDialog.java
+++ b/src/main/java/uy/com/bay/utiles/views/gantt/FieldworkDetailsDialog.java
@@ -1,0 +1,75 @@
+package uy.com.bay.utiles.views.gantt;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.component.textfield.TextField;
+
+import uy.com.bay.utiles.data.Fieldwork;
+
+public class FieldworkDetailsDialog extends Dialog {
+
+    public FieldworkDetailsDialog(Fieldwork fieldwork) {
+        setHeaderTitle("Detalles del Trabajo de Campo");
+
+        FormLayout formLayout = new FormLayout();
+
+        TextField study = new TextField("Estudio");
+        study.setValue(fieldwork.getStudy() != null ? fieldwork.getStudy().getName() : "");
+        study.setReadOnly(true);
+
+        TextField doobloId = new TextField("Dooblo Id");
+        doobloId.setValue(fieldwork.getDoobloId() != null ? fieldwork.getDoobloId() : "");
+        doobloId.setReadOnly(true);
+
+        TextField alchemerId = new TextField("Alchemer Id");
+        alchemerId.setValue(fieldwork.getAlchemerId() != null ? fieldwork.getAlchemerId() : "");
+        alchemerId.setReadOnly(true);
+
+        TextField initPlannedDate = new TextField("Fecha Planificada Inicio");
+        initPlannedDate.setValue(fieldwork.getInitPlannedDate() != null ? fieldwork.getInitPlannedDate().toString() : "");
+        initPlannedDate.setReadOnly(true);
+
+        TextField endPlannedDate = new TextField("Fecha Planificada Fin");
+        endPlannedDate.setValue(fieldwork.getEndPlannedDate() != null ? fieldwork.getEndPlannedDate().toString() : "");
+        endPlannedDate.setReadOnly(true);
+
+        TextField initDate = new TextField("Fecha Inicio");
+        initDate.setValue(fieldwork.getInitDate() != null ? fieldwork.getInitDate().toString() : "");
+        initDate.setReadOnly(true);
+
+        TextField endDate = new TextField("Fecha Fin");
+        endDate.setValue(fieldwork.getEndDate() != null ? fieldwork.getEndDate().toString() : "");
+        endDate.setReadOnly(true);
+
+        TextField goalQuantity = new TextField("Cantidad Objetivo");
+        goalQuantity.setValue(fieldwork.getGoalQuantity() != null ? fieldwork.getGoalQuantity().toString() : "");
+        goalQuantity.setReadOnly(true);
+
+        TextField completed = new TextField("Completadas");
+        completed.setValue(fieldwork.getCompleted() != null ? fieldwork.getCompleted().toString() : "");
+        completed.setReadOnly(true);
+
+        TextField obs = new TextField("Observaciones");
+        obs.setValue(fieldwork.getObs() != null ? fieldwork.getObs() : "");
+        obs.setReadOnly(true);
+
+        TextField status = new TextField("Estado");
+        status.setValue(fieldwork.getStatus() != null ? fieldwork.getStatus().toString() : "");
+        status.setReadOnly(true);
+
+        TextField type = new TextField("Tipo");
+        type.setValue(fieldwork.getType() != null ? fieldwork.getType().toString() : "");
+        type.setReadOnly(true);
+
+        TextField area = new TextField("Area");
+        area.setValue(fieldwork.getArea() != null ? fieldwork.getArea().getNombre() : "");
+        area.setReadOnly(true);
+
+        formLayout.add(study, doobloId, alchemerId, initPlannedDate, endPlannedDate, initDate, endDate, goalQuantity, completed, obs, status, type, area);
+        add(formLayout);
+
+        Button closeButton = new Button("Cerrar", e -> close());
+        getFooter().add(closeButton);
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/views/gantt/GanttView.java
+++ b/src/main/java/uy/com/bay/utiles/views/gantt/GanttView.java
@@ -3,6 +3,7 @@ package uy.com.bay.utiles.views.gantt;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -58,9 +59,11 @@ public class GanttView extends VerticalLayout {
 	private int stepCounter = 2;
 	private int totalgoal = 0;
 	private int totalCompleted = 0;
+	private final Map<String, Fieldwork> stepToFieldworkMap;
 
 	public GanttView(GanttService ganttService) {
 		this.ganttService = ganttService;
+		this.stepToFieldworkMap = new HashMap<>();
 		setWidthFull();
 		setPadding(false);
 
@@ -123,10 +126,12 @@ public class GanttView extends VerticalLayout {
 					subStep.setCaption(fieldwork.getType().toString());
 					subStep.setStartDate(fieldwork.getInitPlannedDate().atStartOfDay());
 					subStep.setEndDate(fieldwork.getEndPlannedDate().atStartOfDay());
-					subStep.setUid(UUID.randomUUID().toString());
+					String uid = UUID.randomUUID().toString();
+					subStep.setUid(uid);
 					subStep.setBackgroundColor("#E6E6E6");
 					subStep.setMovable(false);
 					treeGrid.getTreeData().addItem(studyStep, subStep);
+					stepToFieldworkMap.put(uid, fieldwork);
 					if (fieldwork.getGoalQuantity() != null)
 						totalgoal = totalgoal + fieldwork.getGoalQuantity();
 					if (fieldwork.getCompleted() != null)
@@ -304,7 +309,11 @@ public class GanttView extends VerticalLayout {
 
 	private void onGanttStepClick(StepClickEvent event) {
 		clickedBackgroundIndex = event.getIndex();
-		Notification.show("Clicked step " + event.getAnyStep().getCaption());
+		Fieldwork fieldwork = stepToFieldworkMap.get(event.getAnyStep().getUid());
+		if (fieldwork != null) {
+			FieldworkDetailsDialog dialog = new FieldworkDetailsDialog(fieldwork);
+			dialog.open();
+		}
 	}
 
 	private Div buildControlPanel() {


### PR DESCRIPTION
Refactors the `onGanttStepClick` method in `GanttView` to display a read-only dialog with the details of the corresponding `Fieldwork` entity.

- Creates a new `FieldworkDetailsDialog` class to display `Fieldwork` information in a read-only form.
- Modifies `GanttView` to associate each Gantt step with its `Fieldwork` object using a map.
- Implements the logic to open the details dialog when a step is clicked.