### PR TITLE
This refactor modifies the data fetching logic in the Gantt view.

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/FieldworkRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/FieldworkRepository.java
@@ -1,5 +1,7 @@
 package uy.com.bay.utiles.data.repository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,8 +10,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import uy.com.bay.utiles.data.Fieldwork;
 import uy.com.bay.utiles.data.Study;
 
-import java.util.List;
-
 public interface FieldworkRepository extends JpaRepository<Fieldwork, Long>, JpaSpecificationExecutor<Fieldwork> {
 	Optional<Fieldwork> findByAlchemerId(String alchemerId);
 
@@ -17,5 +17,6 @@ public interface FieldworkRepository extends JpaRepository<Fieldwork, Long>, Jpa
 
 	List<Fieldwork> findAllByStudy(Study study);
 
-	List<Fieldwork> findAllByEndPlannedDateBetween(java.time.LocalDate startDate, java.time.LocalDate endDate);
+	List<Fieldwork> findAllByInitPlannedDateLessThanAndEndPlannedDateGreaterThan(LocalDate endDate,
+			LocalDate startDate);
 }

--- a/src/main/java/uy/com/bay/utiles/services/GanttService.java
+++ b/src/main/java/uy/com/bay/utiles/services/GanttService.java
@@ -16,9 +16,7 @@ public class GanttService {
         this.fieldworkRepository = fieldworkRepository;
     }
 
-    public List<Fieldwork> getFieldworks() {
-        LocalDate today = LocalDate.now();
-        LocalDate sixMonthsFromNow = today.plusMonths(6);
-        return fieldworkRepository.findAllByEndPlannedDateBetween(today, sixMonthsFromNow);
+    public List<Fieldwork> getFieldworks(LocalDate startDate, LocalDate endDate) {
+        return fieldworkRepository.findAllByInitPlannedDateLessThanAndEndPlannedDateGreaterThan(endDate, startDate);
     }
 }

--- a/src/main/java/uy/com/bay/utiles/views/gantt/GanttView.java
+++ b/src/main/java/uy/com/bay/utiles/views/gantt/GanttView.java
@@ -88,7 +88,7 @@ public class GanttView extends VerticalLayout {
 		gantt.setMovableSteps(false);
 		gantt.setResizableSteps(false);
 
-		List<Fieldwork> fieldworks = ganttService.getFieldworks();
+		List<Fieldwork> fieldworks = ganttService.getFieldworks(gantt.getStartDate(), gantt.getEndDate());
 		Map<Study, List<Fieldwork>> fieldworksByStudy = fieldworks.stream()
 				.collect(Collectors.groupingBy(Fieldwork::getStudy));
 		fieldworksByStudy.forEach((study, fieldworkList) -> {


### PR DESCRIPTION
The `buildCaptionTreeGrid` method in `GanttView` now filters `Fieldwork` entities to only show those that overlap with the selected date range in the Gantt chart.

Changes include:
- A new method in `FieldworkRepository` to query for fieldworks within a specific date overlap.
- `GanttService` was updated to use this new repository method.
- `GanttView` was modified to call the updated service with the correct date parameters from the Gantt component itself, making the implementation more robust and avoiding potential NullPointerExceptions.