### PR TITLE
Fix LazyInitializationException when editing a Budget

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/BudgetRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/BudgetRepository.java
@@ -1,10 +1,13 @@
 package uy.com.bay.utiles.data.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import uy.com.bay.utiles.entities.Budget;
 
@@ -12,5 +15,8 @@ public interface BudgetRepository extends JpaRepository<Budget, Long>, JpaSpecif
 
 	@Query(value = "select b from Budget b left join fetch b.entries", countQuery = "select count(b) from Budget b")
 	Page<Budget> findAllWithEntries(Pageable pageable);
+
+	@Query("select b from Budget b left join fetch b.entries where b.id = :id")
+	Optional<Budget> findByIdWithEntries(@Param("id") Long id);
 
 }

--- a/src/main/java/uy/com/bay/utiles/services/BudgetService.java
+++ b/src/main/java/uy/com/bay/utiles/services/BudgetService.java
@@ -18,7 +18,7 @@ public class BudgetService {
 	}
 
 	public Optional<Budget> get(Long id) {
-		return repository.findById(id);
+		return repository.findByIdWithEntries(id);
 	}
 
 	public Budget save(Budget entity) {


### PR DESCRIPTION
A `LazyInitializationException` was occurring when navigating to the budget edit view because the `entries` collection of the `Budget` entity was being accessed after the Hibernate session was closed.

This commit resolves the issue by using a `JOIN FETCH` query in the `BudgetRepository` to eagerly load the `entries` collection along with the `Budget` entity. The `BudgetService` has been updated to use this new repository method, ensuring the collection is available to the Vaadin view layer.