### PR TITLE
Refactor OpenAiService for Audio Chunking

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/OpenAiService.java
+++ b/src/main/java/uy/com/bay/utiles/services/OpenAiService.java
@@ -1,8 +1,22 @@
 package uy.com.bay.utiles.services;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 
+import javax.sound.sampled.AudioFileFormat;
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.UnsupportedAudioFileException;
+
+import org.jaudiotagger.audio.AudioFileIO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpEntity;
@@ -15,15 +29,29 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import uy.com.bay.utiles.dto.AudioFile;
 
 @Service
 public class OpenAiService {
 
+	private static final Logger logger = LoggerFactory.getLogger(OpenAiService.class);
+
 	@Value("${spring.ai.openai.api-key}")
 	private String openaiApiKey;
 
 	private static final String OPENAI_API_URL = "https://api.openai.com/v1/audio/transcriptions";
+
+	private final ObjectMapper objectMapper;
+
+	@Autowired
+	public OpenAiService(ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
+	}
 
 	private RestTemplate buildRestTemplate() {
 		HttpComponentsClientHttpRequestFactory rf = new HttpComponentsClientHttpRequestFactory();
@@ -33,7 +61,17 @@ public class OpenAiService {
 		return new RestTemplate(rf);
 	}
 
-	public String transcribeAudioTotal(AudioFile audioFile) throws Exception {
+	protected double getDuration(File file) {
+		try {
+			org.jaudiotagger.audio.AudioFile audioFile = AudioFileIO.read(file);
+			return audioFile.getAudioHeader().getTrackLength();
+		} catch (Exception e) {
+			logger.warn("Could not determine duration using jaudiotagger: {}", e.getMessage());
+			return 0;
+		}
+	}
+
+	protected String callApi(byte[] bytes, String filename) {
 		RestTemplate restTemplate = buildRestTemplate();
 
 		HttpHeaders headers = new HttpHeaders();
@@ -41,14 +79,11 @@ public class OpenAiService {
 		headers.setContentType(MediaType.MULTIPART_FORM_DATA);
 		headers.setAccept(List.of(MediaType.APPLICATION_JSON));
 
-		// 1) Leé TODO a bytes para tener content-length real (y evitar streams “raros”)
-		byte[] bytes = audioFile.getInputStream().readAllBytes();
-
-		// 2) Resource con filename + length real
+		// Resource con filename + length real
 		ByteArrayResource filePart = new ByteArrayResource(bytes) {
 			@Override
 			public String getFilename() {
-				return audioFile.getFilename();
+				return filename;
 			}
 		};
 
@@ -57,14 +92,230 @@ public class OpenAiService {
 		body.add("model", "gpt-4o-transcribe-diarize");
 		body.add("response_format", "diarized_json");
 		body.add("chunking_strategy", "auto");
-		// Opcional: si querés timestamps más finos (palabra), ver
-		// timestamp_granularities en el spec :contentReference[oaicite:4]{index=4}
 
 		HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
 
 		ResponseEntity<String> response = restTemplate.postForEntity(OPENAI_API_URL, requestEntity, String.class);
 
 		return response.getBody();
+	}
+
+	public String transcribeAudioTotal(AudioFile audioFile) throws Exception {
+		byte[] bytes = audioFile.getInputStream().readAllBytes();
+
+		File tempFile = null;
+		try {
+			String filename = audioFile.getFilename();
+			String suffix = ".tmp";
+			if (filename != null && filename.contains(".")) {
+				suffix = filename.substring(filename.lastIndexOf("."));
+			}
+			tempFile = File.createTempFile("openai_audio_", suffix);
+			try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+				fos.write(bytes);
+			}
+
+			double duration = getDuration(tempFile);
+
+			if (duration <= 1200) {
+				return callApi(bytes, filename);
+			} else {
+				// Try robust WAV splitting first
+				try {
+					return processChunksWav(tempFile);
+				} catch (UnsupportedAudioFileException | IllegalArgumentException | java.io.IOException e) {
+					logger.warn("WAV splitting failed (unsupported format or IO error?), falling back to byte splitting: {}", e.getMessage());
+					return processChunksBytes(bytes, filename, duration);
+				}
+			}
+		} finally {
+			if (tempFile != null && tempFile.exists()) {
+				// noinspection ResultOfMethodCallIgnored
+				tempFile.delete();
+			}
+		}
+	}
+
+	private String processChunksWav(File inputFile) throws Exception {
+		// Prepare merge containers
+		ObjectNode mergedResponse = objectMapper.createObjectNode();
+		StringBuilder combinedText = new StringBuilder();
+		ArrayNode combinedSegments = objectMapper.createArrayNode();
+		String task = null;
+		String language = null;
+		double currentOffset = 0.0;
+		double totalProcessedDuration = 0.0;
+
+		try (AudioInputStream in = AudioSystem.getAudioInputStream(inputFile)) {
+			AudioFormat baseFormat = in.getFormat();
+			// Decode to PCM
+			AudioFormat decodedFormat = new AudioFormat(
+					AudioFormat.Encoding.PCM_SIGNED,
+					baseFormat.getSampleRate(),
+					16,
+					baseFormat.getChannels(),
+					baseFormat.getChannels() * 2,
+					baseFormat.getSampleRate(),
+					false);
+
+			try (AudioInputStream din = AudioSystem.getAudioInputStream(decodedFormat, in)) {
+				// Chunk size: 20MB (approx 2 mins)
+				long bytesPerChunk = 20 * 1024 * 1024;
+				int frameSize = decodedFormat.getFrameSize();
+				if (frameSize <= 0) frameSize = 4;
+				// Align to frame size
+				bytesPerChunk = (bytesPerChunk / frameSize) * frameSize;
+
+				byte[] buffer = new byte[(int) bytesPerChunk];
+				int chunkIndex = 0;
+
+				while (true) {
+					int totalRead = 0;
+					while (totalRead < buffer.length) {
+						int read = din.read(buffer, totalRead, buffer.length - totalRead);
+						if (read == -1) break;
+						totalRead += read;
+					}
+					if (totalRead == 0) break;
+
+					File chunkFile = File.createTempFile("openai_chunk_" + chunkIndex, ".wav");
+					try {
+						ByteArrayInputStream bais = new ByteArrayInputStream(buffer, 0, totalRead);
+						AudioInputStream chunkStream = new AudioInputStream(bais, decodedFormat, totalRead / frameSize);
+						AudioSystem.write(chunkStream, AudioFileFormat.Type.WAVE, chunkFile);
+
+						byte[] chunkBytes = java.nio.file.Files.readAllBytes(chunkFile.toPath());
+						String responseJson = callApi(chunkBytes, chunkFile.getName());
+
+						JsonNode responseNode = objectMapper.readTree(responseJson);
+
+						// Merge logic
+						if (chunkIndex == 0) {
+							if (responseNode.has("task")) task = responseNode.get("task").asText();
+							if (responseNode.has("language")) language = responseNode.get("language").asText();
+						}
+
+						if (responseNode.has("text")) {
+							if (combinedText.length() > 0) combinedText.append(" ");
+							combinedText.append(responseNode.get("text").asText());
+						}
+
+						if (responseNode.has("segments")) {
+							JsonNode segments = responseNode.get("segments");
+							if (segments.isArray()) {
+								for (JsonNode segment : segments) {
+									if (segment.isObject()) {
+										ObjectNode segmentObj = (ObjectNode) segment;
+										if (segmentObj.has("start")) {
+											segmentObj.put("start", segmentObj.get("start").asDouble() + currentOffset);
+										}
+										if (segmentObj.has("end")) {
+											segmentObj.put("end", segmentObj.get("end").asDouble() + currentOffset);
+										}
+										combinedSegments.add(segmentObj);
+									}
+								}
+							}
+						}
+
+						if (responseNode.has("duration")) {
+							double duration = responseNode.get("duration").asDouble();
+							currentOffset += duration;
+							totalProcessedDuration += duration;
+						} else {
+							double approxDuration = (double) totalRead / (decodedFormat.getFrameRate() * frameSize);
+							currentOffset += approxDuration;
+						}
+
+					} finally {
+						chunkFile.delete();
+					}
+					chunkIndex++;
+				}
+			}
+		}
+
+		if (task != null) mergedResponse.put("task", task);
+		if (language != null) mergedResponse.put("language", language);
+		mergedResponse.put("duration", totalProcessedDuration);
+		mergedResponse.put("text", combinedText.toString());
+		mergedResponse.set("segments", combinedSegments);
+
+		return objectMapper.writeValueAsString(mergedResponse);
+	}
+
+	private String processChunksBytes(byte[] bytes, String filename, double totalDuration) throws Exception {
+		// Fallback implementation: split by bytes (risky but necessary for unsupported formats without ffmpeg)
+		long totalBytes = bytes.length;
+		double chunkDurationSeconds = 1000.0;
+		long bytesPerChunk = (long) (totalBytes * (chunkDurationSeconds / totalDuration));
+		if (bytesPerChunk < 1024) bytesPerChunk = totalBytes;
+
+		int numberOfChunks = (int) Math.ceil((double) totalBytes / bytesPerChunk);
+
+		ObjectNode mergedResponse = objectMapper.createObjectNode();
+		StringBuilder combinedText = new StringBuilder();
+		ArrayNode combinedSegments = objectMapper.createArrayNode();
+		String task = null;
+		String language = null;
+		double currentOffset = 0.0;
+		double totalProcessedDuration = 0.0;
+
+		for (int i = 0; i < numberOfChunks; i++) {
+			int start = (int) (i * bytesPerChunk);
+			int end = (int) Math.min((i + 1) * bytesPerChunk, totalBytes);
+			if (start >= end) break;
+
+			byte[] chunkBytes = Arrays.copyOfRange(bytes, start, end);
+			String chunkFilename = "chunk_" + i + "_" + filename;
+
+			String responseJson = callApi(chunkBytes, chunkFilename);
+			JsonNode responseNode = objectMapper.readTree(responseJson);
+
+			if (i == 0) {
+				if (responseNode.has("task")) task = responseNode.get("task").asText();
+				if (responseNode.has("language")) language = responseNode.get("language").asText();
+			}
+
+			if (responseNode.has("text")) {
+				if (combinedText.length() > 0) combinedText.append(" ");
+				combinedText.append(responseNode.get("text").asText());
+			}
+
+			if (responseNode.has("segments")) {
+				JsonNode segments = responseNode.get("segments");
+				if (segments.isArray()) {
+					for (JsonNode segment : segments) {
+						if (segment.isObject()) {
+							ObjectNode segmentObj = (ObjectNode) segment;
+							if (segmentObj.has("start")) {
+								segmentObj.put("start", segmentObj.get("start").asDouble() + currentOffset);
+							}
+							if (segmentObj.has("end")) {
+								segmentObj.put("end", segmentObj.get("end").asDouble() + currentOffset);
+							}
+							combinedSegments.add(segmentObj);
+						}
+					}
+				}
+			}
+
+			if (responseNode.has("duration")) {
+				double duration = responseNode.get("duration").asDouble();
+				currentOffset += duration;
+				totalProcessedDuration += duration;
+			} else {
+				currentOffset += chunkDurationSeconds;
+			}
+		}
+
+		if (task != null) mergedResponse.put("task", task);
+		if (language != null) mergedResponse.put("language", language);
+		mergedResponse.put("duration", totalProcessedDuration);
+		mergedResponse.put("text", combinedText.toString());
+		mergedResponse.set("segments", combinedSegments);
+
+		return objectMapper.writeValueAsString(mergedResponse);
 	}
 
 }

--- a/src/main/java/uy/com/bay/utiles/services/OpenAiService.java
+++ b/src/main/java/uy/com/bay/utiles/services/OpenAiService.java
@@ -27,6 +27,7 @@ import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -72,32 +73,50 @@ public class OpenAiService {
 	}
 
 	protected String callApi(byte[] bytes, String filename) {
-		RestTemplate restTemplate = buildRestTemplate();
+		int maxRetries = 3;
+		for (int attempt = 1; attempt <= maxRetries; attempt++) {
+			try {
+				RestTemplate restTemplate = buildRestTemplate();
 
-		HttpHeaders headers = new HttpHeaders();
-		headers.setBearerAuth(openaiApiKey);
-		headers.setContentType(MediaType.MULTIPART_FORM_DATA);
-		headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+				HttpHeaders headers = new HttpHeaders();
+				headers.setBearerAuth(openaiApiKey);
+				headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+				headers.setAccept(List.of(MediaType.APPLICATION_JSON));
 
-		// Resource con filename + length real
-		ByteArrayResource filePart = new ByteArrayResource(bytes) {
-			@Override
-			public String getFilename() {
-				return filename;
+				// Resource con filename + length real
+				ByteArrayResource filePart = new ByteArrayResource(bytes) {
+					@Override
+					public String getFilename() {
+						return filename;
+					}
+				};
+
+				MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+				body.add("file", filePart);
+				body.add("model", "gpt-4o-transcribe-diarize");
+				body.add("response_format", "diarized_json");
+				body.add("chunking_strategy", "auto");
+
+				HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+
+				ResponseEntity<String> response = restTemplate.postForEntity(OPENAI_API_URL, requestEntity,
+						String.class);
+
+				return response.getBody();
+			} catch (ResourceAccessException e) {
+				logger.warn("API call failed (attempt {}/{}): {}", attempt, maxRetries, e.getMessage());
+				if (attempt == maxRetries) {
+					throw e;
+				}
+				try {
+					Thread.sleep(1000L * attempt);
+				} catch (InterruptedException ie) {
+					Thread.currentThread().interrupt();
+					throw e;
+				}
 			}
-		};
-
-		MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-		body.add("file", filePart);
-		body.add("model", "gpt-4o-transcribe-diarize");
-		body.add("response_format", "diarized_json");
-		body.add("chunking_strategy", "auto");
-
-		HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
-
-		ResponseEntity<String> response = restTemplate.postForEntity(OPENAI_API_URL, requestEntity, String.class);
-
-		return response.getBody();
+		}
+		throw new RuntimeException("API call failed after retries");
 	}
 
 	public String transcribeAudioTotal(AudioFile audioFile) throws Exception {
@@ -124,7 +143,8 @@ public class OpenAiService {
 				try {
 					return processChunksWav(tempFile);
 				} catch (UnsupportedAudioFileException | IllegalArgumentException | java.io.IOException e) {
-					logger.warn("WAV splitting failed (unsupported format or IO error?), falling back to byte splitting: {}", e.getMessage());
+					logger.warn("WAV splitting failed (unsupported format or IO error?), falling back to byte splitting: {}",
+							e.getMessage());
 					return processChunksBytes(bytes, filename, duration);
 				}
 			}
@@ -149,20 +169,15 @@ public class OpenAiService {
 		try (AudioInputStream in = AudioSystem.getAudioInputStream(inputFile)) {
 			AudioFormat baseFormat = in.getFormat();
 			// Decode to PCM
-			AudioFormat decodedFormat = new AudioFormat(
-					AudioFormat.Encoding.PCM_SIGNED,
-					baseFormat.getSampleRate(),
-					16,
-					baseFormat.getChannels(),
-					baseFormat.getChannels() * 2,
-					baseFormat.getSampleRate(),
-					false);
+			AudioFormat decodedFormat = new AudioFormat(AudioFormat.Encoding.PCM_SIGNED, baseFormat.getSampleRate(), 16,
+					baseFormat.getChannels(), baseFormat.getChannels() * 2, baseFormat.getSampleRate(), false);
 
 			try (AudioInputStream din = AudioSystem.getAudioInputStream(decodedFormat, in)) {
-				// Chunk size: 20MB (approx 2 mins)
-				long bytesPerChunk = 20 * 1024 * 1024;
+				// Chunk size: 6MB (approx 35s-40s depending on bitrate, safer for uploads)
+				long bytesPerChunk = 6 * 1024 * 1024;
 				int frameSize = decodedFormat.getFrameSize();
-				if (frameSize <= 0) frameSize = 4;
+				if (frameSize <= 0)
+					frameSize = 4;
 				// Align to frame size
 				bytesPerChunk = (bytesPerChunk / frameSize) * frameSize;
 
@@ -173,10 +188,12 @@ public class OpenAiService {
 					int totalRead = 0;
 					while (totalRead < buffer.length) {
 						int read = din.read(buffer, totalRead, buffer.length - totalRead);
-						if (read == -1) break;
+						if (read == -1)
+							break;
 						totalRead += read;
 					}
-					if (totalRead == 0) break;
+					if (totalRead == 0)
+						break;
 
 					File chunkFile = File.createTempFile("openai_chunk_" + chunkIndex, ".wav");
 					try {
@@ -191,12 +208,15 @@ public class OpenAiService {
 
 						// Merge logic
 						if (chunkIndex == 0) {
-							if (responseNode.has("task")) task = responseNode.get("task").asText();
-							if (responseNode.has("language")) language = responseNode.get("language").asText();
+							if (responseNode.has("task"))
+								task = responseNode.get("task").asText();
+							if (responseNode.has("language"))
+								language = responseNode.get("language").asText();
 						}
 
 						if (responseNode.has("text")) {
-							if (combinedText.length() > 0) combinedText.append(" ");
+							if (combinedText.length() > 0)
+								combinedText.append(" ");
 							combinedText.append(responseNode.get("text").asText());
 						}
 
@@ -235,8 +255,10 @@ public class OpenAiService {
 			}
 		}
 
-		if (task != null) mergedResponse.put("task", task);
-		if (language != null) mergedResponse.put("language", language);
+		if (task != null)
+			mergedResponse.put("task", task);
+		if (language != null)
+			mergedResponse.put("language", language);
 		mergedResponse.put("duration", totalProcessedDuration);
 		mergedResponse.put("text", combinedText.toString());
 		mergedResponse.set("segments", combinedSegments);
@@ -245,11 +267,18 @@ public class OpenAiService {
 	}
 
 	private String processChunksBytes(byte[] bytes, String filename, double totalDuration) throws Exception {
-		// Fallback implementation: split by bytes (risky but necessary for unsupported formats without ffmpeg)
+		// Fallback implementation: split by bytes (risky but necessary for unsupported
+		// formats without ffmpeg)
 		long totalBytes = bytes.length;
-		double chunkDurationSeconds = 1000.0;
+		double chunkDurationSeconds = 400.0; // Reduced from 1000s for safety
 		long bytesPerChunk = (long) (totalBytes * (chunkDurationSeconds / totalDuration));
-		if (bytesPerChunk < 1024) bytesPerChunk = totalBytes;
+		if (bytesPerChunk < 1024)
+			bytesPerChunk = totalBytes;
+		// Cap at 6MB
+		long maxBytes = 6 * 1024 * 1024;
+		if (bytesPerChunk > maxBytes) {
+			bytesPerChunk = maxBytes;
+		}
 
 		int numberOfChunks = (int) Math.ceil((double) totalBytes / bytesPerChunk);
 
@@ -264,7 +293,8 @@ public class OpenAiService {
 		for (int i = 0; i < numberOfChunks; i++) {
 			int start = (int) (i * bytesPerChunk);
 			int end = (int) Math.min((i + 1) * bytesPerChunk, totalBytes);
-			if (start >= end) break;
+			if (start >= end)
+				break;
 
 			byte[] chunkBytes = Arrays.copyOfRange(bytes, start, end);
 			String chunkFilename = "chunk_" + i + "_" + filename;
@@ -273,12 +303,15 @@ public class OpenAiService {
 			JsonNode responseNode = objectMapper.readTree(responseJson);
 
 			if (i == 0) {
-				if (responseNode.has("task")) task = responseNode.get("task").asText();
-				if (responseNode.has("language")) language = responseNode.get("language").asText();
+				if (responseNode.has("task"))
+					task = responseNode.get("task").asText();
+				if (responseNode.has("language"))
+					language = responseNode.get("language").asText();
 			}
 
 			if (responseNode.has("text")) {
-				if (combinedText.length() > 0) combinedText.append(" ");
+				if (combinedText.length() > 0)
+					combinedText.append(" ");
 				combinedText.append(responseNode.get("text").asText());
 			}
 
@@ -309,8 +342,10 @@ public class OpenAiService {
 			}
 		}
 
-		if (task != null) mergedResponse.put("task", task);
-		if (language != null) mergedResponse.put("language", language);
+		if (task != null)
+			mergedResponse.put("task", task);
+		if (language != null)
+			mergedResponse.put("language", language);
 		mergedResponse.put("duration", totalProcessedDuration);
 		mergedResponse.put("text", combinedText.toString());
 		mergedResponse.set("segments", combinedSegments);

--- a/src/main/java/uy/com/bay/utiles/services/SupervisionTaskServiceTransactionalDEPRECATED.java
+++ b/src/main/java/uy/com/bay/utiles/services/SupervisionTaskServiceTransactionalDEPRECATED.java
@@ -78,7 +78,7 @@ public class SupervisionTaskServiceTransactionalDEPRECATED {
 					}
 				}
 
-				String transcription = openAiService.transcribeAudio(audioFile);
+				String transcription = openAiService.transcribeAudioTotal(audioFile);
 				task.setOutput(prettyPrint(transcription));
 
 				ObjectMapper mapper = new ObjectMapper();

--- a/src/test/java/uy/com/bay/utiles/services/OpenAiServiceTest.java
+++ b/src/test/java/uy/com/bay/utiles/services/OpenAiServiceTest.java
@@ -1,0 +1,128 @@
+package uy.com.bay.utiles.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import uy.com.bay.utiles.dto.AudioFile;
+
+class OpenAiServiceTest {
+
+    static class TestableOpenAiService extends OpenAiService {
+        private final double simulatedDuration;
+        private final String[] mockResponses;
+        private int callCount = 0;
+
+        public TestableOpenAiService(ObjectMapper objectMapper, double simulatedDuration, String... mockResponses) {
+            super(objectMapper);
+            this.simulatedDuration = simulatedDuration;
+            this.mockResponses = mockResponses;
+        }
+
+        @Override
+        protected double getDuration(File file) {
+            return simulatedDuration;
+        }
+
+        @Override
+        protected String callApi(byte[] bytes, String filename) {
+            if (callCount < mockResponses.length) {
+                return mockResponses[callCount++];
+            }
+            return "{}";
+        }
+    }
+
+    @Test
+    void testTranscribeAudioTotal_SplitAndMerge() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        // Chunk 1: Duration 1000s
+        ObjectNode response1 = mapper.createObjectNode();
+        response1.put("task", "transcribe");
+        response1.put("language", "english");
+        response1.put("duration", 1000.0);
+        response1.put("text", "Hello world");
+        ArrayNode segments1 = response1.putArray("segments");
+        ObjectNode s1 = segments1.addObject();
+        s1.put("start", 0.0);
+        s1.put("end", 10.0);
+        s1.put("text", "Hello world");
+        s1.put("speaker", "speaker_0");
+
+        // Chunk 2: Duration 500s
+        ObjectNode response2 = mapper.createObjectNode();
+        response2.put("task", "transcribe"); // Should be ignored in merge (taken from first)
+        response2.put("language", "english");
+        response2.put("duration", 500.0);
+        response2.put("text", "Part two");
+        ArrayNode segments2 = response2.putArray("segments");
+        ObjectNode s2 = segments2.addObject();
+        s2.put("start", 0.0); // Relative to chunk start
+        s2.put("end", 5.0);
+        s2.put("text", "Part two");
+        s2.put("speaker", "speaker_1");
+
+        // Total duration 2500s -> chunks logic:
+        // target chunk = 1000s.
+        // total = 2500s.
+        // bytes = 10000.
+        // bytesPerSecond = 4.
+        // bytesPerChunk = 4 * 1000 = 4000.
+        // chunks = ceil(10000 / 4000) = 3.
+        // So we expect 3 calls.
+        // Let's create a 3rd response.
+        ObjectNode response3 = mapper.createObjectNode();
+        response3.put("duration", 200.0);
+        response3.put("text", "End");
+        ArrayNode segments3 = response3.putArray("segments");
+        ObjectNode s3 = segments3.addObject();
+        s3.put("start", 0.0);
+        s3.put("end", 2.0);
+        s3.put("text", "End");
+
+        TestableOpenAiService service = new TestableOpenAiService(mapper, 2500.0,
+                mapper.writeValueAsString(response1),
+                mapper.writeValueAsString(response2),
+                mapper.writeValueAsString(response3));
+
+        byte[] dummyBytes = new byte[10000]; // 10KB
+        AudioFile audioFile = new AudioFile("test.mp3", new ByteArrayInputStream(dummyBytes));
+
+        String result = service.transcribeAudioTotal(audioFile);
+
+        JsonNode root = mapper.readTree(result);
+
+        // Verify text concatenation
+        assertEquals("Hello world Part two End", root.get("text").asText());
+
+        // Verify total duration
+        // 1000 + 500 + 200 = 1700
+        assertEquals(1700.0, root.get("duration").asDouble(), 0.001);
+
+        // Verify segments
+        JsonNode segments = root.get("segments");
+        assertEquals(3, segments.size());
+
+        // Segment 1: 0-10
+        assertEquals(0.0, segments.get(0).get("start").asDouble(), 0.001);
+        assertEquals(10.0, segments.get(0).get("end").asDouble(), 0.001);
+
+        // Segment 2: Offset by Chunk 1 duration (1000) -> 1000-1005
+        assertEquals(1000.0, segments.get(1).get("start").asDouble(), 0.001);
+        assertEquals(1005.0, segments.get(1).get("end").asDouble(), 0.001);
+
+        // Segment 3: Offset by Chunk 1+2 duration (1000+500=1500) -> 1500-1502
+        assertEquals(1500.0, segments.get(2).get("start").asDouble(), 0.001);
+        assertEquals(1502.0, segments.get(2).get("end").asDouble(), 0.001);
+    }
+}


### PR DESCRIPTION
Refactored `OpenAiService.transcribeAudioTotal` to handle audio files longer than 1200 seconds by splitting them into chunks. The implementation attempts to decode the audio using `AudioSystem` and split it into valid WAV files. If decoding fails (e.g., for unsupported formats like M4A), it falls back to a byte-splitting strategy. The method merges the `diarized_json` responses from all chunks, ensuring text concatenation and correct timestamp offsets for speaker segments. Also fixed a compilation error in `SupervisionTaskServiceTransactionalDEPRECATED`.

---
*PR created automatically by Jules for task [913893248562799057](https://jules.google.com/task/913893248562799057) started by @araujomelogno*