### PR TITLE
Fix budget deletion to properly clear study reference

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/BudgetService.java
+++ b/src/main/java/uy/com/bay/utiles/services/BudgetService.java
@@ -43,7 +43,12 @@ public class BudgetService {
 	@Transactional
 	public void delete(Long id) {
 		budgetEntryRepository.deleteAllByBudgetId(id);
-		repository.deleteById(id);
+		repository.findById(id).ifPresent(budget -> {
+			if (budget.getStudy() != null) {
+				budget.getStudy().setBudget(null);
+			}
+			repository.delete(budget);
+		});
 	}
 
 	@Transactional(readOnly = true)


### PR DESCRIPTION
## Summary
Updated the budget deletion logic to properly handle the bidirectional relationship between Budget and Study entities by clearing the study's budget reference before deletion.

## Key Changes
- Modified `BudgetService.delete()` to retrieve the budget entity before deletion
- Added logic to null out the `budget` reference in the associated `Study` entity (if present) before deleting the budget
- Changed from direct `deleteById()` to `findById()` with conditional deletion to enable relationship cleanup

## Implementation Details
The change ensures referential integrity by breaking the bidirectional relationship before deletion. Previously, deleting a budget would leave orphaned references in the Study entity. Now the code:
1. Finds the budget by ID
2. Checks if the budget has an associated study
3. Clears the study's budget reference if it exists
4. Deletes the budget entity

This prevents potential constraint violations or orphaned data when a budget is deleted while still referenced by a study.

https://claude.ai/code/session_01D74iWgYbchDaS4DrsoRJUu