### PR TITLE
Initialize OdooCosts collection in Budget entries

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/BudgetService.java
+++ b/src/main/java/uy/com/bay/utiles/services/BudgetService.java
@@ -39,6 +39,7 @@ public class BudgetService {
 				Hibernate.initialize(entry.getExtras());
 				Hibernate.initialize(entry.getExpenseRequests());
 				Hibernate.initialize(entry.getFieldworks());
+				Hibernate.initialize(entry.getOdooCosts());
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Added initialization of the `OdooCosts` collection in the `BudgetService` to ensure proper lazy-loading handling of Odoo cost data associated with budget entries.

## Key Changes
- Added `Hibernate.initialize(entry.getOdooCosts())` to the `initializeEntryCollections()` method in `BudgetService`
- This ensures the OdooCosts collection is eagerly loaded alongside other entry-related collections (Extras, ExpenseRequests, Fieldworks)

## Implementation Details
The change follows the existing pattern in the codebase where all related collections for a budget entry are initialized together to prevent lazy-loading issues when the Hibernate session is closed. This maintains consistency with how other entry collections are being handled.

https://claude.ai/code/session_01Sjd4jB3DjuoBW45wDXYATD