### PR TITLE
Add method to fetch account move lines from Odoo

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/OdooService.java
+++ b/src/main/java/uy/com/bay/utiles/services/OdooService.java
@@ -295,4 +295,58 @@ public class OdooService {
 		return Collections.emptyList(); // Return empty list in case of any error
 	}
 
+	@SuppressWarnings("unchecked")
+	public List<Map<String, Object>> getOdooAccountMoveLines(String analitycAccountId, String productId) {
+		if (objectClient == null) {
+			logger.error("Odoo object client not initialized. Cannot fetch account move lines.");
+			return Collections.emptyList();
+		}
+		try {
+			Integer uid = authenticate();
+			if (uid == null) {
+				logger.error("Cannot fetch account move lines: Authentication failed.");
+				return Collections.emptyList();
+			}
+
+			List<String> fieldsToFetch = Arrays.asList("id", "date", "move_id", "name", "product_id", "account_id",
+					"debit", "credit", "balance");
+
+			List<Object> domain = Arrays.asList(
+					Arrays.asList("product_id", "=", Integer.parseInt(productId)),
+					Arrays.asList("analytic_account_id", "=", Integer.parseInt(analitycAccountId)));
+
+			HashMap<String, Object> keywordArgs = new HashMap<>();
+			keywordArgs.put("fields", fieldsToFetch);
+
+			Object[] params = new Object[] { odooConfig.getDb(), uid, odooConfig.getPassword(), "account.move.line",
+					"search_read", Collections.singletonList(domain), keywordArgs };
+
+			logger.info("Executing Odoo search_read on 'account.move.line' with fields: {}", fieldsToFetch);
+			Object[] linesRaw = (Object[]) objectClient.execute("execute_kw", params);
+
+			List<Map<String, Object>> linesList = new ArrayList<>();
+			for (Object lineObj : linesRaw) {
+				if (lineObj instanceof Map) {
+					linesList.add((Map<String, Object>) lineObj);
+				} else {
+					logger.warn("Received an object that is not a Map from Odoo: {}", lineObj);
+				}
+			}
+			logger.info("Successfully fetched {} account move lines from Odoo.", linesList.size());
+
+			return linesList;
+
+		} catch (XmlRpcException e) {
+			logger.error(
+					"XmlRpcException while fetching account move lines from Odoo: {}. Check Odoo XML-RPC endpoint and network.",
+					e.getMessage(), e);
+		} catch (ClassCastException e) {
+			logger.error("ClassCastException while processing Odoo response. Unexpected data structure: {}",
+					e.getMessage(), e);
+		} catch (Exception e) {
+			logger.error("Unexpected exception while fetching account move lines from Odoo: {}", e.getMessage(), e);
+		}
+		return Collections.emptyList();
+	}
+
 }


### PR DESCRIPTION
## Summary
Added a new method `getOdooAccountMoveLines()` to the OdooService class to retrieve account move line records from Odoo based on product ID and analytic account ID filters.

## Key Changes
- **New method**: `getOdooAccountMoveLines(String analitycAccountId, String productId)`
  - Fetches account move lines from the `account.move.line` model in Odoo
  - Filters results by product ID and analytic account ID
  - Returns a list of maps containing move line details (id, date, move_id, name, product_id, account_id, debit, credit, balance)

## Implementation Details
- Uses Odoo's `search_read` RPC method to retrieve filtered records
- Includes proper authentication check and error handling for XmlRpcException, ClassCastException, and general exceptions
- Validates that the Odoo object client is initialized before executing the query
- Includes comprehensive logging for debugging and monitoring
- Returns an empty list on any error to maintain consistent behavior with other service methods
- Safely casts response objects and validates they are Map instances before adding to results

https://claude.ai/code/session_019oDbn8DwMCcKBiyZuX8a1n