### PR TITLE
Fix cascade deletion of budget entries by detaching related entities

### DIFF
--- a/src/main/java/uy/com/bay/utiles/repo/BudgetEntryRepository.java
+++ b/src/main/java/uy/com/bay/utiles/repo/BudgetEntryRepository.java
@@ -16,6 +16,18 @@ public interface BudgetEntryRepository extends JpaRepository<BudgetEntry, Long> 
 	Optional<BudgetEntry> findByIdWithExtras(@Param("id") Long id);
 
 	@Modifying(clearAutomatically = true)
+	@Query("UPDATE Extra e SET e.budgetEntry = null WHERE e.budgetEntry.id IN (SELECT be.id FROM BudgetEntry be WHERE be.budget.id = :budgetId)")
+	void detachExtrasByBudgetId(@Param("budgetId") Long budgetId);
+
+	@Modifying(clearAutomatically = true)
+	@Query("UPDATE ExpenseRequest er SET er.budgetEntry = null WHERE er.budgetEntry.id IN (SELECT be.id FROM BudgetEntry be WHERE be.budget.id = :budgetId)")
+	void detachExpenseRequestsByBudgetId(@Param("budgetId") Long budgetId);
+
+	@Modifying(clearAutomatically = true)
+	@Query("UPDATE Fieldwork fw SET fw.budgetEntry = null WHERE fw.budgetEntry.id IN (SELECT be.id FROM BudgetEntry be WHERE be.budget.id = :budgetId)")
+	void detachFieldworksByBudgetId(@Param("budgetId") Long budgetId);
+
+	@Modifying(clearAutomatically = true)
 	@Query("DELETE FROM BudgetEntry be WHERE be.budget.id = :budgetId")
 	void deleteAllByBudgetId(@Param("budgetId") Long budgetId);
 }

--- a/src/main/java/uy/com/bay/utiles/services/BudgetService.java
+++ b/src/main/java/uy/com/bay/utiles/services/BudgetService.java
@@ -55,6 +55,9 @@ public class BudgetService {
 
 	@Transactional
 	public void delete(Long id) {
+		budgetEntryRepository.detachExtrasByBudgetId(id);
+		budgetEntryRepository.detachExpenseRequestsByBudgetId(id);
+		budgetEntryRepository.detachFieldworksByBudgetId(id);
 		budgetEntryRepository.deleteAllByBudgetId(id);
 		repository.deleteByIdBulk(id);
 	}


### PR DESCRIPTION
## Summary
This PR fixes a cascade deletion issue when deleting budgets by properly detaching related entities before deleting budget entries. Previously, deleting a budget would fail due to foreign key constraints from Extra, ExpenseRequest, and Fieldwork entities that reference BudgetEntry.

## Key Changes
- Added three new repository methods to `BudgetEntryRepository`:
  - `detachExtrasByBudgetId()` - Sets budgetEntry to null for all Extra entities linked to budget entries
  - `detachExpenseRequestsByBudgetId()` - Sets budgetEntry to null for all ExpenseRequest entities linked to budget entries
  - `detachFieldworksByBudgetId()` - Sets budgetEntry to null for all Fieldwork entities linked to budget entries

- Updated `BudgetService.delete()` to call the three detach methods before deleting budget entries, ensuring referential integrity is maintained during cascade deletion

## Implementation Details
- All new methods use `@Modifying(clearAutomatically = true)` to ensure the persistence context is cleared after execution
- The detach operations use nested SELECT queries to identify all budget entries belonging to the target budget
- This approach avoids orphaned records and foreign key constraint violations during the deletion process

https://claude.ai/code/session_015DhXuSHU9qTy7zbgzarVGj