### PR TITLE
Add Alchemer API integration to fetch completed surveys

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/AlchemerSurveyResponseHelper.java
+++ b/src/main/java/uy/com/bay/utiles/services/AlchemerSurveyResponseHelper.java
@@ -3,9 +3,14 @@ package uy.com.bay.utiles.services;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import uy.com.bay.utiles.data.AlchemerAnswer;
@@ -19,9 +24,18 @@ import uy.com.bay.utiles.dto.SurveyResponseDTO;
 @Service
 public class AlchemerSurveyResponseHelper {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(AlchemerSurveyResponseHelper.class);
+
     private final AlchemerContactRepository contactRepository;
     private final AlchemerAnswerRepository answerRepository;
     private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${alchemer.api.token}")
+    private String apiToken;
+
+    @Value("${alchemer.api.token.secret}")
+    private String apiTokenSecret;
 
     public AlchemerSurveyResponseHelper(AlchemerContactRepository contactRepository,
                                 AlchemerAnswerRepository answerRepository,
@@ -29,6 +43,22 @@ public class AlchemerSurveyResponseHelper {
         this.contactRepository = contactRepository;
         this.answerRepository = answerRepository;
         this.objectMapper = objectMapper;
+    }
+
+    public Integer getCompletedSurveys(String surveyId) {
+        try {
+            String url = String.format(
+                    "https://api.alchemer.com/v5/survey/%s/surveyresponse?api_token=%s&api_token_secret=%s"
+                            + "&filter[field][0]=status&filter[operator][0]==&filter[value][0]=Complete",
+                    surveyId, apiToken, apiTokenSecret);
+
+            String response = restTemplate.getForObject(url, String.class);
+            JsonNode root = objectMapper.readTree(response);
+            return root.path("total_count").asInt();
+        } catch (Exception e) {
+            LOGGER.error("Error fetching completed surveys from Alchemer API for surveyId {}", surveyId, e);
+            return 0;
+        }
     }
 
     public String buildSurveyResponseJson(int surveyId, String phoneNumber) throws JsonProcessingException {


### PR DESCRIPTION
## Summary
This PR adds integration with the Alchemer API to retrieve the count of completed surveys for a given survey ID. The implementation includes necessary dependencies, configuration properties, and error handling.

## Key Changes
- Added logging capability using SLF4J Logger
- Introduced RestTemplate for making HTTP calls to the Alchemer API
- Added configuration properties for Alchemer API authentication (`alchemer.api.token` and `alchemer.api.token.secret`)
- Implemented `getCompletedSurveys(String surveyId)` method that:
  - Calls the Alchemer API v5 endpoint to fetch survey responses filtered by "Complete" status
  - Parses the JSON response using Jackson's JsonNode
  - Extracts and returns the `total_count` value
  - Includes comprehensive error handling with logging that returns 0 on failure

## Implementation Details
- The API call includes filtering for completed surveys using the Alchemer API filter syntax
- JsonNode is used for flexible JSON parsing to extract the total count
- Exceptions are caught and logged with the survey ID for debugging purposes
- The method gracefully degrades by returning 0 if the API call fails

https://claude.ai/code/session_018NAVRQAjqiyLQVEcuyhNk4