### PR TITLE
Fix lazy loading of budget entry collections

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/BudgetService.java
+++ b/src/main/java/uy/com/bay/utiles/services/BudgetService.java
@@ -3,6 +3,7 @@ package uy.com.bay.utiles.services;
 import java.util.List;
 import java.util.Optional;
 
+import org.hibernate.Hibernate;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -27,7 +28,19 @@ public class BudgetService {
 
 	@Transactional(readOnly = true)
 	public Optional<Budget> get(Long id) {
-		return repository.findByIdWithEntries(id);
+		Optional<Budget> budget = repository.findByIdWithEntries(id);
+		budget.ifPresent(this::initializeEntryCollections);
+		return budget;
+	}
+
+	private void initializeEntryCollections(Budget budget) {
+		if (budget.getEntries() != null) {
+			for (BudgetEntry entry : budget.getEntries()) {
+				Hibernate.initialize(entry.getExtras());
+				Hibernate.initialize(entry.getExpenseRequests());
+				Hibernate.initialize(entry.getFieldworks());
+			}
+		}
 	}
 
 	@Transactional
@@ -67,7 +80,9 @@ public class BudgetService {
 
 	@Transactional(readOnly = true)
 	public Optional<Budget> findByIdWithEntries(Long id) {
-		return repository.findByIdWithEntries(id);
+		Optional<Budget> budget = repository.findByIdWithEntries(id);
+		budget.ifPresent(this::initializeEntryCollections);
+		return budget;
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
@@ -93,7 +93,11 @@ public class BudgetView extends VerticalLayout implements BeforeEnterObserver {
 		if (budget == null) {
 			closeEditor();
 		} else {
-			form.setBudget(budget);
+			Budget toEdit = budget;
+			if (budget.getId() != null) {
+				toEdit = budgetService.get(budget.getId()).orElse(budget);
+			}
+			form.setBudget(toEdit);
 			form.setVisible(true);
 			addClassName("editing");
 		}


### PR DESCRIPTION
## Summary
This PR fixes lazy loading issues with budget entry collections by explicitly initializing nested collections when fetching budgets. This prevents `LazyInitializationException` errors when accessing related data outside of a transaction context.

## Key Changes
- Added `initializeEntryCollections()` method to `BudgetService` that explicitly initializes lazy-loaded collections (`extras`, `expenseRequests`, `fieldworks`) for each budget entry using Hibernate's `initialize()` method
- Updated `get()` method to call the new initialization method after fetching a budget
- Updated `findByIdWithEntries()` method to call the new initialization method for consistency
- Modified `BudgetView.editBudget()` to fetch a fresh budget instance from the service when editing an existing budget, ensuring all nested collections are properly initialized before being passed to the form

## Implementation Details
- The initialization is performed within the `@Transactional(readOnly = true)` context to ensure the session is active during collection initialization
- The `initializeEntryCollections()` method safely checks for null entries before iterating
- The view layer now explicitly fetches the budget through the service layer rather than using a potentially detached entity, ensuring proper lazy loading handling

https://claude.ai/code/session_0187hCH5rfnHkYBoR3Y8xPqh