### PR TITLE
Add ODOO product ID field to BudgetConcept entity and UI

### DIFF
--- a/src/main/java/uy/com/bay/utiles/entities/BudgetConcept.java
+++ b/src/main/java/uy/com/bay/utiles/entities/BudgetConcept.java
@@ -11,6 +11,7 @@ public class BudgetConcept extends AbstractEntity {
 
     private String name;
     private String description;
+    private String odooProductId;
 
     @Enumerated(EnumType.STRING)
     private MatchType matchType;
@@ -29,6 +30,14 @@ public class BudgetConcept extends AbstractEntity {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public String getOdooProductId() {
+        return odooProductId;
+    }
+
+    public void setOdooProductId(String odooProductId) {
+        this.odooProductId = odooProductId;
     }
 
     public MatchType getMatchType() {

--- a/src/main/java/uy/com/bay/utiles/views/budgetconcept/BudgetConceptView.java
+++ b/src/main/java/uy/com/bay/utiles/views/budgetconcept/BudgetConceptView.java
@@ -44,6 +44,7 @@ public class BudgetConceptView extends Div implements BeforeEnterObserver {
 
 	private TextField name;
 	private TextArea description;
+	private TextField odooProductId;
 	private ComboBox<MatchType> matchType;
 
 	private final Button cancel = new Button("Cerrar");
@@ -170,9 +171,10 @@ public class BudgetConceptView extends Div implements BeforeEnterObserver {
 		FormLayout formLayout = new FormLayout();
 		name = new TextField("Nombre");
 		description = new TextArea("Descripción");
+		odooProductId = new TextField("Id de producto ODOO");
 		matchType = new ComboBox<>("Tipo de Coincidencia");
 		matchType.setItems(MatchType.values());
-		formLayout.add(name, description, matchType);
+		formLayout.add(name, description, odooProductId, matchType);
 
 		editorDiv.add(formLayout);
 		createButtonLayout(editorLayoutDiv);


### PR DESCRIPTION
## Summary
This PR adds support for storing and managing ODOO product IDs in the BudgetConcept entity and its corresponding UI view.

## Key Changes
- **Entity Model**: Added `odooProductId` field to `BudgetConcept` class with getter and setter methods
- **UI Form**: Added `odooProductId` text field to `BudgetConceptView` form layout, positioned between the description and match type fields
- **Form Layout**: Updated the form to include the new ODOO product ID input field in the editor layout

## Implementation Details
- The `odooProductId` field is a simple String property following the existing pattern used for `name` and `description` fields
- The UI field is implemented as a `TextField` with the label "Id de producto ODOO"
- The field is integrated into the existing form layout without modifying the structure of other components

https://claude.ai/code/session_013TQe79kxypVqfYNWHaiEAN