### PR TITLE
Add ExpenseReportDTO and optimize grid rendering with DTO-based data provider

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/ExpenseReportDTO.java
+++ b/src/main/java/uy/com/bay/utiles/data/ExpenseReportDTO.java
@@ -1,0 +1,128 @@
+package uy.com.bay.utiles.data;
+
+import java.util.Date;
+import java.util.Objects;
+
+public class ExpenseReportDTO {
+
+	private Long id;
+	private String studyName;
+	private String surveyorFirstName;
+	private String surveyorLastName;
+	private Date date;
+	private Double amount;
+	private String conceptName;
+	private ExpenseReportStatus expenseStatus;
+
+	public ExpenseReportDTO() {
+	}
+
+	public ExpenseReportDTO(Long id, String studyName, String surveyorFirstName, String surveyorLastName, Date date,
+			Double amount, String conceptName, ExpenseReportStatus expenseStatus) {
+		this.id = id;
+		this.studyName = studyName;
+		this.surveyorFirstName = surveyorFirstName;
+		this.surveyorLastName = surveyorLastName;
+		this.date = date;
+		this.amount = amount;
+		this.conceptName = conceptName;
+		this.expenseStatus = expenseStatus;
+	}
+
+	public static ExpenseReportDTO fromEntity(ExpenseReport entity) {
+		if (entity == null) {
+			return null;
+		}
+		return new ExpenseReportDTO(entity.getId(),
+				entity.getStudy() != null ? entity.getStudy().getName() : null,
+				entity.getSurveyor() != null ? entity.getSurveyor().getFirstName() : null,
+				entity.getSurveyor() != null ? entity.getSurveyor().getLastName() : null, entity.getDate(),
+				entity.getAmount(), entity.getConcept() != null ? entity.getConcept().getName() : null,
+				entity.getExpenseStatus());
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getStudyName() {
+		return studyName;
+	}
+
+	public void setStudyName(String studyName) {
+		this.studyName = studyName;
+	}
+
+	public String getSurveyorFirstName() {
+		return surveyorFirstName;
+	}
+
+	public void setSurveyorFirstName(String surveyorFirstName) {
+		this.surveyorFirstName = surveyorFirstName;
+	}
+
+	public String getSurveyorLastName() {
+		return surveyorLastName;
+	}
+
+	public void setSurveyorLastName(String surveyorLastName) {
+		this.surveyorLastName = surveyorLastName;
+	}
+
+	public String getSurveyorName() {
+		String first = surveyorFirstName != null ? surveyorFirstName : "";
+		String last = surveyorLastName != null ? surveyorLastName : "";
+		String name = (first + " " + last).trim();
+		return name.isEmpty() ? "" : name;
+	}
+
+	public Date getDate() {
+		return date;
+	}
+
+	public void setDate(Date date) {
+		this.date = date;
+	}
+
+	public Double getAmount() {
+		return amount;
+	}
+
+	public void setAmount(Double amount) {
+		this.amount = amount;
+	}
+
+	public String getConceptName() {
+		return conceptName;
+	}
+
+	public void setConceptName(String conceptName) {
+		this.conceptName = conceptName;
+	}
+
+	public ExpenseReportStatus getExpenseStatus() {
+		return expenseStatus;
+	}
+
+	public void setExpenseStatus(ExpenseReportStatus expenseStatus) {
+		this.expenseStatus = expenseStatus;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (!(o instanceof ExpenseReportDTO that))
+			return false;
+		return id != null && id.equals(that.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return id != null ? Objects.hash(id) : System.identityHashCode(this);
+	}
+}

--- a/src/main/java/uy/com/bay/utiles/data/repository/ExpenseReportRepositoryCustom.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/ExpenseReportRepositoryCustom.java
@@ -1,8 +1,13 @@
 package uy.com.bay.utiles.data.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import uy.com.bay.utiles.data.ExpenseReport;
+import uy.com.bay.utiles.data.ExpenseReportDTO;
 
 public interface ExpenseReportRepositoryCustom {
     Double sumAmount(Specification<ExpenseReport> spec);
+
+    Page<ExpenseReportDTO> findAllDtos(Specification<ExpenseReport> spec, Pageable pageable);
 }

--- a/src/main/java/uy/com/bay/utiles/data/repository/ExpenseReportRepositoryImpl.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/ExpenseReportRepositoryImpl.java
@@ -1,13 +1,30 @@
 package uy.com.bay.utiles.data.repository;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
+
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Order;
+import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import uy.com.bay.utiles.data.ExpenseReport;
+import uy.com.bay.utiles.data.ExpenseReportDTO;
+import uy.com.bay.utiles.data.ExpenseRequestType;
+import uy.com.bay.utiles.data.Study;
+import uy.com.bay.utiles.data.Surveyor;
 
 public class ExpenseReportRepositoryImpl implements ExpenseReportRepositoryCustom {
 
@@ -30,5 +47,96 @@ public class ExpenseReportRepositoryImpl implements ExpenseReportRepositoryCusto
         }
 
         return entityManager.createQuery(query).getSingleResult();
+    }
+
+    @Override
+    public Page<ExpenseReportDTO> findAllDtos(Specification<ExpenseReport> spec, Pageable pageable) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<ExpenseReportDTO> query = cb.createQuery(ExpenseReportDTO.class);
+        Root<ExpenseReport> root = query.from(ExpenseReport.class);
+
+        Join<ExpenseReport, Study> studyJoin = root.join("study", JoinType.LEFT);
+        Join<ExpenseReport, Surveyor> surveyorJoin = root.join("surveyor", JoinType.LEFT);
+        Join<ExpenseReport, ExpenseRequestType> conceptJoin = root.join("concept", JoinType.LEFT);
+
+        query.select(cb.construct(ExpenseReportDTO.class,
+                root.get("id"),
+                studyJoin.get("name"),
+                surveyorJoin.get("firstName"),
+                surveyorJoin.get("lastName"),
+                root.get("date"),
+                root.get("amount"),
+                conceptJoin.get("name"),
+                root.get("expenseStatus")));
+
+        if (spec != null) {
+            Predicate predicate = spec.toPredicate(root, query, cb);
+            if (predicate != null) {
+                query.where(predicate);
+            }
+        }
+
+        if (pageable.getSort().isSorted()) {
+            List<Order> orders = new ArrayList<>();
+            for (Sort.Order order : pageable.getSort()) {
+                Path<?> path = resolveSortPath(root, studyJoin, surveyorJoin, conceptJoin, order.getProperty());
+                orders.add(order.isAscending() ? cb.asc(path) : cb.desc(path));
+            }
+            query.orderBy(orders);
+        }
+
+        TypedQuery<ExpenseReportDTO> typedQuery = entityManager.createQuery(query);
+        if (pageable.isPaged()) {
+            typedQuery.setFirstResult((int) pageable.getOffset());
+            typedQuery.setMaxResults(pageable.getPageSize());
+        }
+
+        List<ExpenseReportDTO> results = typedQuery.getResultList();
+        long total = countDtos(spec);
+
+        return new PageImpl<>(results, pageable, total);
+    }
+
+    private long countDtos(Specification<ExpenseReport> spec) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
+        Root<ExpenseReport> countRoot = countQuery.from(ExpenseReport.class);
+        countQuery.select(cb.count(countRoot));
+
+        if (spec != null) {
+            Predicate predicate = spec.toPredicate(countRoot, countQuery, cb);
+            if (predicate != null) {
+                countQuery.where(predicate);
+            }
+        }
+        return entityManager.createQuery(countQuery).getSingleResult();
+    }
+
+    private Path<?> resolveSortPath(Root<ExpenseReport> root, Join<ExpenseReport, Study> studyJoin,
+            Join<ExpenseReport, Surveyor> surveyorJoin, Join<ExpenseReport, ExpenseRequestType> conceptJoin,
+            String property) {
+        if (property == null || property.isEmpty()) {
+            return root.get("id");
+        }
+        String[] parts = property.split("\\.");
+        Path<?> base;
+        switch (parts[0]) {
+            case "study":
+                base = studyJoin;
+                break;
+            case "surveyor":
+                base = surveyorJoin;
+                break;
+            case "concept":
+                base = conceptJoin;
+                break;
+            default:
+                base = root;
+                return base.get(property);
+        }
+        for (int i = 1; i < parts.length; i++) {
+            base = base.get(parts[i]);
+        }
+        return base;
     }
 }

--- a/src/main/java/uy/com/bay/utiles/services/ExpenseReportService.java
+++ b/src/main/java/uy/com/bay/utiles/services/ExpenseReportService.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import uy.com.bay.utiles.data.ExpenseReport;
+import uy.com.bay.utiles.data.ExpenseReportDTO;
 import uy.com.bay.utiles.data.ExpenseReportStatus;
 import uy.com.bay.utiles.data.JournalEntry;
 import uy.com.bay.utiles.data.repository.JournalEntryRepository;
@@ -60,6 +61,10 @@ public class ExpenseReportService {
 
 	public Page<ExpenseReport> list(Pageable pageable, Specification<ExpenseReport> filter) {
 		return repository.findAll(filter, pageable);
+	}
+
+	public Page<ExpenseReportDTO> listDtos(Pageable pageable, Specification<ExpenseReport> filter) {
+		return repository.findAllDtos(filter, pageable);
 	}
 
 	public List<ExpenseReport> findAllByExpenseStatus(ExpenseReportStatus status) {

--- a/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportsView.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ExpenseReportsView.java
@@ -52,6 +52,7 @@ import com.vaadin.flow.spring.data.VaadinSpringDataHelpers;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.persistence.criteria.Predicate;
 import uy.com.bay.utiles.data.ExpenseReport;
+import uy.com.bay.utiles.data.ExpenseReportDTO;
 import uy.com.bay.utiles.data.ExpenseReportFile;
 import uy.com.bay.utiles.data.ExpenseReportStatus;
 import uy.com.bay.utiles.data.ExpenseRequestType;
@@ -71,7 +72,7 @@ public class ExpenseReportsView extends Div implements BeforeEnterObserver {
 	private final String EXPENSE_REPORT_ID = "expenseReportID";
 	private final String EXPENSE_REPORT_EDIT_ROUTE_TEMPLATE = "expense-reports/%s/edit";
 
-	private final Grid<ExpenseReport> grid = new Grid<>(ExpenseReport.class, false);
+	private final Grid<ExpenseReportDTO> grid = new Grid<>(ExpenseReportDTO.class, false);
 
 	private TextField studyFilter;
 	private TextField surveyorFilter;
@@ -123,24 +124,23 @@ public class ExpenseReportsView extends Div implements BeforeEnterObserver {
 		createGridLayout(splitLayout);
 
 		add(splitLayout);
-		grid.addColumn(er -> er.getStudy() != null ? er.getStudy().getName() : "").setHeader("Estudio")
+		grid.addColumn(dto -> dto.getStudyName() != null ? dto.getStudyName() : "").setHeader("Estudio")
 				.setSortProperty("study.name").setKey("study");
+		grid.addColumn(ExpenseReportDTO::getSurveyorName).setHeader("Encuestador")
+				.setSortProperty("surveyor.firstName").setKey("surveyor");
 		grid.addColumn(
-				er -> er.getSurveyor() != null ? er.getSurveyor().getFirstName() + " " + er.getSurveyor().getLastName()
-						: "")
-				.setHeader("Encuestador").setSortProperty("surveyor.firstName").setKey("surveyor");
-		grid.addColumn(
-				er -> er.getDate() != null ? new java.text.SimpleDateFormat("dd/MM/yyyy").format(er.getDate()) : "")
+				dto -> dto.getDate() != null ? new java.text.SimpleDateFormat("dd/MM/yyyy").format(dto.getDate()) : "")
 				.setHeader("Fecha").setSortProperty("date").setKey("date");
-		grid.addColumn(ExpenseReport::getAmount).setHeader("Monto").setSortProperty("amount").setKey("amount");
-		grid.addColumn(er -> er.getConcept() != null ? er.getConcept().getName() : "").setHeader("Concepto")
+		grid.addColumn(ExpenseReportDTO::getAmount).setHeader("Monto").setSortProperty("amount").setKey("amount");
+		grid.addColumn(dto -> dto.getConceptName() != null ? dto.getConceptName() : "").setHeader("Concepto")
 				.setSortProperty("concept.name").setKey("concept");
-		grid.addColumn(ExpenseReport::getExpenseStatus).setHeader("Estado").setSortProperty("expenseStatus")
+		grid.addColumn(ExpenseReportDTO::getExpenseStatus).setHeader("Estado").setSortProperty("expenseStatus")
 				.setKey("expenseStatus");
 
 		grid.setDataProvider(new CallbackDataProvider<>(
 				query -> expenseReportService
-						.list(VaadinSpringDataHelpers.toSpringPageRequest(query), createFilterSpecification()).stream(),
+						.listDtos(VaadinSpringDataHelpers.toSpringPageRequest(query), createFilterSpecification())
+						.stream(),
 				query -> (int) expenseReportService.count(createFilterSpecification())));
 
 		grid.appendFooterRow();
@@ -179,6 +179,7 @@ public class ExpenseReportsView extends Div implements BeforeEnterObserver {
 
 		save.addClickListener(e -> {
 			try {
+				boolean isNew = this.expenseReport == null || this.expenseReport.getId() == null;
 				if (this.expenseReport == null) {
 					this.expenseReport = new ExpenseReport();
 				}
@@ -187,9 +188,9 @@ public class ExpenseReportsView extends Div implements BeforeEnterObserver {
 				}
 				binder.writeBean(this.expenseReport);
 				if (this.expenseReport.getSurveyor() != null && this.expenseReport.getStudy() != null) {
-					expenseReportService.save(this.expenseReport);
+					ExpenseReport saved = expenseReportService.save(this.expenseReport);
 					clearForm();
-					refreshGrid();
+					refreshGridForChange(saved, isNew);
 					Notification.show("Rendición guardada.");
 					editorLayoutDiv.setVisible(false);
 					UI.getCurrent().navigate(ExpenseReportsView.class);
@@ -208,9 +209,9 @@ public class ExpenseReportsView extends Div implements BeforeEnterObserver {
 		reject.addClickListener(e -> {
 			if (this.expenseReport != null) {
 				this.expenseReport.setExpenseStatus(ExpenseReportStatus.RECHAZADO);
-				expenseReportService.save(this.expenseReport);
+				ExpenseReport saved = expenseReportService.save(this.expenseReport);
 				clearForm();
-				refreshGrid();
+				refreshGridForChange(saved, false);
 				Notification.show("Rendición rechazada.");
 				editorLayoutDiv.setVisible(false);
 				UI.getCurrent().navigate(ExpenseReportsView.class);
@@ -224,8 +225,9 @@ public class ExpenseReportsView extends Div implements BeforeEnterObserver {
 
 					if (this.expenseReport.getSurveyor() != null && this.expenseReport.getStudy() != null) {
 						expenseReportService.approveReport(this.expenseReport);
+						ExpenseReport approved = this.expenseReport;
 						clearForm();
-						refreshGrid();
+						refreshGridForChange(approved, false);
 						Notification.show("Rendición aprobada.");
 						editorLayoutDiv.setVisible(false);
 						UI.getCurrent().navigate(ExpenseReportsView.class);
@@ -438,10 +440,22 @@ public class ExpenseReportsView extends Div implements BeforeEnterObserver {
 		}
 	}
 
+	private void refreshGridForChange(ExpenseReport entity, boolean isNew) {
+		if (isNew || entity == null || entity.getId() == null) {
+			refreshGrid();
+			return;
+		}
+		grid.select(null);
+		grid.getDataProvider().refreshItem(ExpenseReportDTO.fromEntity(entity));
+		if (grid.getFooterRows().size() > 0) {
+			updateFooter();
+		}
+	}
+
 	private void updateFooter() {
 		FooterRow footerRow = grid.getFooterRows().get(0);
-		Grid.Column<ExpenseReport> studyColumn = grid.getColumnByKey("study");
-		Grid.Column<ExpenseReport> amountColumn = grid.getColumnByKey("amount");
+		Grid.Column<ExpenseReportDTO> studyColumn = grid.getColumnByKey("study");
+		Grid.Column<ExpenseReportDTO> amountColumn = grid.getColumnByKey("amount");
 		Specification<ExpenseReport> spec = createFilterSpecification();
 		Double total = expenseReportService.sumAmount(spec);
 		footerRow.getCell(studyColumn).setText("TOTAL");


### PR DESCRIPTION
## Summary
This PR introduces a Data Transfer Object (DTO) pattern for expense reports to optimize the grid view rendering and reduce unnecessary entity loading. The changes include creating an `ExpenseReportDTO` class, implementing a custom repository method to fetch DTOs directly, and updating the grid to use DTOs instead of full entities.

## Key Changes

- **New `ExpenseReportDTO` class**: Created a lightweight DTO that flattens related entity data (study name, surveyor name, concept name) into simple string fields, with a `fromEntity()` factory method for easy conversion
- **Custom repository method `findAllDtos()`**: Implemented in `ExpenseReportRepositoryImpl` using Criteria API to construct DTOs directly from the database query, including support for:
  - LEFT JOINs to related entities (Study, Surveyor, ExpenseRequestType)
  - Filtering via Specification
  - Sorting with dynamic path resolution for nested properties
  - Pagination
- **Grid refactoring**: Updated `ExpenseReportsView` to use `Grid<ExpenseReportDTO>` instead of `Grid<ExpenseReport>`, simplifying column definitions by accessing flattened DTO properties
- **Service layer update**: Added `listDtos()` method to `ExpenseReportService` to expose the new DTO-based query
- **Optimized grid refresh**: Introduced `refreshGridForChange()` method that performs targeted item refresh for updates instead of full grid reload, improving performance for single-item changes
- **Repository interface update**: Extended `ExpenseReportRepositoryCustom` with the new `findAllDtos()` method signature

## Notable Implementation Details

- The DTO's `getSurveyorName()` method safely concatenates first and last names with null-checking
- The `resolveSortPath()` method handles dynamic sort property resolution for nested entity properties (e.g., "study.name", "surveyor.firstName")
- The grid refresh logic distinguishes between new items (full refresh) and updates (targeted refresh) for better performance
- All LEFT JOINs ensure that expense reports without related entities are still included in results

https://claude.ai/code/session_01LcLCG91eQQNuWaHMQwic9c