### PR TITLE
Add interceptor to strip empty extra_body from OpenAI requests

### DIFF
--- a/src/main/java/uy/com/bay/utiles/config/OpenAiTimeoutConfig.java
+++ b/src/main/java/uy/com/bay/utiles/config/OpenAiTimeoutConfig.java
@@ -1,15 +1,24 @@
 package uy.com.bay.utiles.config;
 
+import java.io.IOException;
 import java.net.http.HttpClient;
 import java.time.Duration;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 @Configuration
 public class OpenAiTimeoutConfig {
+
+	private static final ObjectMapper EXTRA_BODY_MAPPER = new ObjectMapper();
 
 	@Bean
 	public RestClient.Builder restClientBuilder() {
@@ -21,6 +30,32 @@ public class OpenAiTimeoutConfig {
 		// ⬇️ ESTE es el read timeout
 		rf.setReadTimeout(Duration.ofMinutes(250));
 
-		return RestClient.builder().requestFactory(rf);
+		return RestClient.builder().requestFactory(rf).requestInterceptor(stripEmptyExtraBodyInterceptor());
+	}
+
+	// Workaround for Spring AI 1.1.1–1.1.4 sending an empty "extra_body": {} that
+	// OpenAI rejects with HTTP 400 "Unknown parameter: 'extra_body'".
+	private static ClientHttpRequestInterceptor stripEmptyExtraBodyInterceptor() {
+		return (request, body, execution) -> {
+			byte[] payload = body;
+			MediaType contentType = request.getHeaders().getContentType();
+			if (payload != null && payload.length > 0 && contentType != null
+					&& MediaType.APPLICATION_JSON.includes(contentType)) {
+				try {
+					JsonNode root = EXTRA_BODY_MAPPER.readTree(payload);
+					if (root.isObject() && root.has("extra_body")) {
+						JsonNode extraBody = root.get("extra_body");
+						if (extraBody == null || extraBody.isNull()
+								|| (extraBody.isObject() && extraBody.isEmpty())) {
+							((ObjectNode) root).remove("extra_body");
+							payload = EXTRA_BODY_MAPPER.writeValueAsBytes(root);
+						}
+					}
+				} catch (IOException ignored) {
+					// Not JSON or unparseable — forward the original body unchanged.
+				}
+			}
+			return execution.execute(request, payload);
+		};
 	}
 }


### PR DESCRIPTION
## Summary
This PR adds a request interceptor to the OpenAI REST client configuration that removes empty `extra_body` parameters from JSON payloads. This works around a compatibility issue with Spring AI versions 1.1.1–1.1.4, which send an empty `extra_body: {}` object that OpenAI's API rejects with an HTTP 400 error.

## Key Changes
- Added a new `stripEmptyExtraBodyInterceptor()` method that implements a `ClientHttpRequestInterceptor` to filter request bodies
- The interceptor parses JSON request payloads and removes the `extra_body` field if it is:
  - `null`
  - An empty object `{}`
- Integrated the interceptor into the `RestClient.Builder` bean configuration
- Added necessary imports for Jackson JSON processing and Spring HTTP client utilities
- Gracefully handles non-JSON or unparseable payloads by forwarding them unchanged

## Implementation Details
- Uses Jackson's `ObjectMapper` to parse and manipulate JSON nodes
- Only processes requests with `Content-Type: application/json`
- Catches `IOException` silently to avoid breaking the request flow for non-JSON content
- Maintains backward compatibility by only modifying payloads that contain the problematic empty `extra_body` field

https://claude.ai/code/session_01359CEn2UGMm3ZF3EycWRKk