### PR TITLE
Add getOdooLeads method to fetch CRM leads from Odoo

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/OdooService.java
+++ b/src/main/java/uy/com/bay/utiles/services/OdooService.java
@@ -153,7 +153,7 @@ public class OdooService {
             }
 
             List<String> fieldsToFetch = Arrays.asList("id", "name");
-            List<Object> domain = Collections.emptyList(); // Fetch all leads
+            List<Object> domain = Collections.singletonList(Arrays.asList("name", "like", "S%")); // Leads starting with "S"
 
             HashMap<String, Object> keywordArgs = new HashMap<>();
             keywordArgs.put("fields", fieldsToFetch);

--- a/src/main/java/uy/com/bay/utiles/services/OdooService.java
+++ b/src/main/java/uy/com/bay/utiles/services/OdooService.java
@@ -138,4 +138,58 @@ public class OdooService {
         }
         return Collections.emptyList(); // Return empty list in case of any error
     }
+
+    @SuppressWarnings("unchecked")
+    public List<Map<String, Object>> getOdooLeads() {
+        if (objectClient == null) {
+            logger.error("Odoo object client not initialized. Cannot fetch leads.");
+            return Collections.emptyList();
+        }
+        try {
+            Integer uid = authenticate();
+            if (uid == null) {
+                logger.error("Cannot fetch leads: Authentication failed.");
+                return Collections.emptyList();
+            }
+
+            List<String> fieldsToFetch = Arrays.asList("id", "name");
+            List<Object> domain = Collections.emptyList(); // Fetch all leads
+
+            HashMap<String, Object> keywordArgs = new HashMap<>();
+            keywordArgs.put("fields", fieldsToFetch);
+
+            Object[] params = new Object[]{
+                    odooConfig.getDb(),
+                    uid,
+                    odooConfig.getPassword(),
+                    "crm.lead", // Odoo model name for leads
+                    "search_read",
+                    Collections.singletonList(domain),
+                    keywordArgs
+            };
+
+            logger.info("Executing Odoo search_read on 'crm.lead' with fields: {}", fieldsToFetch);
+            Object[] leadsRaw = (Object[]) objectClient.execute("execute_kw", params);
+
+            List<Map<String, Object>> leadsList = new ArrayList<>();
+            for (Object leadObj : leadsRaw) {
+                if (leadObj instanceof Map) {
+                    leadsList.add((Map<String, Object>) leadObj);
+                } else {
+                    logger.warn("Received an object that is not a Map from Odoo: {}", leadObj);
+                }
+            }
+            logger.info("Successfully fetched {} leads from Odoo.", leadsList.size());
+
+            return leadsList;
+
+        } catch (XmlRpcException e) {
+            logger.error("XmlRpcException while fetching leads from Odoo: {}. Check Odoo XML-RPC endpoint and network.", e.getMessage(), e);
+        } catch (ClassCastException e) {
+            logger.error("ClassCastException while processing Odoo response. Unexpected data structure: {}", e.getMessage(), e);
+        } catch (Exception e) {
+            logger.error("Unexpected exception while fetching leads from Odoo: {}", e.getMessage(), e);
+        }
+        return Collections.emptyList();
+    }
 }


### PR DESCRIPTION
## Summary
Added a new method `getOdooLeads()` to the `OdooService` class to retrieve CRM leads from Odoo using the XML-RPC API.

## Key Changes
- Implemented `getOdooLeads()` method that fetches leads from the Odoo `crm.lead` model
- Filters leads by name starting with "S" using Odoo domain syntax
- Returns a list of lead records with `id` and `name` fields
- Includes comprehensive error handling for authentication failures, XML-RPC exceptions, and data type mismatches
- Added appropriate logging at info and error levels for debugging and monitoring

## Implementation Details
- Uses the existing `authenticate()` method to obtain a valid session UID
- Leverages the `search_read` operation for efficient data retrieval
- Implements defensive programming with null checks and type validation
- Returns an empty list on any error to maintain API consistency with existing `getOdooProjects()` method
- Includes `@SuppressWarnings("unchecked")` annotation for the type cast operation

https://claude.ai/code/session_011X2uQuGm3TCMs1Tuqc7B97