### PR TITLE
Add odooCosts to Fieldwork repository fetch query

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/FieldworkRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/FieldworkRepository.java
@@ -25,6 +25,7 @@ public interface FieldworkRepository extends JpaRepository<Fieldwork, Long>, Jpa
 			"LEFT JOIN FETCH be.extras " +
 			"LEFT JOIN FETCH be.fieldworks " +
 			"LEFT JOIN FETCH be.expenseRequests " +
+			"LEFT JOIN FETCH be.odooCosts " +
 			"WHERE f.initPlannedDate < :endDate AND f.endPlannedDate > :startDate")
 	List<Fieldwork> findAllByInitPlannedDateLessThanAndEndPlannedDateGreaterThan(
 			@Param("endDate") LocalDate endDate,


### PR DESCRIPTION
## Summary
Updated the Fieldwork repository query to eagerly fetch the `odooCosts` relationship along with other related entities.

## Key Changes
- Added `LEFT JOIN FETCH be.odooCosts` to the `findAllByInitPlannedDateLessThanAndEndPlannedDateGreaterThan` query in FieldworkRepository
- This ensures that odooCosts are loaded in a single query, preventing lazy loading issues and improving performance

## Implementation Details
The change adds eager fetching of the `odooCosts` association from the BusinessEntity (be) to the existing LEFT JOIN FETCH chain that already includes extras, fieldworks, and expenseRequests. This maintains consistency with the current fetching strategy for related entities.

https://claude.ai/code/session_01453tRLDBM1FxcN5VMtw8CF