### PR TITLE
Fix TransientObjectException by using bulk JPQL deletes for Budget re…

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/BudgetRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/BudgetRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -28,4 +29,8 @@ public interface BudgetRepository extends JpaRepository<Budget, Long>, JpaSpecif
 
 	@Query("select distinct b from Budget b left join fetch b.entries where b.study = :study")
 	Optional<Budget> findByStudyWithEntries(@Param("study") Study study);
+
+	@Modifying(clearAutomatically = true)
+	@Query("DELETE FROM Budget b WHERE b.id = :id")
+	void deleteByIdBulk(@Param("id") Long id);
 }

--- a/src/main/java/uy/com/bay/utiles/repo/BudgetEntryRepository.java
+++ b/src/main/java/uy/com/bay/utiles/repo/BudgetEntryRepository.java
@@ -15,7 +15,7 @@ public interface BudgetEntryRepository extends JpaRepository<BudgetEntry, Long> 
 	@Query("SELECT be FROM BudgetEntry be LEFT JOIN FETCH be.extras LEFT JOIN FETCH be.fieldworks LEFT JOIN FETCH be.expenseRequests WHERE be.id = :id")
 	Optional<BudgetEntry> findByIdWithExtras(@Param("id") Long id);
 
-	@Modifying
+	@Modifying(clearAutomatically = true)
 	@Query("DELETE FROM BudgetEntry be WHERE be.budget.id = :budgetId")
 	void deleteAllByBudgetId(@Param("budgetId") Long budgetId);
 }

--- a/src/main/java/uy/com/bay/utiles/services/BudgetService.java
+++ b/src/main/java/uy/com/bay/utiles/services/BudgetService.java
@@ -43,12 +43,7 @@ public class BudgetService {
 	@Transactional
 	public void delete(Long id) {
 		budgetEntryRepository.deleteAllByBudgetId(id);
-		repository.findById(id).ifPresent(budget -> {
-			if (budget.getStudy() != null) {
-				budget.getStudy().setBudget(null);
-			}
-			repository.delete(budget);
-		});
+		repository.deleteByIdBulk(id);
 	}
 
 	@Transactional(readOnly = true)


### PR DESCRIPTION
…moval

Budget.entries is EAGER and Study.fieldworks/Fieldwork.budgetEntry are also EAGER, so loading Budget via em.find (inside repository.deleteById) pulls BudgetEntry entities into the Hibernate session. When em.remove transitions Budget to REMOVED state, CHECK_ON_FLUSH finds BudgetEntry.budget pointing to the REMOVED Budget (session.contains returns false for removed entities) and throws TransientObjectException. OSIV compounds the issue because it keeps the EntityManager open across the whole HTTP request, allowing stale BudgetEntry entities from prior transactions to persist in the L1 cache.

Fix: bypass entity loading entirely using @Modifying JPQL bulk deletes for both BudgetEntry and Budget. clearAutomatically=true evicts stale entities from the L1 cache after each bulk delete, ensuring no managed entity referencing a removed Budget can be found by CHECK_ON_FLUSH at commit time.

https://claude.ai/code/session_01D74iWgYbchDaS4DrsoRJUu