### PR TITLE
Ampliar ancho de columnas en QuestionCodingView

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/questioncoding/QuestionCodingView.java
+++ b/src/main/java/uy/com/bay/utiles/views/questioncoding/QuestionCodingView.java
@@ -184,7 +184,7 @@ public class QuestionCodingView extends VerticalLayout {
 				mapping.setMinimumCodifications(v != null && !v.isEmpty() ? Integer.parseInt(v) : 1);
 			});
 			return textField;
-		})).setHeader("Códigos min").setWidth("8em").setFlexGrow(0);
+		})).setHeader("Códigos min").setWidth("11em").setFlexGrow(0);
 
 		grid.addColumn(new ComponentRenderer<>(mapping -> {
 			TextField textField = new TextField();
@@ -200,7 +200,7 @@ public class QuestionCodingView extends VerticalLayout {
 				mapping.setMaximumCodifications(v != null && !v.isEmpty() ? Integer.parseInt(v) : 1);
 			});
 			return textField;
-		})).setHeader("Códigos max").setWidth("8em").setFlexGrow(0);
+		})).setHeader("Códigos max").setWidth("11em").setFlexGrow(0);
 
 		grid.addColumn(new ComponentRenderer<>(mapping -> {
 			TextField textField = new TextField();
@@ -217,7 +217,7 @@ public class QuestionCodingView extends VerticalLayout {
 				mapping.setMinimunQuestionsWithCode(v != null && !v.isEmpty() ? Integer.parseInt(v) : 1);
 			});
 			return textField;
-		})).setHeader("Respuestas para nueva categoría").setWidth("16em").setFlexGrow(0);
+		})).setHeader("Respuestas para nueva categoría").setWidth("22em").setFlexGrow(0);
 		grid.addColumn(new ComponentRenderer<>(mapping -> {
 			TextArea textField = new TextArea();
 			textField.setValue(mapping.getQuestion() != null ? mapping.getQuestion() : "");


### PR DESCRIPTION
## Summary
- Los encabezados "Códigos min", "Códigos max" y "Respuestas para nueva categoría" se truncaban por ancho insuficiente.
- Se ajusta el ancho de las columnas: 8em → 11em (Códigos min/max) y 16em → 22em (Respuestas para nueva categoría).

## Test plan
- [ ] Compilar con `mvn clean package -Pproduction` y desplegar.
- [ ] Abrir QuestionCodingView, cargar un excel y verificar en el Paso 2 que los encabezados de las tres columnas se muestran completos sin truncarse.
- [ ] Verificar que los TextFields siguen visibles y funcionales dentro de cada columna.

https://claude.ai/code/session_013swyjWwAe2KJ4fJyDNuM84

---
_Generated by [Claude Code](https://claude.ai/code/session_013swyjWwAe2KJ4fJyDNuM84)_