### PR TITLE
Fix LazyInitializationException in Budget view

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/BudgetRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/BudgetRepository.java
@@ -1,10 +1,16 @@
 package uy.com.bay.utiles.data.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 
 import uy.com.bay.utiles.entities.Budget;
 
 public interface BudgetRepository extends JpaRepository<Budget, Long>, JpaSpecificationExecutor<Budget> {
+
+	@Query(value = "select b from Budget b left join fetch b.entries", countQuery = "select count(b) from Budget b")
+	Page<Budget> findAllWithEntries(Pageable pageable);
 
 }

--- a/src/main/java/uy/com/bay/utiles/services/BudgetService.java
+++ b/src/main/java/uy/com/bay/utiles/services/BudgetService.java
@@ -29,7 +29,7 @@ public class BudgetService {
     }
 
     public Page<Budget> list(Pageable pageable) {
-        return repository.findAll(pageable);
+        return repository.findAllWithEntries(pageable);
     }
 
     public int count() {


### PR DESCRIPTION
Resolves a `LazyInitializationException` that occurred when accessing the `entries` collection of the `Budget` entity in the Vaadin view.

The issue was caused by the collection being lazily loaded, and the Hibernate session being closed before the view could access the data.

The fix involves the following changes:
- Added a `findAllWithEntries(Pageable pageable)` method to `BudgetRepository` that uses a `@Query` with `JOIN FETCH` to eagerly load the `entries` collection.
- Included a `countQuery` in the annotation to ensure pagination works correctly with the `JOIN FETCH`.
- Updated `BudgetService` to use this new repository method, providing fully initialized `Budget` objects to the view layer while maintaining correct pagination.