### PR TITLE
Add OdooCost entity and link to BudgetEntry

### DIFF
--- a/src/main/java/uy/com/bay/utiles/entities/BudgetEntry.java
+++ b/src/main/java/uy/com/bay/utiles/entities/BudgetEntry.java
@@ -43,6 +43,9 @@ public class BudgetEntry extends AbstractEntity {
 	@OneToMany(mappedBy = "budgetEntry")
 	private Set<Fieldwork> fieldworks = new HashSet<>();
 
+	@OneToMany(mappedBy = "budgetEntry")
+	private Set<OdooCost> odooCosts = new HashSet<>();
+
 	@Transient
 	private Double total;
 
@@ -140,6 +143,14 @@ public class BudgetEntry extends AbstractEntity {
 
 	public void setExpenseRequests(Set<ExpenseRequest> expenseRequests) {
 		this.expenseRequests = expenseRequests;
+	}
+
+	public Set<OdooCost> getOdooCosts() {
+		return odooCosts;
+	}
+
+	public void setOdooCosts(Set<OdooCost> odooCosts) {
+		this.odooCosts = odooCosts;
 	}
 
 	public void setTotal(Double total) {

--- a/src/main/java/uy/com/bay/utiles/entities/OdooCost.java
+++ b/src/main/java/uy/com/bay/utiles/entities/OdooCost.java
@@ -1,0 +1,107 @@
+package uy.com.bay.utiles.entities;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import uy.com.bay.utiles.data.AbstractEntity;
+
+@Entity
+@Table(name = "odoo_cost")
+public class OdooCost extends AbstractEntity {
+
+	private LocalDate date;
+
+	private String moveId;
+
+	private String name;
+
+	private String productId;
+
+	private String accountId;
+
+	private BigDecimal debit;
+
+	private BigDecimal credit;
+
+	private BigDecimal balance;
+
+	@ManyToOne
+	@JoinColumn(name = "budget_entry_id")
+	private BudgetEntry budgetEntry;
+
+	public LocalDate getDate() {
+		return date;
+	}
+
+	public void setDate(LocalDate date) {
+		this.date = date;
+	}
+
+	public String getMoveId() {
+		return moveId;
+	}
+
+	public void setMoveId(String moveId) {
+		this.moveId = moveId;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getProductId() {
+		return productId;
+	}
+
+	public void setProductId(String productId) {
+		this.productId = productId;
+	}
+
+	public String getAccountId() {
+		return accountId;
+	}
+
+	public void setAccountId(String accountId) {
+		this.accountId = accountId;
+	}
+
+	public BigDecimal getDebit() {
+		return debit;
+	}
+
+	public void setDebit(BigDecimal debit) {
+		this.debit = debit;
+	}
+
+	public BigDecimal getCredit() {
+		return credit;
+	}
+
+	public void setCredit(BigDecimal credit) {
+		this.credit = credit;
+	}
+
+	public BigDecimal getBalance() {
+		return balance;
+	}
+
+	public void setBalance(BigDecimal balance) {
+		this.balance = balance;
+	}
+
+	public BudgetEntry getBudgetEntry() {
+		return budgetEntry;
+	}
+
+	public void setBudgetEntry(BudgetEntry budgetEntry) {
+		this.budgetEntry = budgetEntry;
+	}
+}


### PR DESCRIPTION
## Summary
This PR introduces a new `OdooCost` entity to track Odoo accounting costs and establishes a relationship with the existing `BudgetEntry` entity.

## Key Changes
- **New Entity**: Created `OdooCost` class extending `AbstractEntity` with the following fields:
  - Accounting data: `date`, `moveId`, `name`, `productId`, `accountId`
  - Financial amounts: `debit`, `credit`, `balance` (as `BigDecimal`)
  - Relationship: Many-to-one association with `BudgetEntry`

- **Updated BudgetEntry**: Added bidirectional one-to-many relationship to `OdooCost`
  - New field: `odooCosts` collection
  - Generated getter and setter methods

## Implementation Details
- The `OdooCost` entity is mapped to the `odoo_cost` database table
- The relationship uses `@JoinColumn(name = "budget_entry_id")` for foreign key mapping
- All financial amounts use `BigDecimal` for precision in accounting operations
- The relationship is properly bidirectional with `mappedBy = "budgetEntry"` on the `BudgetEntry` side

https://claude.ai/code/session_015J8zwWjMPHNXqVnciF6MW6