### PR TITLE
Add item-level coincidence and score tracking to SupervisionTask

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/SupervisionTask.java
+++ b/src/main/java/uy/com/bay/utiles/data/SupervisionTask.java
@@ -50,6 +50,18 @@ public class SupervisionTask extends AbstractEntity {
 	@Column(name = "duration")
 	private Map<String, Double> durationBySpeakers = new HashMap<>();
 
+	@ElementCollection
+	@CollectionTable(name = "supervision_task_coincidence_by_item", joinColumns = @JoinColumn(name = "task_id"))
+	@MapKeyColumn(name = "item_id")
+	@Column(name = "coincidence")
+	private Map<String, String> coincidenceByItem = new HashMap<>();
+
+	@ElementCollection
+	@CollectionTable(name = "supervision_task_score_by_item", joinColumns = @JoinColumn(name = "task_id"))
+	@MapKeyColumn(name = "item_id")
+	@Column(name = "score")
+	private Map<String, Integer> scoreByItem = new HashMap<>();
+
 	private double aiScore;
 
 	private int scoreCobertura;
@@ -275,5 +287,21 @@ public class SupervisionTask extends AbstractEntity {
 
 	public void setItemsFaltantes(Integer itemsFaltantes) {
 		this.itemsFaltantes = itemsFaltantes;
+	}
+
+	public Map<String, String> getCoincidenceByItem() {
+		return coincidenceByItem;
+	}
+
+	public void setCoincidenceByItem(Map<String, String> coincidenceByItem) {
+		this.coincidenceByItem = coincidenceByItem;
+	}
+
+	public Map<String, Integer> getScoreByItem() {
+		return scoreByItem;
+	}
+
+	public void setScoreByItem(Map<String, Integer> scoreByItem) {
+		this.scoreByItem = scoreByItem;
 	}
 }

--- a/src/main/java/uy/com/bay/utiles/services/SupervisionTaskProcessorService.java
+++ b/src/main/java/uy/com/bay/utiles/services/SupervisionTaskProcessorService.java
@@ -136,6 +136,21 @@ public class SupervisionTaskProcessorService {
 
 			task.setEvaluationOutput(prettyPrint(response));
 
+			JsonNode evaluationRoot = new ObjectMapper().readTree(task.getEvaluationOutput());
+			JsonNode porItem = evaluationRoot.path("por_item");
+			if (porItem.isArray()) {
+				task.getCoincidenceByItem().clear();
+				task.getScoreByItem().clear();
+				for (JsonNode item : porItem) {
+					String itemId = item.path("item_id").asText();
+					if (itemId == null || itemId.isEmpty()) {
+						continue;
+					}
+					task.getCoincidenceByItem().put(itemId, item.path("calidad_coincidencia").asText());
+					task.getScoreByItem().put(itemId, item.path("puntaje_item").asInt());
+				}
+			}
+
 //			{
 //				  "puntaje_global" : 47,
 //				  "puntajes_componentes" : {


### PR DESCRIPTION
## Summary
This PR adds support for tracking coincidence and score metrics at the item level in supervision tasks. The evaluation output is now parsed to extract per-item data and store it in dedicated map collections.

## Key Changes
- **SupervisionTask entity**: Added two new `@ElementCollection` mapped fields:
  - `coincidenceByItem`: Map storing coincidence quality metrics keyed by item ID
  - `scoreByItem`: Map storing item-level scores keyed by item ID
  - Both fields are persisted in separate database tables with proper JPA annotations

- **SupervisionTaskProcessorService**: Enhanced the task processing logic to:
  - Parse the evaluation output JSON response
  - Extract the `por_item` array from the evaluation results
  - Populate the new maps with item-level data (item_id, calidad_coincidencia, puntaje_item)
  - Skip items with missing or empty item IDs

## Implementation Details
- The new maps are initialized as empty `HashMap` instances in the entity
- Database tables `supervision_task_coincidence_by_item` and `supervision_task_score_by_item` are created via JPA annotations
- The JSON parsing uses Jackson's `ObjectMapper` to safely navigate the evaluation response structure
- Getter and setter methods are provided for both new fields to maintain encapsulation

https://claude.ai/code/session_011SvMYqE59KgtsrBNxHGMmk