### PR TITLE
Add Alchemer survey response integration to budget spent calculation

### DIFF
--- a/src/main/java/uy/com/bay/utiles/entities/BudgetEntry.java
+++ b/src/main/java/uy/com/bay/utiles/entities/BudgetEntry.java
@@ -20,6 +20,7 @@ public class BudgetEntry extends AbstractEntity {
 	private Double ammount;
 	private Integer quantity;
 	private LocalDate created;
+	private Double spent;
 
 	public BudgetEntry() {
 		this.created = LocalDate.now();
@@ -70,6 +71,9 @@ public class BudgetEntry extends AbstractEntity {
 	}
 
 	public Double getSpent() {
+		if (spent != null) {
+			return spent;
+		}
 		double totalSpent = 0.0;
 		if (extras != null) {
 			for (Extra extra : extras) {
@@ -149,6 +153,10 @@ public class BudgetEntry extends AbstractEntity {
 
 	public void setCreated(LocalDate created) {
 		this.created = created;
+	}
+
+	public void setSpent(Double spent) {
+		this.spent = spent;
 	}
 
 }

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
@@ -40,6 +40,7 @@ import uy.com.bay.utiles.entities.Budget;
 import uy.com.bay.utiles.entities.BudgetConcept;
 import uy.com.bay.utiles.entities.BudgetEntry;
 import uy.com.bay.utiles.entities.Extra;
+import uy.com.bay.utiles.services.AlchemerSurveyResponseHelper;
 import uy.com.bay.utiles.services.BudgetConceptService;
 import uy.com.bay.utiles.services.BudgetService;
 import uy.com.bay.utiles.services.StudyService;
@@ -51,20 +52,23 @@ public class BudgetForm extends VerticalLayout {
 	private final ComboBox<Study> study = new ComboBox<>("Estudio");
 	private final Grid<BudgetEntry> entriesGrid = new Grid<>(BudgetEntry.class);
 	private final Button addEntryButton = new Button("Agregar concepto");
+	private final Button refresh = new Button("Actualizar campo");
 	private final Button save = new Button("Guardar");
 	private final Button delete = new Button("Borrar");
 	private final Button close = new Button("Cerrar");
 	private final Binder<Budget> binder = new BeanValidationBinder<>(Budget.class);
 	private final BudgetConceptService budgetConceptService;
 	private final BudgetService budgetService;
+	private final AlchemerSurveyResponseHelper alchemerSurveyResponseHelper;
 	private final Editor<BudgetEntry> editor;
 	private Span totalAmountLabel;
 	private Span totalSpentLabel;
 
 	public BudgetForm(StudyService studyService, BudgetConceptService budgetConceptService,
-			BudgetService budgetService) {
+			BudgetService budgetService, AlchemerSurveyResponseHelper alchemerSurveyResponseHelper) {
 		this.budgetConceptService = budgetConceptService;
 		this.budgetService = budgetService;
+		this.alchemerSurveyResponseHelper = alchemerSurveyResponseHelper;
 		addClassName("budget-form");
 		binder.bindInstanceFields(this);
 		study.setItems(studyService.listAll());
@@ -72,7 +76,8 @@ public class BudgetForm extends VerticalLayout {
 
 		editor = entriesGrid.getEditor();
 		configureGrid();
-		add(createFormLayout(), entriesGrid, addEntryButton, createButtonsLayout());
+		HorizontalLayout entryActions = new HorizontalLayout(addEntryButton, refresh);
+		add(createFormLayout(), entriesGrid, entryActions, createButtonsLayout());
 		addEntryButton.addClickListener(click -> {
 			BudgetEntry newEntry = new BudgetEntry();
 			if (binder.getBean().getEntries() == null) {
@@ -83,6 +88,30 @@ public class BudgetForm extends VerticalLayout {
 			editor.editItem(newEntry);
 			updateTotal();
 		});
+		refresh.addClickListener(click -> refreshSpentFromAlchemer());
+	}
+
+	private void refreshSpentFromAlchemer() {
+		if (binder.getBean() == null || binder.getBean().getEntries() == null) {
+			return;
+		}
+		for (BudgetEntry budgetEntry : binder.getBean().getEntries()) {
+			Double totalFielwdorkCost = 0.0;
+			if (budgetEntry.getFieldworks() != null) {
+				for (Fieldwork fieldwork : budgetEntry.getFieldworks()) {
+					if (fieldwork.getAlchemerId() != null && !fieldwork.getAlchemerId().isEmpty()) {
+						Integer completedSurveys = alchemerSurveyResponseHelper
+								.getCompletedSurveys(fieldwork.getAlchemerId());
+						if (completedSurveys != null && budgetEntry.getAmmount() != null) {
+							totalFielwdorkCost += completedSurveys * budgetEntry.getAmmount();
+						}
+					}
+				}
+			}
+			budgetEntry.setSpent(totalFielwdorkCost);
+		}
+		entriesGrid.setItems(binder.getBean().getEntries());
+		updateTotal();
 	}
 
 	private Component createFormLayout() {

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
@@ -17,6 +17,7 @@ import com.vaadin.flow.router.Route;
 
 import jakarta.annotation.security.RolesAllowed;
 import uy.com.bay.utiles.entities.Budget;
+import uy.com.bay.utiles.services.AlchemerSurveyResponseHelper;
 import uy.com.bay.utiles.services.BudgetConceptService;
 import uy.com.bay.utiles.services.BudgetService;
 import uy.com.bay.utiles.services.StudyService;
@@ -33,13 +34,13 @@ public class BudgetView extends VerticalLayout implements BeforeEnterObserver {
 	private final BudgetService budgetService;
 
 	public BudgetView(BudgetService budgetService, StudyService studyService,
-			BudgetConceptService budgetConceptService) {
+			BudgetConceptService budgetConceptService, AlchemerSurveyResponseHelper alchemerSurveyResponseHelper) {
 		this.budgetService = budgetService;
 		addClassName("budget-view");
 		setSizeFull();
 		configureGrid();
 
-		form = new BudgetForm(studyService, budgetConceptService, budgetService);
+		form = new BudgetForm(studyService, budgetConceptService, budgetService, alchemerSurveyResponseHelper);
 		form.addSaveListener(this::saveBudget);
 		form.addDeleteListener(this::deleteBudget);
 		form.addCloseListener(e -> closeEditor());


### PR DESCRIPTION
## Summary
This PR integrates Alchemer survey response data into the budget management system, allowing users to automatically refresh and calculate spent amounts based on completed surveys from fieldwork activities.

## Key Changes
- **BudgetForm.java**
  - Added `AlchemerSurveyResponseHelper` dependency injection
  - Introduced "Actualizar campo" (Refresh Field) button to recalculate spent amounts from Alchemer survey data
  - Implemented `refreshSpentFromAlchemer()` method that:
    - Iterates through budget entries and their associated fieldwork activities
    - Queries Alchemer for completed surveys per fieldwork
    - Calculates total spent as: completed surveys × budget entry amount
    - Updates the grid and total calculations
  - Reorganized entry action buttons into a `HorizontalLayout` for better UI layout

- **BudgetEntry.java**
  - Added `spent` field to store manually set spent amounts
  - Modified `getSpent()` method to return the stored `spent` value if set, otherwise calculate from extras (preserving backward compatibility)
  - Added `setSpent(Double spent)` setter method

- **BudgetView.java**
  - Updated constructor to accept `AlchemerSurveyResponseHelper` dependency
  - Passed the helper to `BudgetForm` initialization

## Implementation Details
- The refresh functionality allows users to manually sync budget spent amounts with actual Alchemer survey completion data
- The implementation maintains backward compatibility by checking if a `spent` value is explicitly set before falling back to the extras-based calculation
- Null safety checks are in place for fieldwork IDs and completed survey counts

https://claude.ai/code/session_01FFmtm1XA9DvrkF8fKDUM7P