### PR TITLE
Calculate spent amount dynamically from related entities

### DIFF
--- a/src/main/java/uy/com/bay/utiles/entities/BudgetEntry.java
+++ b/src/main/java/uy/com/bay/utiles/entities/BudgetEntry.java
@@ -11,6 +11,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Transient;
 import uy.com.bay.utiles.data.AbstractEntity;
 import uy.com.bay.utiles.data.ExpenseRequest;
+import uy.com.bay.utiles.data.ExpenseStatus;
 import uy.com.bay.utiles.data.Fieldwork;
 
 @Entity
@@ -18,7 +19,6 @@ public class BudgetEntry extends AbstractEntity {
 
 	private Double ammount;
 	private Integer quantity;
-	private Double spent = 0.0;
 	private LocalDate created;
 
 	public BudgetEntry() {
@@ -70,13 +70,31 @@ public class BudgetEntry extends AbstractEntity {
 	}
 
 	public Double getSpent() {
-		if (spent != null)
-			return spent;
-		return 0d;
-	}
-
-	public void setSpent(Double spent) {
-		this.spent = spent;
+		double totalSpent = 0.0;
+		if (extras != null) {
+			for (Extra extra : extras) {
+				if (extra.getQuantity() != null && extra.getUnitPrice() != null) {
+					totalSpent += extra.getQuantity() * extra.getUnitPrice();
+				}
+			}
+		}
+		if (expenseRequests != null) {
+			for (ExpenseRequest expenseRequest : expenseRequests) {
+				if (ExpenseStatus.TRANSFERIDO.equals(expenseRequest.getExpenseStatus())
+						&& expenseRequest.getExpenseTransfer() != null
+						&& expenseRequest.getExpenseTransfer().getAmount() != null) {
+					totalSpent += expenseRequest.getExpenseTransfer().getAmount();
+				}
+			}
+		}
+		if (fieldworks != null) {
+			for (Fieldwork fieldwork : fieldworks) {
+				if (fieldwork.getUnitCost() != null && fieldwork.getCompleted() != null) {
+					totalSpent += fieldwork.getUnitCost().doubleValue() * fieldwork.getCompleted();
+				}
+			}
+		}
+		return totalSpent;
 	}
 
 	public BudgetConcept getConcept() {

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
@@ -32,10 +32,14 @@ import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.shared.Registration;
 
+import uy.com.bay.utiles.data.ExpenseRequest;
+import uy.com.bay.utiles.data.ExpenseStatus;
+import uy.com.bay.utiles.data.Fieldwork;
 import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.entities.Budget;
 import uy.com.bay.utiles.entities.BudgetConcept;
 import uy.com.bay.utiles.entities.BudgetEntry;
+import uy.com.bay.utiles.entities.Extra;
 import uy.com.bay.utiles.services.BudgetConceptService;
 import uy.com.bay.utiles.services.BudgetService;
 import uy.com.bay.utiles.services.StudyService;
@@ -119,7 +123,27 @@ public class BudgetForm extends VerticalLayout {
 		HorizontalLayout actions = new HorizontalLayout(saveButton);
 		actions.setPadding(false);
 
-		Grid.Column<BudgetEntry> spentColumn = entriesGrid.addColumn(BudgetEntry::getSpent).setHeader("Gastado");
+		Grid.Column<BudgetEntry> spentColumn = entriesGrid.addColumn(entry -> {
+			Double totalSpent = 0.0;
+			for (Extra extra : entry.getExtras()) {
+				if (extra.getQuantity() != null && extra.getUnitPrice() != null) {
+					totalSpent += extra.getQuantity() * extra.getUnitPrice();
+				}
+			}
+			for (ExpenseRequest expenseRequest : entry.getExpenseRequests()) {
+				if (ExpenseStatus.TRANSFERIDO.equals(expenseRequest.getExpenseStatus())
+						&& expenseRequest.getExpenseTransfer() != null
+						&& expenseRequest.getExpenseTransfer().getAmount() != null) {
+					totalSpent += expenseRequest.getExpenseTransfer().getAmount();
+				}
+			}
+			for (Fieldwork fieldwork : entry.getFieldworks()) {
+				if (fieldwork.getUnitCost() != null && fieldwork.getCompleted() != null) {
+					totalSpent += fieldwork.getUnitCost().doubleValue() * fieldwork.getCompleted();
+				}
+			}
+			return totalSpent;
+		}).setHeader("Gastado");
 
 		Grid.Column<BudgetEntry> editorColumn = entriesGrid.addComponentColumn(entry -> {
 			HorizontalLayout hl = new HorizontalLayout();


### PR DESCRIPTION
## Summary
Refactored the `BudgetEntry.spent` field from a stored value to a computed property that dynamically calculates the total spent amount based on related entities (Extras, ExpenseRequests, and Fieldworks).

## Key Changes
- **Removed persistent `spent` field** from `BudgetEntry` entity and its setter method
- **Implemented dynamic calculation** in `BudgetEntry.getSpent()` that:
  - Sums up costs from all `Extra` entries (quantity × unit price)
  - Adds amounts from `ExpenseRequest` entries with `TRANSFERIDO` status
  - Includes costs from `Fieldwork` entries (unit cost × completed quantity)
- **Updated `BudgetForm` grid column** to use the same calculation logic for displaying spent amounts in the UI

## Implementation Details
- The spent amount is now calculated on-demand by iterating through related collections with null-safety checks
- Only `ExpenseRequest` entries with `TRANSFERIDO` status are included in the calculation
- The calculation logic is duplicated in both the entity getter and the UI grid renderer to ensure consistency
- Added necessary imports for `ExpenseStatus`, `ExpenseRequest`, `Fieldwork`, and `Extra` classes

https://claude.ai/code/session_01WCDZJM6AwWdw9RchS1rqQy