### PR TITLE
Support multiple assigned codes per survey response

### DIFF
--- a/src/main/java/uy/com/bay/utiles/dto/aiencoding/response/AssignedCode.java
+++ b/src/main/java/uy/com/bay/utiles/dto/aiencoding/response/AssignedCode.java
@@ -1,0 +1,25 @@
+package uy.com.bay.utiles.dto.aiencoding.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AssignedCode {
+    @JsonProperty("assigned_code")
+    private String assignedCode;
+    private String comment;
+
+    public String getAssignedCode() {
+        return assignedCode;
+    }
+
+    public void setAssignedCode(String assignedCode) {
+        this.assignedCode = assignedCode;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/dto/aiencoding/response/Coding.java
+++ b/src/main/java/uy/com/bay/utiles/dto/aiencoding/response/Coding.java
@@ -1,13 +1,14 @@
 package uy.com.bay.utiles.dto.aiencoding.response;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class Coding {
     @JsonProperty("response_id")
     private String responseId;
-    @JsonProperty("assigned_code")
-    private String assignedCode;
-    private String comment;
+    private List<AssignedCode> codes = new ArrayList<>();
 
     public String getResponseId() {
         return responseId;
@@ -17,19 +18,11 @@ public class Coding {
         this.responseId = responseId;
     }
 
-    public String getAssignedCode() {
-        return assignedCode;
+    public List<AssignedCode> getCodes() {
+        return codes;
     }
 
-    public void setAssignedCode(String assignedCode) {
-        this.assignedCode = assignedCode;
-    }
-
-    public String getComment() {
-        return comment;
-    }
-
-    public void setComment(String comment) {
-        this.comment = comment;
+    public void setCodes(List<AssignedCode> codes) {
+        this.codes = codes;
     }
 }

--- a/src/main/java/uy/com/bay/utiles/views/questioncoding/QuestionCodingView.java
+++ b/src/main/java/uy/com/bay/utiles/views/questioncoding/QuestionCodingView.java
@@ -51,6 +51,7 @@ import uy.com.bay.utiles.dto.aiencoding.QuestionAIAnswer;
 import uy.com.bay.utiles.dto.aiencoding.QuestionAICode;
 import uy.com.bay.utiles.dto.aiencoding.QuestionAIInput;
 import uy.com.bay.utiles.dto.aiencoding.QuestionEncodingAIInput;
+import uy.com.bay.utiles.dto.aiencoding.response.AssignedCode;
 import uy.com.bay.utiles.dto.aiencoding.response.CodedResponse;
 import uy.com.bay.utiles.dto.aiencoding.response.Coding;
 import uy.com.bay.utiles.dto.aiencoding.response.Question;
@@ -549,16 +550,7 @@ public class QuestionCodingView extends VerticalLayout {
 			Row headerRow = sheet.getRow(0);
 
 			for (Question question : codedResponse.getQuestions()) {
-				int codingIndex = 0;
 				for (Coding coding : question.getCodings()) {
-					codingIndex++;
-					// Create new headers for code and comment
-					int codeColumnIndex = this.getOrCreateColumnIndex(headerRow,
-							question.getQuestionId() + "-" + codingIndex + "-" + "CODIGO");
-
-					int commentColumnIndex = this.getOrCreateColumnIndex(headerRow,
-							question.getQuestionId() + "-" + codingIndex + "-" + "COMENTARIO");
-
 					try {
 						int responseId = Integer.parseInt(coding.getResponseId());
 						Row dataRow = sheet.getRow(responseId);
@@ -566,11 +558,21 @@ public class QuestionCodingView extends VerticalLayout {
 							dataRow = sheet.createRow(responseId);
 						}
 
-						Cell codeCell = dataRow.createCell(codeColumnIndex);
-						codeCell.setCellValue(coding.getAssignedCode());
+						int codeIndex = 0;
+						for (AssignedCode assignedCode : coding.getCodes()) {
+							codeIndex++;
+							int codeColumnIndex = this.getOrCreateColumnIndex(headerRow,
+									question.getQuestionId() + "-" + codeIndex + "-" + "CODIGO");
 
-						Cell commentCell = dataRow.createCell(commentColumnIndex);
-						commentCell.setCellValue(coding.getComment());
+							int commentColumnIndex = this.getOrCreateColumnIndex(headerRow,
+									question.getQuestionId() + "-" + codeIndex + "-" + "COMENTARIO");
+
+							Cell codeCell = dataRow.createCell(codeColumnIndex);
+							codeCell.setCellValue(assignedCode.getAssignedCode());
+
+							Cell commentCell = dataRow.createCell(commentColumnIndex);
+							commentCell.setCellValue(assignedCode.getComment());
+						}
 					} catch (NumberFormatException e) {
 						System.err.println("Invalid response_id format: " + coding.getResponseId());
 					}


### PR DESCRIPTION
## Summary
Refactored the coding response structure to support multiple assigned codes and comments per survey response, rather than a single code-comment pair.

## Key Changes
- **New DTO class**: Created `AssignedCode` class to represent individual code assignments with their associated comments
- **Updated `Coding` class**: Replaced single `assignedCode` and `comment` fields with a `List<AssignedCode>` to support multiple codes per response
- **Updated `QuestionCodingView`**: Modified the `updateSurveyWithCodedResponses` method to iterate through multiple assigned codes for each coding, creating separate columns for each code-comment pair in the Excel workbook

## Implementation Details
- The `AssignedCode` class uses Jackson's `@JsonProperty` annotation to map the JSON field `assigned_code` to the Java field `assignedCode`
- The refactored logic now creates column headers dynamically for each assigned code (e.g., `QUESTION_ID-1-CODIGO`, `QUESTION_ID-1-COMENTARIO`, `QUESTION_ID-2-CODIGO`, etc.)
- The change maintains backward compatibility with the Excel export functionality while enabling more flexible code assignment scenarios

https://claude.ai/code/session_01RXVD8PcnDLG85TWbZg3dQd