### PR TITLE
Fix: Use POI ExtractorFactory for robust Word document text extraction

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/SupervisionTaskProcessorService.java
+++ b/src/main/java/uy/com/bay/utiles/services/SupervisionTaskProcessorService.java
@@ -9,11 +9,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Date;
 
-import org.apache.poi.hwpf.HWPFDocument;
-import org.apache.poi.hwpf.extractor.WordExtractor;
-import org.apache.poi.openxml4j.opc.OPCPackage;
-import org.apache.poi.xwpf.extractor.XWPFWordExtractor;
-import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.extractor.ExtractorFactory;
+import org.apache.poi.extractor.POITextExtractor;
 import org.jaudiotagger.audio.AudioFileIO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -157,52 +154,23 @@ public class SupervisionTaskProcessorService {
 		if (data == null || data.length == 0)
 			return "";
 
-		String lowerName = fileName != null ? fileName.toLowerCase() : "";
-
-		// DOCX (ZIP) empieza con 'PK'; también se detecta por extensión como fallback
-		boolean looksZip = data.length >= 2 && data[0] == 'P' && data[1] == 'K';
-		boolean nameDocx = lowerName.endsWith(".docx");
-
-		// DOC (Word 97-2003) empieza con D0 CF 11 E0 A1 B1 1A E1 (OLE2); también por
-		// extensión
-		byte[] oleSig = new byte[] { (byte) 0xD0, (byte) 0xCF, (byte) 0x11, (byte) 0xE0, (byte) 0xA1, (byte) 0xB1,
-				(byte) 0x1A, (byte) 0xE1 };
-		boolean looksOle = data.length >= 8 && Arrays.equals(Arrays.copyOfRange(data, 0, 8), oleSig);
-		boolean nameDoc = lowerName.endsWith(".doc");
-
-		// PDF empieza con %PDF
+		// PDF starts with %PDF
 		boolean looksPdf = data.length >= 4 && data[0] == '%' && data[1] == 'P' && data[2] == 'D' && data[3] == 'F';
-
-		logger.debug(
-				"Extracting questionnaire text: file='{}', looksZip={}, nameDocx={}, looksOle={}, nameDoc={}, looksPdf={}, bytes={}",
-				fileName, looksZip, nameDocx, looksOle, nameDoc, looksPdf, data.length);
-
-		if (looksZip || nameDocx) {
-			try (InputStream is = new ByteArrayInputStream(data);
-					XWPFDocument doc = new XWPFDocument(OPCPackage.open(is));
-					XWPFWordExtractor extractor = new XWPFWordExtractor(doc)) {
-				return extractor.getText();
-			} catch (Exception e) {
-				logger.warn("No se pudo extraer texto DOCX de '{}': {}”, fileName, e.getMessage()");
-			}
-		}
-
-		if (looksOle || nameDoc) {
-			try (InputStream is = new ByteArrayInputStream(data);
-					HWPFDocument doc = new HWPFDocument(is);
-					WordExtractor extractor = new WordExtractor(doc)) {
-				return extractor.getText();
-			} catch (Exception e) {
-				logger.warn("No se pudo extraer texto DOC de '{}': {}”, fileName, e.getMessage()");
-			}
-		}
-
 		if (looksPdf) {
-			return "";
+			logger.debug("Extracting questionnaire text: file='{}' appears to be PDF", fileName);
+			return ""; // We don't process PDFs yet, so return empty string
 		}
 
-		// Fallback: asumir texto plano UTF-8
-		return new String(data, StandardCharsets.UTF_8);
+		logger.debug("Extracting questionnaire text: file='{}', bytes={}", fileName, data.length);
+
+		try (InputStream is = new ByteArrayInputStream(data);
+			 POITextExtractor extractor = ExtractorFactory.createExtractor(is)) {
+			return extractor.getText();
+		} catch (Exception e) {
+			logger.warn("No se pudo extraer texto (POI extractor) de '{}': {}", fileName, e.getMessage());
+			// Fallback: asumir texto plano UTF-8 si no es un formato soportado por POI (o archivo corrupto)
+			return new String(data, StandardCharsets.UTF_8);
+		}
 	}
 
 	public String prettyPrint(String json) throws Exception {


### PR DESCRIPTION
This submission resolves an `IllegalArgumentException` ("The document is really a UNKNOWN file") encountered when parsing Word documents. The core issue was that the application used manual byte-signature checks and file extensions to decide whether to instantiate `HWPFDocument` (for OLE2/`.doc`) or `XWPFDocument` (for OOXML/`.docx`). This approach was brittle and failed when files had incorrect extensions or internal formats that didn't strictly match the hardcoded byte signatures.

**Changes made:**
*   Replaced the manual format detection logic in `SupervisionTaskProcessorService.extractQuestionnaireText` with `org.apache.poi.extractor.ExtractorFactory.createExtractor(InputStream)`.
*   This delegates format detection directly to Apache POI, which is the standard and most reliable way to handle these files.
*   If `ExtractorFactory` encounters an unknown or unsupported file format (e.g., throwing an `IllegalArgumentException`), the code now catches the exception, logs a warning, and executes a fallback strategy (reading the bytes as a UTF-8 string) instead of crashing the batch process.
*   Retained the fast-path check for PDF files to ensure they are skipped quickly.
*   Cleaned up unused Apache POI imports.

**Verification:**
*   Ran `mvn clean test` and `mvn clean compile` successfully.
*   Code review passed successfully with no requested changes.

---
*PR created automatically by Jules for task [13376616210484429354](https://jules.google.com/task/13376616210484429354) started by @araujomelogno*