### PR TITLE
Add coincidence and score tracking by item to supervision tasks

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/SupervisionTaskRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/SupervisionTaskRepository.java
@@ -1,5 +1,6 @@
 package uy.com.bay.utiles.data.repository;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
@@ -43,4 +44,12 @@ public interface SupervisionTaskRepository extends JpaRepository<SupervisionTask
 	List<Tuple> findTuplesByCreatedBetweenOrderByCreatedDesc(@Param("from") Date from, @Param("to") Date to,
 			@Param("fileName") String fileName, @Param("alchemerStudyName") String alchemerStudyName,
 			@Param("status") Status status);
+
+	@Query("SELECT st.id as id, KEY(c) as itemId, VALUE(c) as coincidence "
+			+ "FROM SupervisionTask st JOIN st.coincidenceByItem c WHERE st.id IN :ids")
+	List<Tuple> findCoincidenceByItemForIds(@Param("ids") Collection<Long> ids);
+
+	@Query("SELECT st.id as id, KEY(s) as itemId, VALUE(s) as score "
+			+ "FROM SupervisionTask st JOIN st.scoreByItem s WHERE st.id IN :ids")
+	List<Tuple> findScoreByItemForIds(@Param("ids") Collection<Long> ids);
 }

--- a/src/main/java/uy/com/bay/utiles/data/service/SupervisionTaskService.java
+++ b/src/main/java/uy/com/bay/utiles/data/service/SupervisionTaskService.java
@@ -81,6 +81,31 @@ public class SupervisionTaskService {
 				dto.getDurationBySpeakers().put(speaker, duration);
 			}
 		}
+
+		if (!dtoMap.isEmpty()) {
+			for (Tuple tuple : repository.findCoincidenceByItemForIds(dtoMap.keySet())) {
+				SupervisionTaskDTO dto = dtoMap.get(tuple.get("id", Long.class));
+				if (dto != null) {
+					String itemId = tuple.get("itemId", String.class);
+					String coincidence = tuple.get("coincidence", String.class);
+					if (itemId != null) {
+						dto.getCoincidenceByItem().put(itemId, coincidence);
+					}
+				}
+			}
+
+			for (Tuple tuple : repository.findScoreByItemForIds(dtoMap.keySet())) {
+				SupervisionTaskDTO dto = dtoMap.get(tuple.get("id", Long.class));
+				if (dto != null) {
+					String itemId = tuple.get("itemId", String.class);
+					Integer score = tuple.get("score", Integer.class);
+					if (itemId != null) {
+						dto.getScoreByItem().put(itemId, score);
+					}
+				}
+			}
+		}
+
 		return new ArrayList<>(dtoMap.values());
 	}
 

--- a/src/main/java/uy/com/bay/utiles/dto/SupervisionTaskDTO.java
+++ b/src/main/java/uy/com/bay/utiles/dto/SupervisionTaskDTO.java
@@ -14,6 +14,8 @@ public class SupervisionTaskDTO {
 	private Double totalAudioDuration;
 	private Double speakingDuration;
 	private Map<String, Double> durationBySpeakers = new HashMap<>();
+	private Map<String, String> coincidenceByItem = new HashMap<>();
+	private Map<String, Integer> scoreByItem = new HashMap<>();
 	private Date created;
 	private String output;
 	private String evaluationOutput;
@@ -104,6 +106,22 @@ public class SupervisionTaskDTO {
 
 	public void setDurationBySpeakers(Map<String, Double> durationBySpeakers) {
 		this.durationBySpeakers = durationBySpeakers;
+	}
+
+	public Map<String, String> getCoincidenceByItem() {
+		return coincidenceByItem;
+	}
+
+	public void setCoincidenceByItem(Map<String, String> coincidenceByItem) {
+		this.coincidenceByItem = coincidenceByItem;
+	}
+
+	public Map<String, Integer> getScoreByItem() {
+		return scoreByItem;
+	}
+
+	public void setScoreByItem(Map<String, Integer> scoreByItem) {
+		this.scoreByItem = scoreByItem;
 	}
 
 	public Date getCreated() {


### PR DESCRIPTION
## Summary
This PR extends the `SupervisionTaskDTO` and related service/repository layers to track coincidence and score metrics on a per-item basis, in addition to the existing speaker duration tracking.

## Key Changes
- **SupervisionTaskDTO**: Added two new map fields to store item-level metrics:
  - `coincidenceByItem`: Maps item IDs to coincidence values (String)
  - `scoreByItem`: Maps item IDs to score values (Integer)
  - Added corresponding getters and setters for both fields

- **SupervisionTaskService**: Enhanced the `findDTOsByCreatedBetweenAndFileNameAndStatus()` method to populate the new item-level metrics:
  - Queries repository for coincidence data and populates `coincidenceByItem` map
  - Queries repository for score data and populates `scoreByItem` map
  - Both operations are guarded by a null check on the DTO before populating maps

- **SupervisionTaskRepository**: Added two new query methods:
  - `findCoincidenceByItemForIds()`: Retrieves coincidence values grouped by item for given supervision task IDs
  - `findScoreByItemForIds()`: Retrieves score values grouped by item for given supervision task IDs
  - Both use JPA's `KEY()` and `VALUE()` functions to extract map entries from entity relationships

## Implementation Details
- The new queries use batch loading with a collection of IDs to efficiently fetch related data
- Null checks are performed before accessing tuple values to ensure robustness
- The implementation follows the existing pattern used for `durationBySpeakers` population

https://claude.ai/code/session_013XHDd2xrKsQQZBe9CeaDyD