### PR TITLE
Initialize OdooCosts collection in BudgetEntry lazy loading

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/BudgetService.java
+++ b/src/main/java/uy/com/bay/utiles/services/BudgetService.java
@@ -91,7 +91,9 @@ public class BudgetService {
 
 	@Transactional(readOnly = true)
 	public Optional<BudgetEntry> getEntryByIdWithExtras(Long id) {
-		return budgetEntryRepository.findByIdWithExtras(id);
+		Optional<BudgetEntry> entry = budgetEntryRepository.findByIdWithExtras(id);
+		entry.ifPresent(e -> Hibernate.initialize(e.getOdooCosts()));
+		return entry;
 	}
 
 }


### PR DESCRIPTION
## Summary
This change ensures that the `odooCosts` collection is properly initialized when retrieving a `BudgetEntry` with its related data, preventing lazy loading issues in read-only transactions.

## Key Changes
- Modified `getEntryByIdWithExtras()` method to explicitly initialize the `odooCosts` collection using `Hibernate.initialize()`
- The collection is now eagerly loaded within the transactional context before the method returns, avoiding potential `LazyInitializationException` when accessing the collection outside the transaction

## Implementation Details
- The method now stores the `Optional<BudgetEntry>` result in a local variable
- Uses `ifPresent()` to conditionally initialize the `odooCosts` collection only when the entry exists
- This approach maintains the `Optional` return type while ensuring the collection is accessible after the transaction closes

https://claude.ai/code/session_016n9wgcGqCz93VnhFYzwKBn