### PR TITLE
Fix grid column widths in QuestionCodingView

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/questioncoding/QuestionCodingView.java
+++ b/src/main/java/uy/com/bay/utiles/views/questioncoding/QuestionCodingView.java
@@ -175,41 +175,41 @@ public class QuestionCodingView extends VerticalLayout {
 			IntegerField textField = new IntegerField();
 			textField.setValue(mapping.getMinimumCodifications() != null ? mapping.getMinimumCodifications() : 1);
 			textField.setMin(0);
-			textField.setWidth("4em");
+			textField.setWidthFull();
 			textField.setEnabled(mapping.isToCode());
 			textField.getElement().addEventListener("click", e -> {
 			}).addEventData("event.stopPropagation()");
 			textField.addValueChangeListener(
 					event -> mapping.setMinimumCodifications(event.getValue() != null ? event.getValue() : 1));
 			return textField;
-		})).setHeader("Códigos min").setAutoWidth(true).setFlexGrow(0);
+		})).setHeader("Códigos min").setWidth("8em").setFlexGrow(0);
 
 		grid.addColumn(new ComponentRenderer<>(mapping -> {
 			IntegerField textField = new IntegerField();
 			textField.setValue(mapping.getMaximumCodifications() != null ? mapping.getMaximumCodifications() : 1);
 			textField.setMin(0);
-			textField.setWidth("4em");
+			textField.setWidthFull();
 			textField.setEnabled(mapping.isToCode());
 			textField.getElement().addEventListener("click", e -> {
 			}).addEventData("event.stopPropagation()");
 			textField.addValueChangeListener(
 					event -> mapping.setMaximumCodifications(event.getValue() != null ? event.getValue() : 1));
 			return textField;
-		})).setHeader("Códigos max").setAutoWidth(true).setFlexGrow(0);
+		})).setHeader("Códigos max").setWidth("8em").setFlexGrow(0);
 
 		grid.addColumn(new ComponentRenderer<>(mapping -> {
 			IntegerField textField = new IntegerField();
 			textField.setValue(
 					mapping.getMinimunQuestionsWithCode() != null ? mapping.getMinimunQuestionsWithCode() : 1);
 			textField.setMin(0);
-			textField.setWidth("4em");
+			textField.setWidthFull();
 			textField.setEnabled(mapping.isGenerateCodes());
 			textField.getElement().addEventListener("click", e -> {
 			}).addEventData("event.stopPropagation()");
 			textField.addValueChangeListener(
 					event -> mapping.setMinimunQuestionsWithCode(event.getValue() != null ? event.getValue() : 1));
 			return textField;
-		})).setHeader("Respuestas para nueva categoría").setAutoWidth(true).setFlexGrow(0);
+		})).setHeader("Respuestas para nueva categoría").setWidth("16em").setFlexGrow(0);
 		grid.addColumn(new ComponentRenderer<>(mapping -> {
 			TextArea textField = new TextArea();
 			textField.setValue(mapping.getQuestion() != null ? mapping.getQuestion() : "");


### PR DESCRIPTION
## Summary
Updated the grid column width configuration in the QuestionCodingView to improve layout consistency and readability. Changed from fixed component widths with auto-width columns to full-width components with explicit column widths.

## Key Changes
- Modified three IntegerField components to use `setWidthFull()` instead of fixed `setWidth("4em")`
- Updated corresponding grid column headers to use explicit widths:
  - "Códigos min" column: `setWidth("8em")`
  - "Códigos max" column: `setWidth("8em")`
  - "Respuestas para nueva categoría" column: `setWidth("16em")`
- Replaced `setAutoWidth(true)` with explicit `setWidth()` calls on all three columns
- Maintained `setFlexGrow(0)` on all columns to prevent flex growth

## Implementation Details
This change ensures that the input fields expand to fill their container while the grid columns maintain consistent, predictable widths. The wider column for "Respuestas para nueva categoría" accommodates the longer header text without truncation.

https://claude.ai/code/session_013swyjWwAe2KJ4fJyDNuM84