### PR TITLE
Refactor SupervisionTasksView performance

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/SupervisionTaskRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/SupervisionTaskRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 
 import uy.com.bay.utiles.data.Status;
 import uy.com.bay.utiles.data.SupervisionTask;
+import jakarta.persistence.Tuple;
 
 @Repository
 public interface SupervisionTaskRepository extends JpaRepository<SupervisionTask, Long> {
@@ -22,4 +23,16 @@ public interface SupervisionTaskRepository extends JpaRepository<SupervisionTask
             "ORDER BY st.created DESC")
     List<SupervisionTask> findByCreatedBetweenOrderByCreatedDesc(@Param("from") Date from, @Param("to") Date to,
                                                                  @Param("fileName") String fileName, @Param("status") Status status);
+
+    @Query("SELECT st.id as id, st.fileName as fileName, st.status as status, st.aiScore as aiScore, " +
+           "st.totalAudioDuration as totalAudioDuration, st.speakingDuration as speakingDuration, " +
+           "st.created as created, st.output as output, st.evaluationOutput as evaluationOutput, " +
+           "KEY(d) as speaker, VALUE(d) as duration " +
+           "FROM SupervisionTask st LEFT JOIN st.durationBySpeakers d " +
+           "WHERE st.created BETWEEN :from AND :to " +
+           "AND (:fileName IS NULL OR :fileName = '' OR lower(st.fileName) LIKE lower(concat('%', :fileName, '%'))) " +
+           "AND (:status IS NULL OR st.status = :status) " +
+           "ORDER BY st.created DESC")
+    List<Tuple> findTuplesByCreatedBetweenOrderByCreatedDesc(@Param("from") Date from, @Param("to") Date to,
+                                                             @Param("fileName") String fileName, @Param("status") Status status);
 }

--- a/src/main/java/uy/com/bay/utiles/data/service/SupervisionTaskService.java
+++ b/src/main/java/uy/com/bay/utiles/data/service/SupervisionTaskService.java
@@ -1,12 +1,17 @@
 package uy.com.bay.utiles.data.service;
 
+import jakarta.persistence.Tuple;
 import org.springframework.stereotype.Service;
 import uy.com.bay.utiles.data.Status;
 import uy.com.bay.utiles.data.SupervisionTask;
 import uy.com.bay.utiles.data.repository.SupervisionTaskRepository;
+import uy.com.bay.utiles.dto.SupervisionTaskDTO;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class SupervisionTaskService {
@@ -21,6 +26,42 @@ public class SupervisionTaskService {
 			Status status) {
 		return repository.findByCreatedBetweenOrderByCreatedDesc(from, to, fileName, status);
 	}
+
+    public List<SupervisionTaskDTO> findDTOByCreatedBetweenAndFileNameAndStatus(Date from, Date to, String fileName,
+			Status status) {
+        List<Tuple> tuples = repository.findTuplesByCreatedBetweenOrderByCreatedDesc(from, to, fileName, status);
+        Map<Long, SupervisionTaskDTO> dtoMap = new LinkedHashMap<>();
+
+        for (Tuple t : tuples) {
+            Long id = t.get("id", Long.class);
+            SupervisionTaskDTO dto = dtoMap.computeIfAbsent(id, k -> {
+                String fName = t.get("fileName", String.class);
+                Status st = t.get("status", Status.class);
+                Double aiScoreVal = t.get("aiScore", Double.class);
+                double aiScore = aiScoreVal != null ? aiScoreVal : 0.0;
+
+                Double totalDurationVal = t.get("totalAudioDuration", Double.class);
+                double totalDuration = totalDurationVal != null ? totalDurationVal : 0.0;
+
+                Double speakingDurationVal = t.get("speakingDuration", Double.class);
+                double speakingDuration = speakingDurationVal != null ? speakingDurationVal : 0.0;
+
+                Date created = t.get("created", Date.class);
+                String output = t.get("output", String.class);
+                String evaluationOutput = t.get("evaluationOutput", String.class);
+
+                return new SupervisionTaskDTO(id, fName, st, aiScore, totalDuration, speakingDuration, created, output, evaluationOutput);
+            });
+
+            String speaker = t.get("speaker", String.class);
+            Double duration = t.get("duration", Double.class);
+            if (speaker != null) {
+                dto.getDurationBySpeakers().put(speaker, duration);
+            }
+        }
+        return new ArrayList<>(dtoMap.values());
+    }
+
     public void saveAll(List<SupervisionTask> tasks) {
         repository.saveAll(tasks);
     }

--- a/src/main/java/uy/com/bay/utiles/dto/SupervisionTaskDTO.java
+++ b/src/main/java/uy/com/bay/utiles/dto/SupervisionTaskDTO.java
@@ -1,0 +1,117 @@
+package uy.com.bay.utiles.dto;
+
+import uy.com.bay.utiles.data.Status;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SupervisionTaskDTO {
+
+    private Long id;
+    private String fileName;
+    private Status status;
+    private double aiScore;
+    private double totalAudioDuration;
+    private double speakingDuration;
+    private Map<String, Double> durationBySpeakers = new HashMap<>();
+    private Date created;
+    private String output;
+    private String evaluationOutput;
+
+    public SupervisionTaskDTO() {
+    }
+
+    public SupervisionTaskDTO(Long id, String fileName, Status status, double aiScore,
+                              double totalAudioDuration, double speakingDuration,
+                              Date created, String output, String evaluationOutput) {
+        this.id = id;
+        this.fileName = fileName;
+        this.status = status;
+        this.aiScore = aiScore;
+        this.totalAudioDuration = totalAudioDuration;
+        this.speakingDuration = speakingDuration;
+        this.created = created;
+        this.output = output;
+        this.evaluationOutput = evaluationOutput;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public double getAiScore() {
+        return aiScore;
+    }
+
+    public void setAiScore(double aiScore) {
+        this.aiScore = aiScore;
+    }
+
+    public double getTotalAudioDuration() {
+        return totalAudioDuration;
+    }
+
+    public void setTotalAudioDuration(double totalAudioDuration) {
+        this.totalAudioDuration = totalAudioDuration;
+    }
+
+    public double getSpeakingDuration() {
+        return speakingDuration;
+    }
+
+    public void setSpeakingDuration(double speakingDuration) {
+        this.speakingDuration = speakingDuration;
+    }
+
+    public Map<String, Double> getDurationBySpeakers() {
+        return durationBySpeakers;
+    }
+
+    public void setDurationBySpeakers(Map<String, Double> durationBySpeakers) {
+        this.durationBySpeakers = durationBySpeakers;
+    }
+
+    public Date getCreated() {
+        return created;
+    }
+
+    public void setCreated(Date created) {
+        this.created = created;
+    }
+
+    public String getOutput() {
+        return output;
+    }
+
+    public void setOutput(String output) {
+        this.output = output;
+    }
+
+    public String getEvaluationOutput() {
+        return evaluationOutput;
+    }
+
+    public void setEvaluationOutput(String evaluationOutput) {
+        this.evaluationOutput = evaluationOutput;
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/services/WordExportService.java
+++ b/src/main/java/uy/com/bay/utiles/services/WordExportService.java
@@ -6,6 +6,7 @@ import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.apache.poi.xwpf.usermodel.XWPFRun;
 import org.springframework.stereotype.Service;
 import uy.com.bay.utiles.data.SupervisionTask;
+import uy.com.bay.utiles.dto.SupervisionTaskDTO;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -15,6 +16,14 @@ import java.io.IOException;
 public class WordExportService {
 
     public ByteArrayInputStream generateSupervisionTaskReport(SupervisionTask task) {
+        return generateReport(task.getFileName(), task.getEvaluationOutput(), task.getOutput());
+    }
+
+    public ByteArrayInputStream generateSupervisionTaskReport(SupervisionTaskDTO task) {
+        return generateReport(task.getFileName(), task.getEvaluationOutput(), task.getOutput());
+    }
+
+    private ByteArrayInputStream generateReport(String fileName, String evaluationOutput, String output) {
         try (XWPFDocument document = new XWPFDocument();
              ByteArrayOutputStream out = new ByteArrayOutputStream()) {
 
@@ -28,13 +37,13 @@ public class WordExportService {
             titleRun.addBreak();
 
             // Evaluation Output Section
-            addSection(document, "Archivo evaluado", task.getFileName());
-            
+            addSection(document, "Archivo evaluado", fileName);
+
             // Evaluation Output Section
-            addSection(document, "Resultado de Evaluación", task.getEvaluationOutput());
+            addSection(document, "Resultado de Evaluación", evaluationOutput);
 
             // Output Section
-            addSection(document, "Output", task.getOutput());
+            addSection(document, "Output", output);
 
             document.write(out);
             return new ByteArrayInputStream(out.toByteArray());

--- a/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionTasksView.java
+++ b/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionTasksView.java
@@ -22,8 +22,8 @@ import com.vaadin.flow.server.StreamResource;
 
 import jakarta.annotation.security.RolesAllowed;
 import uy.com.bay.utiles.data.Status;
-import uy.com.bay.utiles.data.SupervisionTask;
 import uy.com.bay.utiles.data.service.SupervisionTaskService;
+import uy.com.bay.utiles.dto.SupervisionTaskDTO;
 import uy.com.bay.utiles.services.WordExportService;
 import uy.com.bay.utiles.views.MainLayout;
 
@@ -37,7 +37,7 @@ public class SupervisionTasksView extends VerticalLayout {
 
 	private final DatePicker fromDateField = new DatePicker("Desde:");
 	private final DatePicker toDateField = new DatePicker("Hasta:");
-	private final Grid<SupervisionTask> grid = new Grid<>(SupervisionTask.class, false);
+	private final Grid<SupervisionTaskDTO> grid = new Grid<>(SupervisionTaskDTO.class, false);
 	private final TextField fileNameFilter = new TextField();
 	private final ComboBox<Status> statusFilter = new ComboBox<>();
 
@@ -54,11 +54,11 @@ public class SupervisionTasksView extends VerticalLayout {
 
 	private void configureGrid() {
 		grid.setSizeFull();
-		Grid.Column<SupervisionTask> fileNameColumn = grid.addColumn(SupervisionTask::getFileName).setHeader("Archivo");
-		Grid.Column<SupervisionTask> statusColumn = grid.addColumn(SupervisionTask::getStatus).setHeader("Estado");
-		grid.addColumn(SupervisionTask::getAiScore).setHeader("Scoring");
-		grid.addColumn(SupervisionTask::getTotalAudioDuration).setHeader("Duración del audio");
-		grid.addColumn(SupervisionTask::getSpeakingDuration).setHeader("Duración hablando");
+		Grid.Column<SupervisionTaskDTO> fileNameColumn = grid.addColumn(SupervisionTaskDTO::getFileName).setHeader("Archivo");
+		Grid.Column<SupervisionTaskDTO> statusColumn = grid.addColumn(SupervisionTaskDTO::getStatus).setHeader("Estado");
+		grid.addColumn(SupervisionTaskDTO::getAiScore).setHeader("Scoring");
+		grid.addColumn(SupervisionTaskDTO::getTotalAudioDuration).setHeader("Duración del audio");
+		grid.addColumn(SupervisionTaskDTO::getSpeakingDuration).setHeader("Duración hablando");
 		grid.addColumn(task -> {
 			Map<String, Double> speakers = task.getDurationBySpeakers();
 			if (speakers != null) {
@@ -119,7 +119,7 @@ public class SupervisionTasksView extends VerticalLayout {
 
 		Date to = Date.from(toDateField.getValue().atStartOfDay(ZoneId.systemDefault()).toInstant());
 		if (from != null && to != null) {
-			grid.setItems(supervisionTaskService.findByCreatedBetweenAndFileNameAndStatus(from, to,
+			grid.setItems(supervisionTaskService.findDTOByCreatedBetweenAndFileNameAndStatus(from, to,
 					fileNameFilter.getValue(), statusFilter.getValue()));
 		}
 	}

--- a/src/test/java/uy/com/bay/utiles/data/service/SupervisionTaskServiceTest.java
+++ b/src/test/java/uy/com/bay/utiles/data/service/SupervisionTaskServiceTest.java
@@ -1,0 +1,84 @@
+package uy.com.bay.utiles.data.service;
+
+import jakarta.persistence.Tuple;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uy.com.bay.utiles.data.Status;
+import uy.com.bay.utiles.data.repository.SupervisionTaskRepository;
+import uy.com.bay.utiles.dto.SupervisionTaskDTO;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SupervisionTaskServiceTest {
+
+    @Mock
+    private SupervisionTaskRepository repository;
+
+    private SupervisionTaskService service;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        service = new SupervisionTaskService(repository);
+    }
+
+    @Test
+    void testFindDTOByCreatedBetweenAndFileNameAndStatus() {
+        // Mock Tuple 1 (Speaker 1)
+        Tuple tuple1 = mock(Tuple.class);
+        when(tuple1.get("id", Long.class)).thenReturn(1L);
+        when(tuple1.get("fileName", String.class)).thenReturn("file1.mp3");
+        when(tuple1.get("status", Status.class)).thenReturn(Status.DONE);
+        when(tuple1.get("aiScore", Double.class)).thenReturn(0.85);
+        when(tuple1.get("totalAudioDuration", Double.class)).thenReturn(100.0);
+        when(tuple1.get("speakingDuration", Double.class)).thenReturn(80.0);
+        when(tuple1.get("created", Date.class)).thenReturn(new Date());
+        when(tuple1.get("output", String.class)).thenReturn("Output");
+        when(tuple1.get("evaluationOutput", String.class)).thenReturn("Eval");
+        when(tuple1.get("speaker", String.class)).thenReturn("Speaker1");
+        when(tuple1.get("duration", Double.class)).thenReturn(50.0);
+
+        // Mock Tuple 2 (Speaker 2 for same task)
+        Tuple tuple2 = mock(Tuple.class);
+        when(tuple2.get("id", Long.class)).thenReturn(1L);
+        when(tuple2.get("fileName", String.class)).thenReturn("file1.mp3");
+        when(tuple2.get("status", Status.class)).thenReturn(Status.DONE);
+        when(tuple2.get("aiScore", Double.class)).thenReturn(0.85);
+        when(tuple2.get("totalAudioDuration", Double.class)).thenReturn(100.0);
+        when(tuple2.get("speakingDuration", Double.class)).thenReturn(80.0);
+        when(tuple2.get("created", Date.class)).thenReturn(new Date());
+        when(tuple2.get("output", String.class)).thenReturn("Output");
+        when(tuple2.get("evaluationOutput", String.class)).thenReturn("Eval");
+        when(tuple2.get("speaker", String.class)).thenReturn("Speaker2");
+        when(tuple2.get("duration", Double.class)).thenReturn(30.0);
+
+        when(repository.findTuplesByCreatedBetweenOrderByCreatedDesc(any(), any(), any(), any()))
+                .thenReturn(Arrays.asList(tuple1, tuple2));
+
+        List<SupervisionTaskDTO> results = service.findDTOByCreatedBetweenAndFileNameAndStatus(new Date(), new Date(), null, null);
+
+        assertEquals(1, results.size());
+        SupervisionTaskDTO dto = results.get(0);
+        assertEquals(1L, dto.getId());
+        assertEquals("file1.mp3", dto.getFileName());
+        assertEquals(Status.DONE, dto.getStatus());
+        assertEquals(0.85, dto.getAiScore());
+        assertEquals(100.0, dto.getTotalAudioDuration());
+        assertEquals(80.0, dto.getSpeakingDuration());
+        assertEquals("Output", dto.getOutput());
+        assertEquals("Eval", dto.getEvaluationOutput());
+
+        assertEquals(2, dto.getDurationBySpeakers().size());
+        assertEquals(50.0, dto.getDurationBySpeakers().get("Speaker1"));
+        assertEquals(30.0, dto.getDurationBySpeakers().get("Speaker2"));
+    }
+}


### PR DESCRIPTION
Introduced `SupervisionTaskDTO` to fetch only necessary fields for `SupervisionTasksView`.
Added `findDTOByCreatedBetweenAndFileNameAndStatus` in `SupervisionTaskService` and corresponding repository method returning `Tuple`.
Updated `WordExportService` to support report generation from `SupervisionTaskDTO`.
Refactored `SupervisionTasksView` to use `SupervisionTaskDTO`.
Added unit test for `SupervisionTaskService`.

---
*PR created automatically by Jules for task [3989381273386705721](https://jules.google.com/task/3989381273386705721) started by @araujomelogno*