### PR TITLE
Add manual refresh for budget entry spent amounts from Alchemer

### DIFF
--- a/src/main/java/uy/com/bay/utiles/entities/BudgetEntry.java
+++ b/src/main/java/uy/com/bay/utiles/entities/BudgetEntry.java
@@ -46,6 +46,9 @@ public class BudgetEntry extends AbstractEntity {
 	@Transient
 	private Double total;
 
+	@Transient
+	private Double spent;
+
 	public Double getTotal() {
 		if (ammount != null && quantity != null) {
 			return ammount * quantity;
@@ -70,6 +73,9 @@ public class BudgetEntry extends AbstractEntity {
 	}
 
 	public Double getSpent() {
+		if (spent != null) {
+			return spent;
+		}
 		double totalSpent = 0.0;
 		if (extras != null) {
 			for (Extra extra : extras) {
@@ -139,6 +145,10 @@ public class BudgetEntry extends AbstractEntity {
 
 	public void setTotal(Double total) {
 		this.total = total;
+	}
+
+	public void setSpent(Double spent) {
+		this.spent = spent;
 	}
 
 	public LocalDate getCreated() {

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
@@ -40,6 +40,7 @@ import uy.com.bay.utiles.entities.Budget;
 import uy.com.bay.utiles.entities.BudgetConcept;
 import uy.com.bay.utiles.entities.BudgetEntry;
 import uy.com.bay.utiles.entities.Extra;
+import uy.com.bay.utiles.services.AlchemerSurveyResponseHelper;
 import uy.com.bay.utiles.services.BudgetConceptService;
 import uy.com.bay.utiles.services.BudgetService;
 import uy.com.bay.utiles.services.StudyService;
@@ -51,20 +52,23 @@ public class BudgetForm extends VerticalLayout {
 	private final ComboBox<Study> study = new ComboBox<>("Estudio");
 	private final Grid<BudgetEntry> entriesGrid = new Grid<>(BudgetEntry.class);
 	private final Button addEntryButton = new Button("Agregar concepto");
+	private final Button refresh = new Button("Actualizar campo");
 	private final Button save = new Button("Guardar");
 	private final Button delete = new Button("Borrar");
 	private final Button close = new Button("Cerrar");
 	private final Binder<Budget> binder = new BeanValidationBinder<>(Budget.class);
 	private final BudgetConceptService budgetConceptService;
 	private final BudgetService budgetService;
+	private final AlchemerSurveyResponseHelper alchemerSurveyResponseHelper;
 	private final Editor<BudgetEntry> editor;
 	private Span totalAmountLabel;
 	private Span totalSpentLabel;
 
 	public BudgetForm(StudyService studyService, BudgetConceptService budgetConceptService,
-			BudgetService budgetService) {
+			BudgetService budgetService, AlchemerSurveyResponseHelper alchemerSurveyResponseHelper) {
 		this.budgetConceptService = budgetConceptService;
 		this.budgetService = budgetService;
+		this.alchemerSurveyResponseHelper = alchemerSurveyResponseHelper;
 		addClassName("budget-form");
 		binder.bindInstanceFields(this);
 		study.setItems(studyService.listAll());
@@ -72,7 +76,8 @@ public class BudgetForm extends VerticalLayout {
 
 		editor = entriesGrid.getEditor();
 		configureGrid();
-		add(createFormLayout(), entriesGrid, addEntryButton, createButtonsLayout());
+		HorizontalLayout entryActions = new HorizontalLayout(addEntryButton, refresh);
+		add(createFormLayout(), entriesGrid, entryActions, createButtonsLayout());
 		addEntryButton.addClickListener(click -> {
 			BudgetEntry newEntry = new BudgetEntry();
 			if (binder.getBean().getEntries() == null) {
@@ -83,6 +88,30 @@ public class BudgetForm extends VerticalLayout {
 			editor.editItem(newEntry);
 			updateTotal();
 		});
+		refresh.addClickListener(click -> refreshSpent());
+	}
+
+	private void refreshSpent() {
+		if (binder.getBean() == null || binder.getBean().getEntries() == null) {
+			return;
+		}
+		for (BudgetEntry entry : binder.getBean().getEntries()) {
+			Double totalFielwdorkCost = 0.0;
+			if (entry.getFieldworks() != null) {
+				for (Fieldwork fieldwork : entry.getFieldworks()) {
+					if (fieldwork.getAlchemerId() != null && !fieldwork.getAlchemerId().isEmpty()) {
+						Integer completedSurveys = alchemerSurveyResponseHelper
+								.getCompletedSurveys(fieldwork.getAlchemerId());
+						if (completedSurveys != null && fieldwork.getUnitCost() != null) {
+							totalFielwdorkCost += fieldwork.getUnitCost().doubleValue() * completedSurveys;
+						}
+					}
+				}
+			}
+			entry.setSpent(totalFielwdorkCost);
+		}
+		entriesGrid.setItems(binder.getBean().getEntries());
+		updateTotal();
 	}
 
 	private Component createFormLayout() {

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
@@ -17,6 +17,7 @@ import com.vaadin.flow.router.Route;
 
 import jakarta.annotation.security.RolesAllowed;
 import uy.com.bay.utiles.entities.Budget;
+import uy.com.bay.utiles.services.AlchemerSurveyResponseHelper;
 import uy.com.bay.utiles.services.BudgetConceptService;
 import uy.com.bay.utiles.services.BudgetService;
 import uy.com.bay.utiles.services.StudyService;
@@ -33,13 +34,13 @@ public class BudgetView extends VerticalLayout implements BeforeEnterObserver {
 	private final BudgetService budgetService;
 
 	public BudgetView(BudgetService budgetService, StudyService studyService,
-			BudgetConceptService budgetConceptService) {
+			BudgetConceptService budgetConceptService, AlchemerSurveyResponseHelper alchemerSurveyResponseHelper) {
 		this.budgetService = budgetService;
 		addClassName("budget-view");
 		setSizeFull();
 		configureGrid();
 
-		form = new BudgetForm(studyService, budgetConceptService, budgetService);
+		form = new BudgetForm(studyService, budgetConceptService, budgetService, alchemerSurveyResponseHelper);
 		form.addSaveListener(this::saveBudget);
 		form.addDeleteListener(this::deleteBudget);
 		form.addCloseListener(e -> closeEditor());


### PR DESCRIPTION
## Summary
This PR adds functionality to manually refresh the "spent" amount for budget entries by querying completed surveys from Alchemer. Users can now click a "Actualizar campo" (Refresh Field) button to recalculate spending based on fieldwork survey completion data.

## Key Changes
- Added `AlchemerSurveyResponseHelper` dependency injection to `BudgetForm` and `BudgetView`
- Added "Actualizar campo" (Refresh Field) button to the budget entry actions layout
- Implemented `refreshSpent()` method that:
  - Iterates through all budget entries and their associated fieldworks
  - Queries Alchemer for completed surveys per fieldwork
  - Calculates total spent amount based on unit cost × completed surveys count
  - Updates the grid and total amounts display
- Added `spent` field to `BudgetEntry` entity as a `@Transient` property to store manually refreshed values
- Modified `BudgetEntry.getSpent()` to return the manually set spent value if available, otherwise calculate from extras
- Added setter method `setSpent()` to `BudgetEntry` for programmatic updates

## Implementation Details
- The refresh button is grouped with the "Agregar concepto" button in a `HorizontalLayout` for better UI organization
- The `refreshSpent()` method includes null checks to safely handle missing fieldwork or Alchemer IDs
- The spent amount calculation only processes fieldworks with valid Alchemer IDs and unit costs
- Grid items are refreshed after updating spent amounts to reflect changes in the UI

https://claude.ai/code/session_01YRovab9sgngpboR1rW9kJJ