### PR TITLE
Fix UNKNOWN file IllegalArgumentException in extractQuestionnaireText

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/SupervisionTaskProcessorService.java
+++ b/src/main/java/uy/com/bay/utiles/services/SupervisionTaskProcessorService.java
@@ -9,11 +9,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Date;
 
-import org.apache.poi.hwpf.HWPFDocument;
-import org.apache.poi.hwpf.extractor.WordExtractor;
-import org.apache.poi.openxml4j.opc.OPCPackage;
-import org.apache.poi.xwpf.extractor.XWPFWordExtractor;
-import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.extractor.ExtractorFactory;
+import org.apache.poi.extractor.POITextExtractor;
 import org.jaudiotagger.audio.AudioFileIO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -157,52 +154,23 @@ public class SupervisionTaskProcessorService {
 		if (data == null || data.length == 0)
 			return "";
 
-		String lowerName = fileName != null ? fileName.toLowerCase() : "";
-
-		// DOCX (ZIP) empieza con 'PK'; también se detecta por extensión como fallback
-		boolean looksZip = data.length >= 2 && data[0] == 'P' && data[1] == 'K';
-		boolean nameDocx = lowerName.endsWith(".docx");
-
-		// DOC (Word 97-2003) empieza con D0 CF 11 E0 A1 B1 1A E1 (OLE2); también por
-		// extensión
-		byte[] oleSig = new byte[] { (byte) 0xD0, (byte) 0xCF, (byte) 0x11, (byte) 0xE0, (byte) 0xA1, (byte) 0xB1,
-				(byte) 0x1A, (byte) 0xE1 };
-		boolean looksOle = data.length >= 8 && Arrays.equals(Arrays.copyOfRange(data, 0, 8), oleSig);
-		boolean nameDoc = lowerName.endsWith(".doc");
-
 		// PDF empieza con %PDF
 		boolean looksPdf = data.length >= 4 && data[0] == '%' && data[1] == 'P' && data[2] == 'D' && data[3] == 'F';
-
-		logger.debug(
-				"Extracting questionnaire text: file='{}', looksZip={}, nameDocx={}, looksOle={}, nameDoc={}, looksPdf={}, bytes={}",
-				fileName, looksZip, nameDocx, looksOle, nameDoc, looksPdf, data.length);
-
-		if (looksZip || nameDocx) {
-			try (InputStream is = new ByteArrayInputStream(data);
-					XWPFDocument doc = new XWPFDocument(OPCPackage.open(is));
-					XWPFWordExtractor extractor = new XWPFWordExtractor(doc)) {
-				return extractor.getText();
-			} catch (Exception e) {
-				logger.warn("No se pudo extraer texto DOCX de '{}': {}”, fileName, e.getMessage()");
-			}
-		}
-
-		if (looksOle || nameDoc) {
-			try (InputStream is = new ByteArrayInputStream(data);
-					HWPFDocument doc = new HWPFDocument(is);
-					WordExtractor extractor = new WordExtractor(doc)) {
-				return extractor.getText();
-			} catch (Exception e) {
-				logger.warn("No se pudo extraer texto DOC de '{}': {}”, fileName, e.getMessage()");
-			}
-		}
 
 		if (looksPdf) {
 			return "";
 		}
 
-		// Fallback: asumir texto plano UTF-8
-		return new String(data, StandardCharsets.UTF_8);
+		logger.debug("Extracting questionnaire text: file='{}', bytes={}", fileName, data.length);
+
+		try (InputStream is = new ByteArrayInputStream(data);
+				POITextExtractor extractor = ExtractorFactory.createExtractor(is)) {
+			return extractor.getText();
+		} catch (Exception e) {
+			logger.warn("No se pudo extraer texto de '{}' usando POI: {}. Fallback a UTF-8", fileName, e.getMessage());
+			// Fallback: asumir texto plano UTF-8
+			return new String(data, StandardCharsets.UTF_8);
+		}
 	}
 
 	public String prettyPrint(String json) throws Exception {


### PR DESCRIPTION
This commit fixes a bug where processing `.doc` and `.docx` files during the `SupervisionTask` workflow failed with an `IllegalArgumentException` from Apache POI.

**Root cause:** The system used heuristic filename extensions and OLE magic byte checks to force initialisation of either `HWPFDocument` or `XWPFDocument`. If the file type did not perfectly match the hardcoded byte signatures (e.g. an RTF masquerading as `.doc`, or unexpected encoding), POI threw an exception that crashed the text extraction service and task.

**Fix:** Removed the brittle manual byte checking and replaced it with `org.apache.poi.extractor.ExtractorFactory.createExtractor()`. This delegates the document type detection and specific class initialisation to the Apache POI library, ensuring stable, automatic text extraction for any supported format. Removed unused imports and legacy boolean flag logic (`looksZip`, `looksOle`, etc.). Retained PDF exclusion and UTF-8 string fallback.

---
*PR created automatically by Jules for task [5647714408962503539](https://jules.google.com/task/5647714408962503539) started by @araujomelogno*