### PR TITLE
Adjust IntegerField widths in question coding step 2

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/questioncoding/QuestionCodingView.java
+++ b/src/main/java/uy/com/bay/utiles/views/questioncoding/QuestionCodingView.java
@@ -147,7 +147,7 @@ public class QuestionCodingView extends VerticalLayout {
 			IntegerField textField = new IntegerField();
 			textField.setValue(mapping.getMinimumCodifications() != null ? mapping.getMinimumCodifications() : 1);
 			textField.setMin(0);
-			textField.setWidthFull();
+			textField.setWidth("4em");
 			textField.getElement().addEventListener("click", e -> {
 			}).addEventData("event.stopPropagation()");
 			textField.addValueChangeListener(
@@ -159,7 +159,7 @@ public class QuestionCodingView extends VerticalLayout {
 			IntegerField textField = new IntegerField();
 			textField.setValue(mapping.getMaximumCodifications() != null ? mapping.getMaximumCodifications() : 1);
 			textField.setMin(0);
-			textField.setWidthFull();
+			textField.setWidth("4em");
 			textField.getElement().addEventListener("click", e -> {
 			}).addEventData("event.stopPropagation()");
 			textField.addValueChangeListener(
@@ -172,7 +172,7 @@ public class QuestionCodingView extends VerticalLayout {
 			textField.setValue(
 					mapping.getMinimunQuestionsWithCode() != null ? mapping.getMinimunQuestionsWithCode() : 1);
 			textField.setMin(0);
-			textField.setWidthFull();
+			textField.setWidth("4em");
 			textField.getElement().addEventListener("click", e -> {
 			}).addEventData("event.stopPropagation()");
 			textField.addValueChangeListener(


### PR DESCRIPTION
## Summary
Updated the width styling of three IntegerField components in the question coding view's step 2 to use a fixed width instead of full width layout.

## Changes
- Changed minimum codifications IntegerField width from `setWidthFull()` to `setWidth("4em")`
- Changed maximum codifications IntegerField width from `setWidthFull()` to `setWidth("4em")`
- Changed minimum questions with code IntegerField width from `setWidthFull()` to `setWidth("4em")`

## Details
These IntegerField components are used for numeric input in the question coding configuration. By constraining them to a fixed width of 4em instead of expanding to fill available space, the UI layout becomes more compact and appropriate for small numeric values. This improves the visual hierarchy and prevents unnecessary whitespace in the form.

https://claude.ai/code/session_01M9bSy9UZSf2Rkd6Y1FpcZj