### PR TITLE
Improve document text extraction with format mismatch fallbacks

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/SupervisionTaskProcessorService.java
+++ b/src/main/java/uy/com/bay/utiles/services/SupervisionTaskProcessorService.java
@@ -155,50 +155,75 @@ public class SupervisionTaskProcessorService {
 
 	public static String extractQuestionnaireText(byte[] data, String fileName) {
 		if (data == null || data.length == 0)
-			return "";
+			return “”;
 
-		String lowerName = fileName != null ? fileName.toLowerCase() : "";
+		String lowerName = fileName != null ? fileName.toLowerCase() : “”;
 
 		// DOCX (ZIP) empieza con 'PK'; también se detecta por extensión como fallback
 		boolean looksZip = data.length >= 2 && data[0] == 'P' && data[1] == 'K';
-		boolean nameDocx = lowerName.endsWith(".docx");
+		boolean nameDocx = lowerName.endsWith(“.docx”);
 
 		// DOC (Word 97-2003) empieza con D0 CF 11 E0 A1 B1 1A E1 (OLE2); también por
 		// extensión
 		byte[] oleSig = new byte[] { (byte) 0xD0, (byte) 0xCF, (byte) 0x11, (byte) 0xE0, (byte) 0xA1, (byte) 0xB1,
 				(byte) 0x1A, (byte) 0xE1 };
 		boolean looksOle = data.length >= 8 && Arrays.equals(Arrays.copyOfRange(data, 0, 8), oleSig);
-		boolean nameDoc = lowerName.endsWith(".doc");
+		boolean nameDoc = lowerName.endsWith(“.doc”);
 
 		// PDF empieza con %PDF
 		boolean looksPdf = data.length >= 4 && data[0] == '%' && data[1] == 'P' && data[2] == 'D' && data[3] == 'F';
 
 		logger.debug(
-				"Extracting questionnaire text: file='{}', looksZip={}, nameDocx={}, looksOle={}, nameDoc={}, looksPdf={}, bytes={}",
+				“Extracting questionnaire text: file='{}', looksZip={}, nameDocx={}, looksOle={}, nameDoc={}, looksPdf={}, bytes={}”,
 				fileName, looksZip, nameDocx, looksOle, nameDoc, looksPdf, data.length);
 
+		// Intentar DOCX primero si la firma o extensión lo sugieren
 		if (looksZip || nameDocx) {
 			try (InputStream is = new ByteArrayInputStream(data);
 					XWPFDocument doc = new XWPFDocument(OPCPackage.open(is));
 					XWPFWordExtractor extractor = new XWPFWordExtractor(doc)) {
 				return extractor.getText();
 			} catch (Exception e) {
-				logger.warn("No se pudo extraer texto DOCX de '{}': {}”, fileName, e.getMessage()");
+				logger.warn(“No se pudo extraer texto DOCX de '{}': {}”, fileName, e.getMessage());
 			}
 		}
 
+		// Intentar DOC si la firma o extensión lo sugieren
 		if (looksOle || nameDoc) {
 			try (InputStream is = new ByteArrayInputStream(data);
 					HWPFDocument doc = new HWPFDocument(is);
 					WordExtractor extractor = new WordExtractor(doc)) {
 				return extractor.getText();
 			} catch (Exception e) {
-				logger.warn("No se pudo extraer texto DOC de '{}': {}”, fileName, e.getMessage()");
+				logger.warn(“No se pudo extraer texto DOC de '{}': {}”, fileName, e.getMessage());
+				// Fallback: archivo .doc que en realidad es DOCX (formato incorrecto de extensión)
+				if (nameDoc && !looksZip) {
+					try (InputStream is2 = new ByteArrayInputStream(data);
+							XWPFDocument doc2 = new XWPFDocument(OPCPackage.open(is2));
+							XWPFWordExtractor extractor2 = new XWPFWordExtractor(doc2)) {
+						logger.info(“Archivo '{}' con extensión .doc se abrió exitosamente como DOCX”, fileName);
+						return extractor2.getText();
+					} catch (Exception e2) {
+						logger.warn(“Tampoco se pudo extraer texto DOCX (fallback) de '{}': {}”, fileName, e2.getMessage());
+					}
+				}
+			}
+		}
+
+		// Fallback inverso: archivo .docx que en realidad es DOC
+		if (nameDocx && !looksOle && !looksZip) {
+			try (InputStream is = new ByteArrayInputStream(data);
+					HWPFDocument doc = new HWPFDocument(is);
+					WordExtractor extractor = new WordExtractor(doc)) {
+				logger.info(“Archivo '{}' con extensión .docx se abrió exitosamente como DOC”, fileName);
+				return extractor.getText();
+			} catch (Exception e) {
+				logger.warn(“Tampoco se pudo extraer texto DOC (fallback) de '{}': {}”, fileName, e.getMessage());
 			}
 		}
 
 		if (looksPdf) {
-			return "";
+			return “”;
 		}
 
 		// Fallback: asumir texto plano UTF-8

--- a/src/main/java/uy/com/bay/utiles/services/SupervisionTaskProcessorService.java
+++ b/src/main/java/uy/com/bay/utiles/services/SupervisionTaskProcessorService.java
@@ -155,26 +155,26 @@ public class SupervisionTaskProcessorService {
 
 	public static String extractQuestionnaireText(byte[] data, String fileName) {
 		if (data == null || data.length == 0)
-			return “”;
+			return "";
 
-		String lowerName = fileName != null ? fileName.toLowerCase() : “”;
+		String lowerName = fileName != null ? fileName.toLowerCase() : "";
 
 		// DOCX (ZIP) empieza con 'PK'; también se detecta por extensión como fallback
 		boolean looksZip = data.length >= 2 && data[0] == 'P' && data[1] == 'K';
-		boolean nameDocx = lowerName.endsWith(“.docx”);
+		boolean nameDocx = lowerName.endsWith(".docx");
 
 		// DOC (Word 97-2003) empieza con D0 CF 11 E0 A1 B1 1A E1 (OLE2); también por
 		// extensión
 		byte[] oleSig = new byte[] { (byte) 0xD0, (byte) 0xCF, (byte) 0x11, (byte) 0xE0, (byte) 0xA1, (byte) 0xB1,
 				(byte) 0x1A, (byte) 0xE1 };
 		boolean looksOle = data.length >= 8 && Arrays.equals(Arrays.copyOfRange(data, 0, 8), oleSig);
-		boolean nameDoc = lowerName.endsWith(“.doc”);
+		boolean nameDoc = lowerName.endsWith(".doc");
 
 		// PDF empieza con %PDF
 		boolean looksPdf = data.length >= 4 && data[0] == '%' && data[1] == 'P' && data[2] == 'D' && data[3] == 'F';
 
 		logger.debug(
-				“Extracting questionnaire text: file='{}', looksZip={}, nameDocx={}, looksOle={}, nameDoc={}, looksPdf={}, bytes={}”,
+				"Extracting questionnaire text: file='{}', looksZip={}, nameDocx={}, looksOle={}, nameDoc={}, looksPdf={}, bytes={}",
 				fileName, looksZip, nameDocx, looksOle, nameDoc, looksPdf, data.length);
 
 		// Intentar DOCX primero si la firma o extensión lo sugieren
@@ -184,7 +184,7 @@ public class SupervisionTaskProcessorService {
 					XWPFWordExtractor extractor = new XWPFWordExtractor(doc)) {
 				return extractor.getText();
 			} catch (Exception e) {
-				logger.warn(“No se pudo extraer texto DOCX de '{}': {}”, fileName, e.getMessage());
+				logger.warn("No se pudo extraer texto DOCX de '{}': {}", fileName, e.getMessage());
 			}
 		}
 
@@ -195,16 +195,16 @@ public class SupervisionTaskProcessorService {
 					WordExtractor extractor = new WordExtractor(doc)) {
 				return extractor.getText();
 			} catch (Exception e) {
-				logger.warn(“No se pudo extraer texto DOC de '{}': {}”, fileName, e.getMessage());
+				logger.warn("No se pudo extraer texto DOC de '{}': {}", fileName, e.getMessage());
 				// Fallback: archivo .doc que en realidad es DOCX (formato incorrecto de extensión)
 				if (nameDoc && !looksZip) {
 					try (InputStream is2 = new ByteArrayInputStream(data);
 							XWPFDocument doc2 = new XWPFDocument(OPCPackage.open(is2));
 							XWPFWordExtractor extractor2 = new XWPFWordExtractor(doc2)) {
-						logger.info(“Archivo '{}' con extensión .doc se abrió exitosamente como DOCX”, fileName);
+						logger.info("Archivo '{}' con extensión .doc se abrió exitosamente como DOCX", fileName);
 						return extractor2.getText();
 					} catch (Exception e2) {
-						logger.warn(“Tampoco se pudo extraer texto DOCX (fallback) de '{}': {}”, fileName, e2.getMessage());
+						logger.warn("Tampoco se pudo extraer texto DOCX (fallback) de '{}': {}", fileName, e2.getMessage());
 					}
 				}
 			}
@@ -215,15 +215,15 @@ public class SupervisionTaskProcessorService {
 			try (InputStream is = new ByteArrayInputStream(data);
 					HWPFDocument doc = new HWPFDocument(is);
 					WordExtractor extractor = new WordExtractor(doc)) {
-				logger.info(“Archivo '{}' con extensión .docx se abrió exitosamente como DOC”, fileName);
+				logger.info("Archivo '{}' con extensión .docx se abrió exitosamente como DOC", fileName);
 				return extractor.getText();
 			} catch (Exception e) {
-				logger.warn(“Tampoco se pudo extraer texto DOC (fallback) de '{}': {}”, fileName, e.getMessage());
+				logger.warn("Tampoco se pudo extraer texto DOC (fallback) de '{}': {}", fileName, e.getMessage());
 			}
 		}
 
 		if (looksPdf) {
-			return “”;
+			return "";
 		}
 
 		// Fallback: asumir texto plano UTF-8


### PR DESCRIPTION
## Summary
Enhanced the `extractQuestionnaireText` method to handle cases where document files have incorrect file extensions (e.g., a DOCX file saved with a .doc extension or vice versa). The implementation now includes fallback extraction attempts when the primary format fails.

## Key Changes
- **Fixed syntax errors**: Corrected mismatched quotes in logger.warn() calls that were causing compilation errors
- **Added DOCX fallback for .doc files**: When a file has a .doc extension but fails to parse as OLE2 format, the method now attempts to extract it as DOCX format
- **Added DOC fallback for .docx files**: When a file has a .docx extension but doesn't match ZIP or OLE2 signatures, the method attempts to extract it as DOC format
- **Improved logging**: Added informational log messages when fallback extraction succeeds, helping with debugging format mismatches
- **Added code comments**: Clarified the extraction logic flow with Spanish comments explaining each attempt stage

## Implementation Details
- The fallback attempts only trigger when the primary format extraction fails with an exception
- Fallback logic includes signature checks to avoid redundant attempts (e.g., won't try DOCX fallback if ZIP signature is already detected)
- Each fallback attempt includes its own error handling and logging to track which extraction method ultimately succeeds
- The changes maintain backward compatibility while improving robustness for real-world scenarios where file extensions don't match actual content

https://claude.ai/code/session_01CvTjuuokttYuLKixuQ4KWJ