### PR TITLE
Refactor onGanttStepClick to show Study details

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
   <dependency>
    <groupId>org.vaadin.addons.tltv.gantt</groupId>
    <artifactId>gantt-flow-addon</artifactId>
-   <version>24.0.2</version>
+   <version>24.0.1</version>
 </dependency>
     <!-- Vaadin y Spring Boot -->
     <dependency>

--- a/src/main/java/uy/com/bay/utiles/views/gantt/GanttView.java
+++ b/src/main/java/uy/com/bay/utiles/views/gantt/GanttView.java
@@ -56,10 +56,12 @@ public class GanttView extends VerticalLayout {
 	private int totalgoal = 0;
 	private int totalCompleted = 0;
 	private final Map<String, Fieldwork> stepToFieldworkMap;
+	private final Map<String, Study> stepToStudyMap;
 
 	public GanttView(GanttService ganttService) {
 		this.ganttService = ganttService;
 		this.stepToFieldworkMap = new HashMap<>();
+		this.stepToStudyMap = new HashMap<>();
 		setWidthFull();
 		setPadding(false);
 
@@ -82,7 +84,8 @@ public class GanttView extends VerticalLayout {
 	}
 
 	private void buildCaptionTreeGrid() {
-		treeGrid = gantt.buildCaptionTreeGrid("Proyecto");
+		treeGrid = new TreeGrid<>();
+		treeGrid.addHierarchyColumn(Step::getCaption).setHeader("Proyecto");
 		treeGrid.setWidth("30%");
 		treeGrid.setAllRowsVisible(true);
 		treeGrid.getStyle().set("--gantt-caption-grid-row-height", "30px");
@@ -110,6 +113,7 @@ public class GanttView extends VerticalLayout {
 			studyStep.setBackgroundColor("#eb590580");
 			studyStep.setMovable(false);
 
+			stepToStudyMap.put(studyStep.getUid(), study);
 			gantt.addStep(0, studyStep);
 			fieldworkList.forEach(fieldwork -> {
 				if (fieldwork.getInitPlannedDate() != null && fieldwork.getEndPlannedDate() != null) {
@@ -220,8 +224,13 @@ public class GanttView extends VerticalLayout {
 
 	private void onGanttStepClick(StepClickEvent event) {
 		clickedBackgroundIndex = event.getIndex();
-		Fieldwork fieldwork = stepToFieldworkMap.get(event.getAnyStep().getUid());
-		if (fieldwork != null) {
+		String stepUid = event.getAnyStep().getUid();
+		if (stepToStudyMap.containsKey(stepUid)) {
+			Study study = stepToStudyMap.get(stepUid);
+			StudyDetailsDialog dialog = new StudyDetailsDialog(study);
+			dialog.open();
+		} else if (stepToFieldworkMap.containsKey(stepUid)) {
+			Fieldwork fieldwork = stepToFieldworkMap.get(stepUid);
 			FieldworkDetailsDialog dialog = new FieldworkDetailsDialog(fieldwork);
 			dialog.open();
 		}

--- a/src/main/java/uy/com/bay/utiles/views/gantt/StudyDetailsDialog.java
+++ b/src/main/java/uy/com/bay/utiles/views/gantt/StudyDetailsDialog.java
@@ -1,0 +1,65 @@
+package uy.com.bay.utiles.views.gantt;
+
+import com.vaadin.flow.component.checkbox.Checkbox;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.textfield.TextArea;
+import com.vaadin.flow.component.textfield.TextField;
+import uy.com.bay.utiles.data.Fieldwork;
+import uy.com.bay.utiles.data.Study;
+
+public class StudyDetailsDialog extends Dialog {
+
+    public StudyDetailsDialog(Study study) {
+        setHeaderTitle("Detalles del Estudio: " + study.getName());
+        setWidth("800px");
+
+        VerticalLayout layout = new VerticalLayout();
+        add(layout);
+
+        FormLayout formLayout = new FormLayout();
+        TextField name = new TextField("Name");
+        name.setValue(study.getName());
+        name.setReadOnly(true);
+
+        TextField odooId = new TextField("Odoo Id");
+        odooId.setValue(study.getOdooId());
+        odooId.setReadOnly(true);
+
+        TextArea obs = new TextArea("Observaciones");
+        obs.setValue(study.getObs());
+        obs.setReadOnly(true);
+
+        TextField casosCompletos = new TextField("Casos completos");
+        casosCompletos.setReadOnly(true);
+
+        Checkbox showSurveyor = new Checkbox("Mostrar a encuestador");
+        showSurveyor.setValue(study.isShowSurveyor());
+        showSurveyor.setReadOnly(true);
+
+        TextField totalTransfered = new TextField("Total de gastos transferidos");
+        totalTransfered.setValue(Double.valueOf(study.getTotalTransfered()).toString());
+        totalTransfered.setReadOnly(true);
+
+        TextField totalReportedCost = new TextField("Total de gastos rendidos");
+        totalReportedCost.setValue(Double.valueOf(study.getTotalReportedCost()).toString());
+        totalReportedCost.setReadOnly(true);
+
+        formLayout.add(name, odooId, obs, casosCompletos, showSurveyor, totalTransfered, totalReportedCost);
+        layout.add(formLayout);
+
+        Grid<Fieldwork> fieldworkGrid = new Grid<>(Fieldwork.class, false);
+        fieldworkGrid.addColumn("status").setHeader("Estado");
+        fieldworkGrid.addColumn("type").setHeader("Tipo");
+        fieldworkGrid.addColumn("initPlannedDate").setHeader("Fecha de inicio planificada");
+        fieldworkGrid.addColumn("endPlannedDate").setHeader("Fecha de fin planificada");
+        fieldworkGrid.addColumn("goalQuantity").setHeader("Cantidad objetivo");
+        fieldworkGrid.addColumn("completed").setHeader("Completado");
+        fieldworkGrid.setItems(study.getFieldworks());
+        fieldworkGrid.setAllRowsVisible(true);
+
+        layout.add(fieldworkGrid);
+    }
+}


### PR DESCRIPTION
- Refactored the `onGanttStepClick` method in `GanttView` to display a dialog with `Study` details when a `Study` step is clicked.
- The dialog includes a form with the `Study`'s properties and a grid of its associated `Fieldwork` entities.
- This change also involved downgrading the `gantt-flow-addon` to a compatible version and updating the `TreeGrid` creation accordingly.