### PR TITLE
Add conditional field enabling and grid refresh in QuestionCodingView

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/questioncoding/QuestionCodingView.java
+++ b/src/main/java/uy/com/bay/utiles/views/questioncoding/QuestionCodingView.java
@@ -132,14 +132,21 @@ public class QuestionCodingView extends VerticalLayout {
 		grid.addColumn(new ComponentRenderer<>(mapping -> {
 			Checkbox checkbox = new Checkbox();
 			checkbox.setValue(mapping.isToCode());
-			checkbox.addValueChangeListener(event -> mapping.setToCode(event.getValue()));
+			checkbox.addValueChangeListener(event -> {
+				mapping.setToCode(event.getValue());
+				grid.getDataProvider().refreshItem(mapping);
+			});
 			return checkbox;
 		})).setHeader("Codificar");
 
 		grid.addColumn(new ComponentRenderer<>(mapping -> {
 			Checkbox checkbox = new Checkbox();
 			checkbox.setValue(mapping.isGenerateCodes());
-			checkbox.addValueChangeListener(event -> mapping.setGenerateCodes(event.getValue()));
+			checkbox.setEnabled(mapping.isToCode());
+			checkbox.addValueChangeListener(event -> {
+				mapping.setGenerateCodes(event.getValue());
+				grid.getDataProvider().refreshItem(mapping);
+			});
 			return checkbox;
 		})).setHeader("Generar códigos");
 
@@ -148,6 +155,7 @@ public class QuestionCodingView extends VerticalLayout {
 			textField.setValue(mapping.getMinimumCodifications() != null ? mapping.getMinimumCodifications() : 1);
 			textField.setMin(0);
 			textField.setWidth("4em");
+			textField.setEnabled(mapping.isToCode());
 			textField.getElement().addEventListener("click", e -> {
 			}).addEventData("event.stopPropagation()");
 			textField.addValueChangeListener(
@@ -160,6 +168,7 @@ public class QuestionCodingView extends VerticalLayout {
 			textField.setValue(mapping.getMaximumCodifications() != null ? mapping.getMaximumCodifications() : 1);
 			textField.setMin(0);
 			textField.setWidth("4em");
+			textField.setEnabled(mapping.isToCode());
 			textField.getElement().addEventListener("click", e -> {
 			}).addEventData("event.stopPropagation()");
 			textField.addValueChangeListener(
@@ -173,6 +182,7 @@ public class QuestionCodingView extends VerticalLayout {
 					mapping.getMinimunQuestionsWithCode() != null ? mapping.getMinimunQuestionsWithCode() : 1);
 			textField.setMin(0);
 			textField.setWidth("4em");
+			textField.setEnabled(mapping.isGenerateCodes());
 			textField.getElement().addEventListener("click", e -> {
 			}).addEventData("event.stopPropagation()");
 			textField.addValueChangeListener(
@@ -182,12 +192,14 @@ public class QuestionCodingView extends VerticalLayout {
 		grid.addColumn(new ComponentRenderer<>(mapping -> {
 			TextArea textField = new TextArea();
 			textField.setValue(mapping.getQuestion() != null ? mapping.getQuestion() : "");
+			textField.setEnabled(mapping.isToCode());
 			textField.addValueChangeListener(event -> mapping.setQuestion(event.getValue()));
 			return textField;
 		})).setHeader("Pregunta");
 		grid.addColumn(new ComponentRenderer<>(mapping -> {
 			TextArea textField = new TextArea();
 			textField.setValue(mapping.getFineTuning() != null ? mapping.getFineTuning() : "");
+			textField.setEnabled(mapping.isToCode());
 			textField.addValueChangeListener(event -> mapping.setFineTuning(event.getValue()));
 			return textField;
 		})).setHeader("Fine Tuning ");


### PR DESCRIPTION
## Summary
Enhanced the QuestionCodingView to improve user experience by conditionally enabling/disabling form fields based on checkbox states and ensuring grid updates reflect changes immediately.

## Key Changes
- **Grid refresh on checkbox changes**: Added `grid.getDataProvider().refreshItem(mapping)` calls to both "Codificar" and "Generar códigos" checkboxes to ensure the grid updates when values change
- **Conditional field enabling**: 
  - "Generar códigos" checkbox is now disabled when "Codificar" is unchecked
  - Minimum/Maximum Codifications fields are disabled when "Codificar" is unchecked
  - Minimum Questions with Code field is disabled when "Generar códigos" is unchecked
  - Question and Fine Tuning text areas are disabled when "Codificar" is unchecked
- **Improved validation flow**: Fields that depend on parent checkboxes are now automatically disabled, preventing invalid state combinations

## Implementation Details
The changes follow a dependency model where:
1. "Codificar" checkbox is the primary toggle controlling multiple dependent fields
2. "Generar códigos" checkbox depends on "Codificar" being enabled
3. Related input fields are disabled based on their parent checkbox state, providing clear visual feedback to users about which fields are applicable

https://claude.ai/code/session_01DpGsc3sLsS3stkxEPodRPW