### PR TITLE
Add template save functionality for question encoding configurations

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/ColumnMapping.java
+++ b/src/main/java/uy/com/bay/utiles/data/ColumnMapping.java
@@ -1,0 +1,101 @@
+package uy.com.bay.utiles.data;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class ColumnMapping extends AbstractEntity {
+
+    private String questionVariable = "";
+    private boolean toCode;
+    private boolean generateCodes;
+    private String fineTuning = "";
+    private String question = "";
+    private Integer minimumCodifications = 1;
+    private Integer maximumCodifications = 1;
+    private Integer minimunQuestionsWithCode = 1;
+
+    @ManyToOne
+    @JoinColumn(name = "question_encoding_template_id")
+    private QuestionEncodingTemplate questionEncodingTemplate;
+
+    public ColumnMapping() {
+    }
+
+    public ColumnMapping(String originalName) {
+        this.questionVariable = originalName;
+    }
+
+    public String getQuestionVariable() {
+        return questionVariable;
+    }
+
+    public void setQuestionVariable(String questionVariable) {
+        this.questionVariable = questionVariable;
+    }
+
+    public boolean isToCode() {
+        return toCode;
+    }
+
+    public void setToCode(boolean toCode) {
+        this.toCode = toCode;
+    }
+
+    public boolean isGenerateCodes() {
+        return generateCodes;
+    }
+
+    public void setGenerateCodes(boolean generateCodes) {
+        this.generateCodes = generateCodes;
+    }
+
+    public String getFineTuning() {
+        return fineTuning;
+    }
+
+    public void setFineTuning(String fineTuning) {
+        this.fineTuning = fineTuning;
+    }
+
+    public String getQuestion() {
+        return question;
+    }
+
+    public void setQuestion(String question) {
+        this.question = question;
+    }
+
+    public Integer getMinimumCodifications() {
+        return minimumCodifications;
+    }
+
+    public void setMinimumCodifications(Integer minimumCodifications) {
+        this.minimumCodifications = minimumCodifications;
+    }
+
+    public Integer getMaximumCodifications() {
+        return maximumCodifications;
+    }
+
+    public void setMaximumCodifications(Integer maximumCodifications) {
+        this.maximumCodifications = maximumCodifications;
+    }
+
+    public Integer getMinimunQuestionsWithCode() {
+        return minimunQuestionsWithCode;
+    }
+
+    public void setMinimunQuestionsWithCode(Integer minimunQuestionsWithCode) {
+        this.minimunQuestionsWithCode = minimunQuestionsWithCode;
+    }
+
+    public QuestionEncodingTemplate getQuestionEncodingTemplate() {
+        return questionEncodingTemplate;
+    }
+
+    public void setQuestionEncodingTemplate(QuestionEncodingTemplate questionEncodingTemplate) {
+        this.questionEncodingTemplate = questionEncodingTemplate;
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/data/QuestionEncodingTemplate.java
+++ b/src/main/java/uy/com/bay/utiles/data/QuestionEncodingTemplate.java
@@ -1,0 +1,57 @@
+package uy.com.bay.utiles.data;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Lob;
+import jakarta.persistence.OneToMany;
+
+@Entity
+public class QuestionEncodingTemplate extends AbstractEntity {
+
+    private LocalDate created;
+
+    private String name;
+
+    @OneToMany(mappedBy = "questionEncodingTemplate", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    private List<ColumnMapping> columnMappings = new ArrayList<>();
+
+    @Lob
+    private byte[] codeMappingFileContent;
+
+    public LocalDate getCreated() {
+        return created;
+    }
+
+    public void setCreated(LocalDate created) {
+        this.created = created;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<ColumnMapping> getColumnMappings() {
+        return columnMappings;
+    }
+
+    public void setColumnMappings(List<ColumnMapping> columnMappings) {
+        this.columnMappings = columnMappings;
+    }
+
+    public byte[] getCodeMappingFileContent() {
+        return codeMappingFileContent;
+    }
+
+    public void setCodeMappingFileContent(byte[] codeMappingFileContent) {
+        this.codeMappingFileContent = codeMappingFileContent;
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/data/repository/QuestionEncodingTemplateRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/QuestionEncodingTemplateRepository.java
@@ -1,0 +1,10 @@
+package uy.com.bay.utiles.data.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import uy.com.bay.utiles.data.QuestionEncodingTemplate;
+
+@Repository
+public interface QuestionEncodingTemplateRepository extends JpaRepository<QuestionEncodingTemplate, Long> {
+}

--- a/src/main/java/uy/com/bay/utiles/data/service/QuestionEncodingTemplateService.java
+++ b/src/main/java/uy/com/bay/utiles/data/service/QuestionEncodingTemplateService.java
@@ -1,0 +1,20 @@
+package uy.com.bay.utiles.data.service;
+
+import org.springframework.stereotype.Service;
+
+import uy.com.bay.utiles.data.QuestionEncodingTemplate;
+import uy.com.bay.utiles.data.repository.QuestionEncodingTemplateRepository;
+
+@Service
+public class QuestionEncodingTemplateService {
+
+    private final QuestionEncodingTemplateRepository repository;
+
+    public QuestionEncodingTemplateService(QuestionEncodingTemplateRepository repository) {
+        this.repository = repository;
+    }
+
+    public QuestionEncodingTemplate save(QuestionEncodingTemplate template) {
+        return repository.save(template);
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/views/questioncoding/QuestionCodingView.java
+++ b/src/main/java/uy/com/bay/utiles/views/questioncoding/QuestionCodingView.java
@@ -5,6 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,6 +25,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.checkbox.Checkbox;
+import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.H2;
@@ -42,6 +44,9 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.StreamResource;
 
 import jakarta.annotation.security.RolesAllowed;
+import uy.com.bay.utiles.data.ColumnMapping;
+import uy.com.bay.utiles.data.QuestionEncodingTemplate;
+import uy.com.bay.utiles.data.service.QuestionEncodingTemplateService;
 import uy.com.bay.utiles.dto.aiencoding.QuestionAIAnswer;
 import uy.com.bay.utiles.dto.aiencoding.QuestionAICode;
 import uy.com.bay.utiles.dto.aiencoding.QuestionAIInput;
@@ -63,14 +68,17 @@ public class QuestionCodingView extends VerticalLayout {
 	private final VerticalLayout step4;
 	private List<ColumnMapping> columnMappings;
 	private final ChatClient chatClient;
+	private final QuestionEncodingTemplateService questionEncodingTemplateService;
 	private byte[] surveyFileContent;
 	private byte[] codeMappingFileContent;
 	private String fileName;
 	private String basePrompt;
 	Grid<ColumnMapping> grid;
 
-	public QuestionCodingView(ChatClient.Builder chatClientBuilder) {
+	public QuestionCodingView(ChatClient.Builder chatClientBuilder,
+			QuestionEncodingTemplateService questionEncodingTemplateService) {
 		this.chatClient = chatClientBuilder.build();
+		this.questionEncodingTemplateService = questionEncodingTemplateService;
 		try (InputStream inputStream = getClass().getResourceAsStream("/prompts/questionEncoding.txt")) {
 			byte[] byteArray = FileCopyUtils.copyToByteArray(inputStream);
 			this.basePrompt = new String(byteArray, StandardCharsets.UTF_8);
@@ -279,6 +287,7 @@ public class QuestionCodingView extends VerticalLayout {
 	private VerticalLayout createStep4() {
 		H2 header = new H2("Paso 4: Procesar codificación");
 		Button prevButton = new Button("Anterior");
+		Button saveButton = new Button("guardar como template");
 		Button processButton = new Button("Procesar");
 		Button downloadButton = new Button("Descargar");
 		downloadButton.setVisible(false);
@@ -286,6 +295,8 @@ public class QuestionCodingView extends VerticalLayout {
 		Anchor downloadLink = new Anchor();
 		downloadLink.getElement().setAttribute("download", true);
 		downloadLink.add(downloadButton);
+
+		saveButton.addClickListener(event -> openSaveTemplateDialog());
 
 		processButton.addClickListener(event -> {
 			ProgressDialog dialog = new ProgressDialog();
@@ -375,12 +386,46 @@ public class QuestionCodingView extends VerticalLayout {
 		prevButton.addClickListener(event -> showStep(3));
 
 		VerticalLayout layout = new VerticalLayout(header,
-				new HorizontalLayout(prevButton, processButton, downloadLink));
+				new HorizontalLayout(prevButton, saveButton, processButton, downloadLink));
 		layout.setSizeFull();
 		layout.setJustifyContentMode(JustifyContentMode.CENTER);
 		layout.setDefaultHorizontalComponentAlignment(Alignment.CENTER);
 		layout.getStyle().set("text-align", "center");
 		return layout;
+	}
+
+	private void openSaveTemplateDialog() {
+		Dialog dialog = new Dialog();
+		dialog.setHeaderTitle("Guardar template");
+
+		TextField nameField = new TextField("Nombre del template a guardar");
+		nameField.setWidthFull();
+
+		Button cancelButton = new Button("Cancelar", e -> dialog.close());
+		Button saveDialogButton = new Button("Guardar", e -> {
+			String name = nameField.getValue();
+			if (name == null || name.trim().isEmpty()) {
+				Notification.show("Debe ingresar un nombre");
+				return;
+			}
+			QuestionEncodingTemplate template = new QuestionEncodingTemplate();
+			template.setCreated(LocalDate.now());
+			template.setName(name);
+			template.setCodeMappingFileContent(codeMappingFileContent);
+			if (columnMappings != null) {
+				for (ColumnMapping mapping : columnMappings) {
+					mapping.setQuestionEncodingTemplate(template);
+					template.getColumnMappings().add(mapping);
+				}
+			}
+			questionEncodingTemplateService.save(template);
+			Notification.show("Template guardado");
+			dialog.close();
+		});
+
+		dialog.add(new VerticalLayout(nameField));
+		dialog.getFooter().add(cancelButton, saveDialogButton);
+		dialog.open();
 	}
 
 	private StreamResource createExcelStreamResource(Workbook workbook) {
@@ -493,82 +538,4 @@ public class QuestionCodingView extends VerticalLayout {
 		return newColumnIndex;
 	}
 
-	public static class ColumnMapping {
-		private String questionVariable = "";
-		private boolean toCode;
-		private boolean generateCodes;
-		private String fineTuning = "";
-		private String question = "";
-		private Integer minimumCodifications = 1;
-		private Integer maximumCodifications = 1;
-		private Integer minimunQuestionsWithCode = 1;
-
-		public ColumnMapping(String originalName) {
-			this.questionVariable = originalName;
-		}
-
-		public String getQuestionVariable() {
-			return questionVariable;
-		}
-
-		public boolean isToCode() {
-			return toCode;
-		}
-
-		public void setToCode(boolean toCode) {
-			this.toCode = toCode;
-		}
-
-		public String getFineTuning() {
-			return fineTuning;
-		}
-
-		public void setFineTuning(String fineTuning) {
-			this.fineTuning = fineTuning;
-		}
-
-		public String getQuestion() {
-			return question;
-		}
-
-		public void setQuestion(String question) {
-			this.question = question;
-		}
-
-		public boolean isGenerateCodes() {
-			return generateCodes;
-		}
-
-		public void setGenerateCodes(boolean generateCodes) {
-			this.generateCodes = generateCodes;
-		}
-
-		public Integer getMinimumCodifications() {
-			return minimumCodifications;
-		}
-
-		public void setMinimumCodifications(Integer minimumCodifications) {
-			this.minimumCodifications = minimumCodifications;
-		}
-
-		public Integer getMaximumCodifications() {
-			return maximumCodifications;
-		}
-
-		public void setMaximumCodifications(Integer maximumCodifications) {
-			this.maximumCodifications = maximumCodifications;
-		}
-
-		public Integer getMinimunQuestionsWithCode() {
-			return minimunQuestionsWithCode;
-		}
-
-		public void setMinimunQuestionsWithCode(Integer minimunQuestionsWithCode) {
-			this.minimunQuestionsWithCode = minimunQuestionsWithCode;
-		}
-
-		public void setQuestionVariable(String questionVariable) {
-			this.questionVariable = questionVariable;
-		}
-	}
 }


### PR DESCRIPTION
## Summary
This PR adds the ability to save question encoding configurations as reusable templates. It extracts the `ColumnMapping` class into a JPA entity and introduces new entities and services to persist encoding templates with their associated column mappings.

## Key Changes
- **Extracted `ColumnMapping` to JPA Entity**: Moved `ColumnMapping` from an inner class in `QuestionCodingView` to a standalone JPA entity (`src/main/java/uy/com/bay/utiles/data/ColumnMapping.java`) with a many-to-one relationship to `QuestionEncodingTemplate`
- **Created `QuestionEncodingTemplate` Entity**: New entity to represent a saved encoding template with:
  - Name and creation date
  - One-to-many relationship with `ColumnMapping` entities
  - Storage of the code mapping file content as a BLOB
- **Added Service Layer**: Implemented `QuestionEncodingTemplateService` to handle template persistence operations
- **Added Repository**: Created `QuestionEncodingTemplateRepository` for database access
- **UI Enhancement**: Added "guardar como template" button in Step 4 that opens a dialog allowing users to:
  - Enter a template name
  - Save the current column mappings and code mapping file
  - Persist the configuration for future reuse
- **Updated Constructor**: Modified `QuestionCodingView` constructor to accept `QuestionEncodingTemplateService` dependency

## Implementation Details
- The save template dialog validates that a name is provided before persisting
- Column mappings are automatically associated with the template through bidirectional relationship management
- Templates are created with the current date and can be retrieved later for reuse
- The implementation uses Vaadin's Dialog component for user interaction

https://claude.ai/code/session_01KK8cdSwY2AcnwyqWbfuX73