### PR TITLE
feat: Add BudgetEntry entity

### DIFF
--- a/src/main/java/uy/com/bay/utiles/entities/BudgetEntry.java
+++ b/src/main/java/uy/com/bay/utiles/entities/BudgetEntry.java
@@ -1,0 +1,50 @@
+package uy.com.bay.utiles.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import uy.com.bay.utiles.data.AbstractEntity;
+
+@Entity
+public class BudgetEntry extends AbstractEntity {
+
+    private Double ammount;
+    private Integer quantity;
+    private Double spent;
+
+    @ManyToOne
+    @JoinColumn(name = "budget_concept_id")
+    private BudgetConcept concept;
+
+    public Double getAmmount() {
+        return ammount;
+    }
+
+    public void setAmmount(Double ammount) {
+        this.ammount = ammount;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Integer quantity) {
+        this.quantity = quantity;
+    }
+
+    public Double getSpent() {
+        return spent;
+    }
+
+    public void setSpent(Double spent) {
+        this.spent = spent;
+    }
+
+    public BudgetConcept getConcept() {
+        return concept;
+    }
+
+    public void setConcept(BudgetConcept concept) {
+        this.concept = concept;
+    }
+}


### PR DESCRIPTION
Adds the `BudgetEntry` entity with the following attributes:
- ammount (double)
- quantity (integer)
- spent (double)
- concept (ManyToOne relationship with BudgetConcept)

This entity will be used to store budget entry information.