### PR TITLE
Add date range filtering for budget entry costs from Odoo

### DIFF
--- a/src/main/java/uy/com/bay/utiles/entities/BudgetEntry.java
+++ b/src/main/java/uy/com/bay/utiles/entities/BudgetEntry.java
@@ -20,6 +20,8 @@ public class BudgetEntry extends AbstractEntity {
 	private Double ammount;
 	private Integer quantity;
 	private LocalDate created;
+	private LocalDate init;
+	private LocalDate end;
 
 	public BudgetEntry() {
 		this.created = LocalDate.now();
@@ -171,6 +173,22 @@ public class BudgetEntry extends AbstractEntity {
 
 	public void setCreated(LocalDate created) {
 		this.created = created;
+	}
+
+	public LocalDate getInit() {
+		return init;
+	}
+
+	public void setInit(LocalDate init) {
+		this.init = init;
+	}
+
+	public LocalDate getEnd() {
+		return end;
+	}
+
+	public void setEnd(LocalDate end) {
+		this.end = end;
 	}
 
 }

--- a/src/main/java/uy/com/bay/utiles/services/OdooService.java
+++ b/src/main/java/uy/com/bay/utiles/services/OdooService.java
@@ -11,6 +11,7 @@ import uy.com.bay.utiles.config.OdooConfig;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -296,7 +297,8 @@ public class OdooService {
 	}
 
 	@SuppressWarnings("unchecked")
-	public List<Map<String, Object>> getOdooAccountMoveLines(String analitycAccountId, String productId) {
+	public List<Map<String, Object>> getOdooAccountMoveLines(String analitycAccountId, String productId, LocalDate init,
+			LocalDate end) {
 		if (objectClient == null) {
 			logger.error("Odoo object client not initialized. Cannot fetch account move lines.");
 			return Collections.emptyList();
@@ -311,9 +313,13 @@ public class OdooService {
 			List<String> fieldsToFetch = Arrays.asList("id", "date", "move_id", "name", "product_id", "account_id",
 					"debit", "credit", "balance");
 
-			List<Object> domain = Arrays.asList(
-					Arrays.asList("product_id", "=", Integer.parseInt(productId)),
-					Arrays.asList("analytic_account_id", "=", Integer.parseInt(analitycAccountId)));
+			List<Object> domain = new ArrayList<>();
+			domain.add(Arrays.asList("product_id", "=", Integer.parseInt(productId)));
+			domain.add(Arrays.asList("analytic_account_id", "=", Integer.parseInt(analitycAccountId)));
+			if (init != null && end != null) {
+				domain.add(Arrays.asList("date", ">=", init.toString()));
+				domain.add(Arrays.asList("date", "<=", end.toString()));
+			}
 
 			HashMap<String, Object> keywordArgs = new HashMap<>();
 			keywordArgs.put("fields", fieldsToFetch);

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -20,6 +21,7 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.grid.FooterRow;
 import com.vaadin.flow.component.grid.Grid;
@@ -81,6 +83,7 @@ public class BudgetForm extends VerticalLayout {
 	private Span totalAmountLabel;
 	private Span totalSpentLabel;
 	private final NumberFormat currencyFormat;
+	private final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
 	private final DoobloSurveyRetriever doobloSurveyRetriever;
 	private final OdooService odooService;
 	private final OdooCostService odooCostService;
@@ -200,7 +203,7 @@ public class BudgetForm extends VerticalLayout {
 			}
 			BigDecimal totalOdooCost = BigDecimal.ZERO;
 			List<Map<String, Object>> moveLines = odooService.getOdooAccountMoveLines(budgetStudy.getOdooId(),
-					concept.getOdooProductId());
+					concept.getOdooProductId(), budgetEntry.getInit(), budgetEntry.getEnd());
 			for (Map<String, Object> line : moveLines) {
 				String moveId = odooIdToString(line.get("move_id"));
 				if (moveId == null || moveId.isEmpty()) {
@@ -301,6 +304,19 @@ public class BudgetForm extends VerticalLayout {
 		entryBinder.forField(quantityField).bind(BudgetEntry::getQuantity, BudgetEntry::setQuantity);
 		Grid.Column<BudgetEntry> quantityColumn = entriesGrid.addColumn(BudgetEntry::getQuantity).setHeader("Cantidad")
 				.setResizable(true).setEditorComponent(quantityField);
+
+		DatePicker initField = new DatePicker();
+		initField.setWidthFull();
+		entryBinder.forField(initField).bind(BudgetEntry::getInit, BudgetEntry::setInit);
+		entriesGrid.addColumn(entry -> entry.getInit() != null ? entry.getInit().format(dateFormatter) : "")
+				.setHeader("Inicio").setResizable(true).setEditorComponent(initField);
+
+		DatePicker endField = new DatePicker();
+		endField.setWidthFull();
+		entryBinder.forField(endField).bind(BudgetEntry::getEnd, BudgetEntry::setEnd);
+		entriesGrid.addColumn(entry -> entry.getEnd() != null ? entry.getEnd().format(dateFormatter) : "")
+				.setHeader("Fin").setResizable(true).setEditorComponent(endField);
+
 		Grid.Column<BudgetEntry> totalColumn = entriesGrid.addColumn(entry -> currencyFormat.format(entry.getTotal()))
 				.setHeader("Total").setResizable(true);
 

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
@@ -70,8 +70,8 @@ public class BudgetView extends VerticalLayout implements BeforeEnterObserver {
 
 	private Component getContent() {
 		HorizontalLayout content = new HorizontalLayout(grid, form);
-		content.setFlexGrow(2, grid);
-		content.setFlexGrow(1, form);
+		content.setFlexGrow(1, grid);
+		content.setFlexGrow(3, form);
 		content.addClassNames("content");
 		content.setSizeFull();
 		return content;


### PR DESCRIPTION
## Summary
This PR adds support for filtering Odoo account move lines by date range when retrieving costs for budget entries. Users can now specify start and end dates for each budget entry, which are used to filter the costs fetched from Odoo.

## Key Changes
- **BudgetEntry entity**: Added `init` (start date) and `end` (end date) fields with corresponding getters and setters
- **BudgetForm UI**: 
  - Added two new `DatePicker` components for selecting start and end dates
  - Integrated date fields into the budget entries grid with formatted display (dd/MM/yyyy)
  - Updated the Odoo cost refresh logic to pass the date range parameters
- **OdooService**: 
  - Modified `getOdooAccountMoveLines()` method signature to accept `LocalDate init` and `end` parameters
  - Enhanced the Odoo domain filter to include date range conditions when both dates are provided
  - Changed domain construction from fixed Arrays.asList to dynamic ArrayList for flexibility
- **BudgetView layout**: Adjusted flex grow ratios to give more space to the form (3) relative to the grid (1)

## Implementation Details
- Date filtering is optional - if either init or end date is null, no date filter is applied to the Odoo query
- Dates are converted to ISO string format (yyyy-MM-dd) for Odoo API compatibility
- The UI displays dates in dd/MM/yyyy format for better user readability
- Date fields are editable inline within the budget entries grid

https://claude.ai/code/session_01FWx56vk3v2PYxKV4KxdPT9