### PR TITLE
Feat: Model bidirectional one-to-one relationship between Study and B…

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/Study.java
+++ b/src/main/java/uy/com/bay/utiles/data/Study.java
@@ -4,10 +4,15 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import java.util.List;
+import uy.com.bay.utiles.entities.Budget;
 
 @Entity
 public class Study extends AbstractEntity {
+
+	@OneToOne(mappedBy = "study")
+	private Budget budget;
 
 	@OneToMany(mappedBy = "study", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
 	private List<Fieldwork> fieldworks;
@@ -75,5 +80,13 @@ public class Study extends AbstractEntity {
 
 	public void setFieldworks(List<Fieldwork> fieldworks) {
 		this.fieldworks = fieldworks;
+	}
+
+	public Budget getBudget() {
+		return budget;
+	}
+
+	public void setBudget(Budget budget) {
+		this.budget = budget;
 	}
 }


### PR DESCRIPTION
…udget

Adds the `budget` attribute to the `Study` entity to establish a bidirectional one-to-one relationship with the `Budget` entity.

The `Budget` entity already had a `study` attribute with a `@OneToOne` relationship. This change adds the corresponding `@OneToOne(mappedBy = "study")` annotation to the `Study` entity, making the relationship bidirectional.