### PR TITLE
feat: Add Budget entity, view, and form

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/BudgetRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/BudgetRepository.java
@@ -1,0 +1,10 @@
+package uy.com.bay.utiles.data.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import uy.com.bay.utiles.entities.Budget;
+
+public interface BudgetRepository extends JpaRepository<Budget, Long>, JpaSpecificationExecutor<Budget> {
+
+}

--- a/src/main/java/uy/com/bay/utiles/entities/Budget.java
+++ b/src/main/java/uy/com/bay/utiles/entities/Budget.java
@@ -1,0 +1,47 @@
+package uy.com.bay.utiles.entities;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import uy.com.bay.utiles.entities.BudgetEntry;
+
+@Entity
+public class Budget extends AbstractEntity {
+
+    private LocalDate created;
+
+    @OneToMany(mappedBy = "budget", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<BudgetEntry> entries;
+
+    @OneToOne
+    private Study study;
+
+    public LocalDate getCreated() {
+        return created;
+    }
+
+    public void setCreated(LocalDate created) {
+        this.created = created;
+    }
+
+    public List<BudgetEntry> getEntries() {
+        return entries;
+    }
+
+    public void setEntries(List<BudgetEntry> entries) {
+        this.entries = entries;
+    }
+
+    public Study getStudy() {
+        return study;
+    }
+
+    public void setStudy(Study study) {
+        this.study = study;
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/entities/BudgetEntry.java
+++ b/src/main/java/uy/com/bay/utiles/entities/BudgetEntry.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import uy.com.bay.utiles.data.AbstractEntity;
+import uy.com.bay.utiles.entities.Budget;
 
 @Entity
 public class BudgetEntry extends AbstractEntity {
@@ -15,6 +16,10 @@ public class BudgetEntry extends AbstractEntity {
     @ManyToOne
     @JoinColumn(name = "budget_concept_id")
     private BudgetConcept concept;
+
+    @ManyToOne
+    @JoinColumn(name = "budget_id")
+    private Budget budget;
 
     public Double getAmmount() {
         return ammount;
@@ -46,5 +51,13 @@ public class BudgetEntry extends AbstractEntity {
 
     public void setConcept(BudgetConcept concept) {
         this.concept = concept;
+    }
+
+    public Budget getBudget() {
+        return budget;
+    }
+
+    public void setBudget(Budget budget) {
+        this.budget = budget;
     }
 }

--- a/src/main/java/uy/com/bay/utiles/services/BudgetService.java
+++ b/src/main/java/uy/com/bay/utiles/services/BudgetService.java
@@ -1,0 +1,39 @@
+package uy.com.bay.utiles.services;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import uy.com.bay.utiles.entities.Budget;
+import uy.com.bay.utiles.data.repository.BudgetRepository;
+
+@Service
+public class BudgetService {
+
+    private final BudgetRepository repository;
+
+    public BudgetService(BudgetRepository repository) {
+        this.repository = repository;
+    }
+
+    public Optional<Budget> get(Long id) {
+        return repository.findById(id);
+    }
+
+    public Budget save(Budget entity) {
+        return repository.save(entity);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+
+    public Page<Budget> list(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+    public int count() {
+        return (int) repository.count();
+    }
+
+}

--- a/src/main/java/uy/com/bay/utiles/views/MainLayout.java
+++ b/src/main/java/uy/com/bay/utiles/views/MainLayout.java
@@ -162,6 +162,9 @@ public class MainLayout extends AppLayout {
 		SideNavItem budgetConceptsItem = new SideNavItem("Conceptos de presupuesto", "budget-concepts");
 		budgetConceptsItem.setPrefixComponent(new Icon("vaadin", "list"));
 		presupuestosItem.addItem(budgetConceptsItem);
+		SideNavItem crearPresupuestoItem = new SideNavItem("Crear", "budgets");
+		crearPresupuestoItem.setPrefixComponent(new Icon("vaadin", "plus"));
+		presupuestosItem.addItem(crearPresupuestoItem);
 		nav.addItem(presupuestosItem);
 
 		SideNavItem surveyorPortalItem = new SideNavItem("Portal Encuestador");

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
@@ -1,0 +1,207 @@
+package uy.com.bay.utiles.views.budget;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.editor.Editor;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.component.textfield.NumberField;
+import com.vaadin.flow.data.binder.BeanValidationBinder;
+import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.shared.Registration;
+import uy.com.bay.utiles.data.Study;
+import uy.com.bay.utiles.entities.Budget;
+import uy.com.bay.utiles.entities.BudgetConcept;
+import uy.com.bay.utiles.entities.BudgetEntry;
+import uy.com.bay.utiles.services.BudgetConceptService;
+import uy.com.bay.utiles.services.StudyService;
+
+import java.util.ArrayList;
+
+public class BudgetForm extends VerticalLayout {
+
+    private final DatePicker created = new DatePicker("Fecha de Creación");
+    private final ComboBox<Study> study = new ComboBox<>("Estudio");
+    private final Grid<BudgetEntry> entriesGrid = new Grid<>(BudgetEntry.class);
+    private final Button addEntryButton = new Button("Agregar Renglón");
+
+    private final Button save = new Button("Guardar");
+    private final Button delete = new Button("Borrar");
+    private final Button close = new Button("Cerrar");
+
+    private final Binder<Budget> binder = new BeanValidationBinder<>(Budget.class);
+    private final BudgetConceptService budgetConceptService;
+    private final Editor<BudgetEntry> editor;
+
+    public BudgetForm(StudyService studyService, BudgetConceptService budgetConceptService) {
+        this.budgetConceptService = budgetConceptService;
+
+        addClassName("budget-form");
+        binder.bindInstanceFields(this);
+
+        study.setItems(studyService.listAll());
+        study.setItemLabelGenerator(Study::getName);
+
+        editor = entriesGrid.getEditor();
+        configureGrid();
+
+        add(createFormLayout(), entriesGrid, addEntryButton, createButtonsLayout());
+
+        addEntryButton.addClickListener(click -> {
+            BudgetEntry newEntry = new BudgetEntry();
+            if (binder.getBean().getEntries() == null) {
+                binder.getBean().setEntries(new ArrayList<>());
+            }
+            binder.getBean().getEntries().add(newEntry);
+            entriesGrid.setItems(binder.getBean().getEntries());
+            editor.editItem(newEntry);
+        });
+    }
+
+    private Component createFormLayout() {
+        FormLayout formLayout = new FormLayout();
+        formLayout.add(created, study);
+        return formLayout;
+    }
+
+    private void configureGrid() {
+        entriesGrid.setColumns(); // Clear existing columns
+
+        Binder<BudgetEntry> entryBinder = new Binder<>(BudgetEntry.class);
+        editor.setBinder(entryBinder);
+        editor.setBuffered(true);
+
+        // Amount Column
+        NumberField ammountField = new NumberField();
+        ammountField.setWidthFull();
+        entryBinder.forField(ammountField).bind(BudgetEntry::getAmmount, BudgetEntry::setAmmount);
+        entriesGrid.addColumn(BudgetEntry::getAmmount)
+                .setHeader("Monto").setEditorComponent(ammountField);
+
+        // Quantity Column
+        IntegerField quantityField = new IntegerField();
+        quantityField.setWidthFull();
+        entryBinder.forField(quantityField).bind(BudgetEntry::getQuantity, BudgetEntry::setQuantity);
+        entriesGrid.addColumn(BudgetEntry::getQuantity)
+                .setHeader("Cantidad").setEditorComponent(quantityField);
+
+        // Concept Column
+        ComboBox<BudgetConcept> conceptComboBox = new ComboBox<>();
+        conceptComboBox.setItems(budgetConceptService.findAll());
+        conceptComboBox.setItemLabelGenerator(BudgetConcept::getName);
+        entryBinder.forField(conceptComboBox).bind(BudgetEntry::getConcept, BudgetEntry::setConcept);
+        entriesGrid.addColumn(entry -> entry.getConcept() != null ? entry.getConcept().getName() : "")
+                .setHeader("Concepto").setEditorComponent(conceptComboBox);
+
+        // Edit Column
+        Button saveButton = new Button("Guardar", e -> editor.save());
+        Button cancelButton = new Button("Cancelar", e -> editor.cancel());
+        HorizontalLayout actions = new HorizontalLayout(saveButton, cancelButton);
+        actions.setPadding(false);
+
+        Grid.Column<BudgetEntry> editorColumn = entriesGrid.addComponentColumn(entry -> {
+            Button editButton = new Button("Editar");
+            editButton.addClickListener(e -> {
+                if (editor.isOpen()) {
+                    editor.cancel();
+                }
+                entriesGrid.getEditor().editItem(entry);
+            });
+            return editButton;
+        }).setWidth("150px").setFlexGrow(0);
+
+        editorColumn.setEditorComponent(actions);
+
+        // Remove Column
+        entriesGrid.addComponentColumn(entry -> {
+            Button removeButton = new Button("Borrar");
+            removeButton.addClickListener(e -> {
+                if (binder.getBean().getEntries() != null) {
+                    binder.getBean().getEntries().remove(entry);
+                    entriesGrid.setItems(binder.getBean().getEntries());
+                }
+            });
+            return removeButton;
+        }).setWidth("150px").setFlexGrow(0);
+    }
+
+    private Component createButtonsLayout() {
+        save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        delete.addThemeVariants(ButtonVariant.LUMO_ERROR);
+        close.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+
+        save.addClickListener(event -> validateAndSave());
+        delete.addClickListener(event -> fireEvent(new DeleteEvent(this, binder.getBean())));
+        close.addClickListener(event -> fireEvent(new CloseEvent(this)));
+
+        binder.addStatusChangeListener(e -> save.setEnabled(binder.isValid()));
+        return new HorizontalLayout(save, delete, close);
+    }
+
+    private void validateAndSave() {
+        if (binder.isValid()) {
+            fireEvent(new SaveEvent(this, binder.getBean()));
+        }
+    }
+
+    public void setBudget(Budget budget) {
+        binder.setBean(budget);
+        if (budget != null && budget.getEntries() != null) {
+            entriesGrid.setItems(budget.getEntries());
+        } else if (budget != null) {
+            budget.setEntries(new ArrayList<>());
+            entriesGrid.setItems(budget.getEntries());
+        }
+    }
+
+    // Events
+    public static abstract class BudgetFormEvent extends com.vaadin.flow.component.ComponentEvent<BudgetForm> {
+        private final Budget budget;
+
+        protected BudgetFormEvent(BudgetForm source, Budget budget) {
+            super(source, false);
+            this.budget = budget;
+        }
+
+        public Budget getBudget() {
+            return budget;
+        }
+    }
+
+    public static class SaveEvent extends BudgetFormEvent {
+        SaveEvent(BudgetForm source, Budget budget) {
+            super(source, budget);
+        }
+    }
+
+    public static class DeleteEvent extends BudgetFormEvent {
+        DeleteEvent(BudgetForm source, Budget budget) {
+            super(source, budget);
+        }
+    }
+
+    public static class CloseEvent extends BudgetFormEvent {
+        CloseEvent(BudgetForm source) {
+            super(source, null);
+        }
+    }
+
+    public Registration addDeleteListener(ComponentEventListener<DeleteEvent> listener) {
+        return addListener(DeleteEvent.class, listener);
+    }
+
+    public Registration addSaveListener(ComponentEventListener<SaveEvent> listener) {
+        return addListener(SaveEvent.class, listener);
+    }
+
+    public Registration addCloseListener(ComponentEventListener<CloseEvent> listener) {
+        return addListener(CloseEvent.class, listener);
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
@@ -1,0 +1,114 @@
+package uy.com.bay.utiles.views.budget;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import jakarta.annotation.security.RolesAllowed;
+import org.springframework.data.domain.Pageable;
+import uy.com.bay.utiles.entities.Budget;
+import uy.com.bay.utiles.services.BudgetConceptService;
+import uy.com.bay.utiles.services.BudgetService;
+import uy.com.bay.utiles.services.StudyService;
+import uy.com.bay.utiles.views.MainLayout;
+
+@PageTitle("Presupuestos")
+@Route(value = "budgets", layout = MainLayout.class)
+@RolesAllowed("ADMIN")
+public class BudgetView extends VerticalLayout {
+
+    private final Grid<Budget> grid = new Grid<>(Budget.class);
+    private final BudgetForm form;
+    private final BudgetService budgetService;
+
+    public BudgetView(BudgetService budgetService, StudyService studyService, BudgetConceptService budgetConceptService) {
+        this.budgetService = budgetService;
+        addClassName("budget-view");
+        setSizeFull();
+        configureGrid();
+
+        form = new BudgetForm(studyService, budgetConceptService);
+        form.addSaveListener(this::saveBudget);
+        form.addDeleteListener(this::deleteBudget);
+        form.addCloseListener(e -> closeEditor());
+
+        Component content = getContent();
+        add(getToolbar(), content);
+        updateList();
+        closeEditor();
+    }
+
+    private Component getContent() {
+        HorizontalLayout content = new HorizontalLayout(grid, form);
+        content.setFlexGrow(2, grid);
+        content.setFlexGrow(1, form);
+        content.addClassNames("content");
+        content.setSizeFull();
+        return content;
+    }
+
+    private void configureGrid() {
+        grid.addClassNames("budget-grid");
+        grid.setSizeFull();
+        grid.setColumns("created");
+        grid.addColumn(budget -> budget.getStudy() == null ? "" : budget.getStudy().getName()).setHeader("Estudio");
+        grid.getColumns().forEach(col -> col.setAutoWidth(true));
+        grid.asSingleSelect().addValueChangeListener(event -> editBudget(event.getValue()));
+    }
+
+    private Component getToolbar() {
+        Button addBudgetButton = new Button("Crear");
+        addBudgetButton.addClickListener(click -> addBudget());
+
+        HorizontalLayout toolbar = new HorizontalLayout(addBudgetButton);
+        toolbar.addClassName("toolbar");
+        return toolbar;
+    }
+
+    public void editBudget(Budget budget) {
+        if (budget == null) {
+            closeEditor();
+        } else {
+            form.setBudget(budget);
+            form.setVisible(true);
+            addClassName("editing");
+        }
+    }
+
+    private void closeEditor() {
+        form.setBudget(null);
+        form.setVisible(false);
+        removeClassName("editing");
+    }
+
+    private void addBudget() {
+        grid.asSingleSelect().clear();
+        Budget newBudget = new Budget();
+        newBudget.setEntries(new java.util.ArrayList<>());
+        newBudget.setCreated(java.time.LocalDate.now());
+        editBudget(newBudget);
+    }
+
+    private void saveBudget(BudgetForm.SaveEvent event) {
+        Budget budget = event.getBudget();
+        if (budget.getEntries() != null) {
+            budget.getEntries().forEach(entry -> entry.setBudget(budget));
+        }
+        budgetService.save(budget);
+        updateList();
+        closeEditor();
+    }
+
+    private void deleteBudget(BudgetForm.DeleteEvent event) {
+        budgetService.delete(event.getBudget().getId());
+        updateList();
+        closeEditor();
+    }
+
+    private void updateList() {
+        grid.setItems(budgetService.list(Pageable.unpaged()));
+    }
+}


### PR DESCRIPTION
This commit introduces a new "Budget" feature, which includes:

- A `Budget` entity with a one-to-one relationship to `Study` and a one-to-many relationship to `BudgetEntry`.
- A `BudgetView` to display a grid of `Budget` entities and a form for creating, editing, and deleting them.
- A `BudgetForm` that includes a nested, editable grid for managing `BudgetEntry` items.
- A new "Presupuestos" > "Crear" navigation link in the main layout to access the `BudgetView`.