### PR TITLE
Refactor Study form to add 'View Budget' button

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
@@ -7,10 +7,13 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 
 import jakarta.annotation.security.RolesAllowed;
+import java.util.Optional;
 import uy.com.bay.utiles.entities.Budget;
 import uy.com.bay.utiles.services.BudgetConceptService;
 import uy.com.bay.utiles.services.BudgetService;
@@ -18,10 +21,11 @@ import uy.com.bay.utiles.services.StudyService;
 import uy.com.bay.utiles.views.MainLayout;
 
 @PageTitle("Presupuestos")
-@Route(value = "budgets", layout = MainLayout.class)
+@Route(value = "budgets/:budgetID?/:action?(edit)", layout = MainLayout.class)
 @RolesAllowed("ADMIN")
-public class BudgetView extends VerticalLayout {
+public class BudgetView extends VerticalLayout implements BeforeEnterObserver {
 
+	private final String BUDGET_ID = "budgetID";
 	private final Grid<Budget> grid = new Grid<>(Budget.class);
 	private final BudgetForm form;
 	private final BudgetService budgetService;
@@ -42,6 +46,17 @@ public class BudgetView extends VerticalLayout {
 		add(getToolbar(), content);
 		updateList();
 		closeEditor();
+	}
+
+	@Override
+	public void beforeEnter(BeforeEnterEvent event) {
+		Optional<Long> budgetId = event.getRouteParameters().get(BUDGET_ID).map(Long::parseLong);
+		if (budgetId.isPresent()) {
+			Optional<Budget> budgetFromBackend = budgetService.get(budgetId.get());
+			if (budgetFromBackend.isPresent()) {
+				editBudget(budgetFromBackend.get());
+			}
+		}
 	}
 
 	private Component getContent() {

--- a/src/main/java/uy/com/bay/utiles/views/proyectos/ProyectosView.java
+++ b/src/main/java/uy/com/bay/utiles/views/proyectos/ProyectosView.java
@@ -75,6 +75,7 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 	private Button deleteButton; // Added deleteButton declaration
 	private Button viewMovementsButton;
 	private Button viewFieldworksButton;
+	private Button viewBudgetButton;
 
 	private final BeanValidationBinder<Study> binder;
 
@@ -121,6 +122,9 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 
 		viewFieldworksButton = new Button("Ver solicitudes de campo");
 		viewFieldworksButton.setEnabled(false);
+
+		viewBudgetButton = new Button("Ver presupuesto");
+		viewBudgetButton.setEnabled(false);
 
 		nameFilter = new TextField();
 		nameFilter.setPlaceholder("Nombre...");
@@ -269,6 +273,12 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 				dialog.open();
 			}
 		});
+
+		viewBudgetButton.addClickListener(e -> {
+			if (this.proyecto != null && this.proyecto.getBudget() != null) {
+				UI.getCurrent().navigate("budgets/" + this.proyecto.getBudget().getId() + "/edit");
+			}
+		});
 	}
 
 	@Override
@@ -325,7 +335,7 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 		buttonLayout.setClassName("button-layout");
 		cancel.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
 		save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
-		buttonLayout.add(save, deleteButton, cancel);
+		buttonLayout.add(save, deleteButton, cancel, viewBudgetButton);
 		editorLayoutDiv.add(buttonLayout);
 	}
 
@@ -379,6 +389,9 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 		}
 		if (this.viewFieldworksButton != null) {
 			this.viewFieldworksButton.setEnabled(value != null && value.getId() != null);
+		}
+		if (this.viewBudgetButton != null) {
+			this.viewBudgetButton.setEnabled(value != null && value.getBudget() != null);
 		}
 	}
 }


### PR DESCRIPTION
- Adds a "Ver presupuesto" button to the Study entity's edit form in `ProyectosView`.
- The button is enabled only when the Study has an associated budget.
- Updates `BudgetView` to handle direct navigation to the edit form via a URL parameter (`/budgets/:id/edit`).
- Clicking the button navigates the user to the `BudgetView` to edit the corresponding budget.