### PR TITLE
Replace SimpleDateFormat with DateTimeFormatter in ExpensesView

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpensesView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpensesView.java
@@ -140,7 +140,7 @@ public class ExpensesView extends Div implements BeforeEnterObserver {
 				.setHeader("Aprobado:").setAutoWidth(true).setSortable(true).setSortProperty("aprovalDate");
 		Grid.Column<ExpenseRequest> transferDateColumn = grid
 				.addColumn(new com.vaadin.flow.data.renderer.TextRenderer<>(er -> er.getTransferDate() != null
-						? new java.text.SimpleDateFormat("dd/MM/yyyy").format(er.getTransferDate())
+						? er.getTransferDate().format(java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy"))
 						: ""))
 				.setHeader("Transferido").setAutoWidth(true).setSortable(true).setSortProperty("transferDate");
 		Grid.Column<ExpenseRequest> amountColumn = grid.addColumn(ExpenseRequest::getAmount).setHeader("Monto")


### PR DESCRIPTION
## Summary
Modernized date formatting in the ExpensesView by replacing the legacy `SimpleDateFormat` with the modern `DateTimeFormatter` API from `java.time` package.

## Key Changes
- Replaced `SimpleDateFormat` with `DateTimeFormatter.ofPattern()` for formatting transfer dates
- Updated the date formatting logic to use the modern Java Time API instead of the deprecated `java.text` package
- Maintained the same date format pattern ("dd/MM/yyyy") to preserve existing behavior

## Implementation Details
The change improves code quality by:
- Using thread-safe date formatting (DateTimeFormatter is immutable and thread-safe, unlike SimpleDateFormat)
- Adopting modern Java Time API best practices
- Reducing reliance on legacy date/time classes

https://claude.ai/code/session_01Jg4dFMiSQV3AtZ8wW43T6g