### PR TITLE
Add Excel export and Alchem study name filtering to supervision tasks

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/SupervisionTaskRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/SupervisionTaskRepository.java
@@ -38,7 +38,9 @@ public interface SupervisionTaskRepository extends JpaRepository<SupervisionTask
 			+ "st.alchemerStudyName as alchemerStudyName "
 			+ "FROM SupervisionTask st LEFT JOIN st.durationBySpeakers ds " + "WHERE st.created BETWEEN :from AND :to "
 			+ "AND (:fileName IS NULL OR :fileName = '' OR lower(st.fileName) LIKE lower(concat('%', :fileName, '%'))) "
+			+ "AND (:alchemerStudyName IS NULL OR :alchemerStudyName = '' OR lower(st.alchemerStudyName) LIKE lower(concat('%', :alchemerStudyName, '%'))) "
 			+ "AND (:status IS NULL OR st.status = :status) " + "ORDER BY st.created DESC")
 	List<Tuple> findTuplesByCreatedBetweenOrderByCreatedDesc(@Param("from") Date from, @Param("to") Date to,
-			@Param("fileName") String fileName, @Param("status") Status status);
+			@Param("fileName") String fileName, @Param("alchemerStudyName") String alchemerStudyName,
+			@Param("status") Status status);
 }

--- a/src/main/java/uy/com/bay/utiles/data/service/SupervisionTaskService.java
+++ b/src/main/java/uy/com/bay/utiles/data/service/SupervisionTaskService.java
@@ -30,7 +30,13 @@ public class SupervisionTaskService {
 
 	public List<SupervisionTaskDTO> findDTOsByCreatedBetweenAndFileNameAndStatus(Date from, Date to, String fileName,
 			Status status) {
-		List<Tuple> tuples = repository.findTuplesByCreatedBetweenOrderByCreatedDesc(from, to, fileName, status);
+		return findDTOsByCreatedBetweenAndFileNameAndStatus(from, to, fileName, null, status);
+	}
+
+	public List<SupervisionTaskDTO> findDTOsByCreatedBetweenAndFileNameAndStatus(Date from, Date to, String fileName,
+			String alchemerStudyName, Status status) {
+		List<Tuple> tuples = repository.findTuplesByCreatedBetweenOrderByCreatedDesc(from, to, fileName,
+				alchemerStudyName, status);
 		Map<Long, SupervisionTaskDTO> dtoMap = new LinkedHashMap<>();
 
 		for (Tuple tuple : tuples) {

--- a/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionTasksView.java
+++ b/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionTasksView.java
@@ -1,10 +1,20 @@
 package uy.com.bay.utiles.views.supervision;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.combobox.ComboBox;
@@ -12,6 +22,7 @@ import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.HeaderRow;
 import com.vaadin.flow.component.html.Anchor;
+import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
@@ -22,7 +33,6 @@ import com.vaadin.flow.server.StreamResource;
 
 import jakarta.annotation.security.RolesAllowed;
 import uy.com.bay.utiles.data.Status;
-import uy.com.bay.utiles.data.SupervisionTask;
 import uy.com.bay.utiles.data.service.SupervisionTaskService;
 import uy.com.bay.utiles.dto.SupervisionTaskDTO;
 import uy.com.bay.utiles.services.WordExportService;
@@ -40,7 +50,10 @@ public class SupervisionTasksView extends VerticalLayout {
 	private final DatePicker toDateField = new DatePicker("Hasta:");
 	private final Grid<SupervisionTaskDTO> grid = new Grid<>(SupervisionTaskDTO.class, false);
 	private final TextField fileNameFilter = new TextField();
+	private final TextField alchemerStudyNameFilter = new TextField();
 	private final ComboBox<Status> statusFilter = new ComboBox<>();
+
+	private List<SupervisionTaskDTO> currentItems = List.of();
 
 	public SupervisionTasksView(SupervisionTaskService supervisionTaskService, WordExportService wordExportService) {
 		this.supervisionTaskService = supervisionTaskService;
@@ -55,9 +68,20 @@ public class SupervisionTasksView extends VerticalLayout {
 
 	private void configureGrid() {
 		grid.setSizeFull();
+		Grid.Column<SupervisionTaskDTO> alchemerStudyNameColumn = grid
+				.addColumn(SupervisionTaskDTO::getAlchemerStudyName).setHeader("Estudio");
 		Grid.Column<SupervisionTaskDTO> fileNameColumn = grid.addColumn(SupervisionTaskDTO::getFileName).setHeader("Archivo");
 		Grid.Column<SupervisionTaskDTO> statusColumn = grid.addColumn(SupervisionTaskDTO::getStatus).setHeader("Estado");
-		grid.addColumn(SupervisionTaskDTO::getAiScore).setHeader("Scoring");
+		grid.addColumn(SupervisionTaskDTO::getAiScore).setHeader("Scoring global");
+		grid.addColumn(SupervisionTaskDTO::getScoreCobertura).setHeader("Cobertura");
+		grid.addColumn(SupervisionTaskDTO::getScoreFidelidad).setHeader("Fidelidad");
+		grid.addColumn(SupervisionTaskDTO::getScoreNeutralidad).setHeader("Neutralidad");
+		grid.addColumn(SupervisionTaskDTO::getScoreFluidez).setHeader("Fluidez");
+		grid.addColumn(SupervisionTaskDTO::getItemsEsperados).setHeader("Items Esperados");
+		grid.addColumn(SupervisionTaskDTO::getItemsFaltantes).setHeader("Items Faltantes");
+		grid.addColumn(SupervisionTaskDTO::getItemsEncontrados).setHeader("Items Encontrados");
+		grid.addColumn(SupervisionTaskDTO::getProblemasMayores).setHeader("Problemas Mayores");
+		grid.addColumn(SupervisionTaskDTO::getProblemasMenores).setHeader("Problemas Menores");
 		grid.addColumn(SupervisionTaskDTO::getTotalAudioDuration).setHeader("Duración del audio");
 		grid.addColumn(SupervisionTaskDTO::getSpeakingDuration).setHeader("Duración hablando");
 		grid.addColumn(task -> {
@@ -94,6 +118,10 @@ public class SupervisionTasksView extends VerticalLayout {
 
 		HeaderRow headerRow = grid.appendHeaderRow();
 
+		alchemerStudyNameFilter.setValueChangeMode(ValueChangeMode.LAZY);
+		alchemerStudyNameFilter.addValueChangeListener(e -> refreshGrid());
+		headerRow.getCell(alchemerStudyNameColumn).setComponent(alchemerStudyNameFilter);
+
 		fileNameFilter.setValueChangeMode(ValueChangeMode.LAZY);
 		fileNameFilter.addValueChangeListener(e -> refreshGrid());
 		headerRow.getCell(fileNameColumn).setComponent(fileNameFilter);
@@ -110,7 +138,9 @@ public class SupervisionTasksView extends VerticalLayout {
 	private HorizontalLayout getToolbar() {
 		Button searchButton = new Button("Buscar");
 		searchButton.addClickListener(e -> refreshGrid());
-		HorizontalLayout toolbar = new HorizontalLayout(fromDateField, toDateField, searchButton);
+		Button exportButton = new Button("Exportar");
+		exportButton.addClickListener(e -> exportToExcel());
+		HorizontalLayout toolbar = new HorizontalLayout(fromDateField, toDateField, searchButton, exportButton);
 		toolbar.setAlignItems(Alignment.BASELINE);
 		return toolbar;
 	}
@@ -120,8 +150,106 @@ public class SupervisionTasksView extends VerticalLayout {
 
 		Date to = Date.from(toDateField.getValue().atStartOfDay(ZoneId.systemDefault()).toInstant());
 		if (from != null && to != null) {
-			grid.setItems(supervisionTaskService.findDTOsByCreatedBetweenAndFileNameAndStatus(from, to,
-					fileNameFilter.getValue(), statusFilter.getValue()));
+			currentItems = supervisionTaskService.findDTOsByCreatedBetweenAndFileNameAndStatus(from, to,
+					fileNameFilter.getValue(), alchemerStudyNameFilter.getValue(), statusFilter.getValue());
+			grid.setItems(currentItems);
+		}
+	}
+
+	private void exportToExcel() {
+		try {
+			StreamResource sr = new StreamResource("supervision-tasks.xlsx", () -> {
+				try {
+					return buildExcel(currentItems);
+				} catch (IOException ex) {
+					Notification.show("Error al generar el archivo Excel.", 3000, Notification.Position.TOP_CENTER);
+					return null;
+				}
+			});
+			Anchor anchor = new Anchor(sr, "");
+			anchor.getElement().setAttribute("download", true);
+			anchor.getStyle().set("display", "none");
+			add(anchor);
+			anchor.getElement().callJsFunction("click");
+		} catch (Exception ex) {
+			Notification.show("Error al exportar a Excel.", 3000, Notification.Position.TOP_CENTER);
+		}
+	}
+
+	private ByteArrayInputStream buildExcel(List<SupervisionTaskDTO> data) throws IOException {
+		String[] columns = { "Estudio", "Archivo", "Estado", "Scoring global", "Cobertura", "Fidelidad", "Neutralidad",
+				"Fluidez", "Items Esperados", "Items Faltantes", "Items Encontrados", "Problemas Mayores",
+				"Problemas Menores", "Duración del audio", "Duración hablando", "Duración/ participante", "Creada",
+				"Output" };
+		java.text.SimpleDateFormat dateFormatter = new java.text.SimpleDateFormat("dd/MM/yyyy");
+
+		try (Workbook workbook = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+			Sheet sheet = workbook.createSheet("Supervision Tasks");
+
+			Row headerRow = sheet.createRow(0);
+			for (int col = 0; col < columns.length; col++) {
+				Cell cell = headerRow.createCell(col);
+				cell.setCellValue(columns[col]);
+			}
+
+			int rowIdx = 1;
+			for (SupervisionTaskDTO dto : data) {
+				Row row = sheet.createRow(rowIdx++);
+				row.createCell(0).setCellValue(dto.getAlchemerStudyName() != null ? dto.getAlchemerStudyName() : "");
+				row.createCell(1).setCellValue(dto.getFileName() != null ? dto.getFileName() : "");
+				row.createCell(2).setCellValue(dto.getStatus() != null ? dto.getStatus().name() : "");
+				if (dto.getAiScore() != null) {
+					row.createCell(3).setCellValue(dto.getAiScore());
+				} else {
+					row.createCell(3).setCellValue("");
+				}
+				row.createCell(4).setCellValue(dto.getScoreCobertura());
+				row.createCell(5).setCellValue(dto.getScoreFidelidad());
+				row.createCell(6).setCellValue(dto.getScoreNeutralidad());
+				row.createCell(7).setCellValue(dto.getScoreFluidez());
+				if (dto.getItemsEsperados() != null) {
+					row.createCell(8).setCellValue(dto.getItemsEsperados());
+				} else {
+					row.createCell(8).setCellValue("");
+				}
+				if (dto.getItemsFaltantes() != null) {
+					row.createCell(9).setCellValue(dto.getItemsFaltantes());
+				} else {
+					row.createCell(9).setCellValue("");
+				}
+				if (dto.getItemsEncontrados() != null) {
+					row.createCell(10).setCellValue(dto.getItemsEncontrados());
+				} else {
+					row.createCell(10).setCellValue("");
+				}
+				row.createCell(11).setCellValue(dto.getProblemasMayores() != null ? dto.getProblemasMayores() : "");
+				row.createCell(12).setCellValue(dto.getProblemasMenores() != null ? dto.getProblemasMenores() : "");
+				if (dto.getTotalAudioDuration() != null) {
+					row.createCell(13).setCellValue(dto.getTotalAudioDuration());
+				} else {
+					row.createCell(13).setCellValue("");
+				}
+				if (dto.getSpeakingDuration() != null) {
+					row.createCell(14).setCellValue(dto.getSpeakingDuration());
+				} else {
+					row.createCell(14).setCellValue("");
+				}
+				Map<String, Double> speakers = dto.getDurationBySpeakers();
+				String durationBySpeakers = "";
+				if (speakers != null && dto.getSpeakingDuration() != null && dto.getSpeakingDuration() != 0) {
+					durationBySpeakers = speakers.entrySet().stream()
+							.map(entry -> entry.getKey() + ":"
+									+ Double.valueOf(100 * entry.getValue() / dto.getSpeakingDuration()).intValue()
+									+ "%")
+							.collect(Collectors.joining(", "));
+				}
+				row.createCell(15).setCellValue(durationBySpeakers);
+				row.createCell(16).setCellValue(dto.getCreated() != null ? dateFormatter.format(dto.getCreated()) : "");
+				row.createCell(17).setCellValue(dto.getOutput() != null && !dto.getOutput().isEmpty() ? "Sí" : "No");
+			}
+
+			workbook.write(out);
+			return new ByteArrayInputStream(out.toByteArray());
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Enhanced the SupervisionTasksView with Excel export functionality and added filtering capability by Alchem study name. This allows users to export supervision task data to Excel files and filter results by study name in addition to existing filters.

## Key Changes
- **Excel Export Feature**: Added "Exportar" button to toolbar that generates and downloads an Excel file containing all filtered supervision task data with 18 columns including scores, durations, and metadata
- **Alchem Study Name Filter**: Added new filter field to grid header allowing users to search/filter tasks by study name
- **Service Layer Updates**: Extended `SupervisionTaskService` with overloaded method to support the new `alchemerStudyName` parameter
- **Repository Query Enhancement**: Updated `findTuplesByCreatedBetweenOrderByCreatedDesc` query to include Alchem study name filtering with case-insensitive LIKE matching
- **Grid Column Additions**: Added 10 new columns to the grid display including individual scoring metrics (Cobertura, Fidelidad, Neutralidad, Fluidez), item counts, and problem categories
- **State Management**: Added `currentItems` field to track filtered results for export functionality

## Implementation Details
- Excel generation uses Apache POI (XSSFWorkbook) with proper null-value handling
- Date formatting in Excel uses `SimpleDateFormat("dd/MM/yyyy")`
- Duration by speakers is calculated as percentage distribution in the export
- Filter uses `ValueChangeMode.LAZY` for performance optimization
- Export creates a temporary Anchor element to trigger browser download
- Error notifications display if Excel generation or export fails

https://claude.ai/code/session_016EUiL44TZQVobAfySYQCCy