### PR TITLE
Adjust TextField widths in QuestionCodingView grid columns

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/questioncoding/QuestionCodingView.java
+++ b/src/main/java/uy/com/bay/utiles/views/questioncoding/QuestionCodingView.java
@@ -176,7 +176,8 @@ public class QuestionCodingView extends VerticalLayout {
 			textField.setValue(
 					mapping.getMinimumCodifications() != null ? String.valueOf(mapping.getMinimumCodifications())
 							: "1");
-			textField.setWidthFull();
+			textField.setWidth("1ch");
+			textField.getStyle().set("min-width", "1ch");
 			textField.setEnabled(mapping.isToCode());
 			textField.getElement().addEventListener("click", e -> {
 			}).addEventData("event.stopPropagation()");
@@ -185,7 +186,7 @@ public class QuestionCodingView extends VerticalLayout {
 				mapping.setMinimumCodifications(v != null && !v.isEmpty() ? Integer.parseInt(v) : 1);
 			});
 			return textField;
-		})).setHeader("Códigos min").setWidth("11em").setFlexGrow(0);
+		})).setHeader("Códigos min").setWidth("5em").setFlexGrow(0);
 
 		grid.addColumn(new ComponentRenderer<>(mapping -> {
 			TextField textField = new TextField();
@@ -193,7 +194,8 @@ public class QuestionCodingView extends VerticalLayout {
 			textField.setValue(
 					mapping.getMaximumCodifications() != null ? String.valueOf(mapping.getMaximumCodifications())
 							: "1");
-			textField.setWidthFull();
+			textField.setWidth("1ch");
+			textField.getStyle().set("min-width", "1ch");
 			textField.setEnabled(mapping.isToCode());
 			textField.getElement().addEventListener("click", e -> {
 			}).addEventData("event.stopPropagation()");
@@ -202,7 +204,7 @@ public class QuestionCodingView extends VerticalLayout {
 				mapping.setMaximumCodifications(v != null && !v.isEmpty() ? Integer.parseInt(v) : 1);
 			});
 			return textField;
-		})).setHeader("Códigos max").setWidth("11em").setFlexGrow(0);
+		})).setHeader("Códigos max").setWidth("5em").setFlexGrow(0);
 
 		grid.addColumn(new ComponentRenderer<>(mapping -> {
 			TextField textField = new TextField();
@@ -210,7 +212,8 @@ public class QuestionCodingView extends VerticalLayout {
 			textField.setValue(mapping.getMinimunQuestionsWithCode() != null
 					? String.valueOf(mapping.getMinimunQuestionsWithCode())
 					: "1");
-			textField.setWidthFull();
+			textField.setWidth("1ch");
+			textField.getStyle().set("min-width", "1ch");
 			textField.setEnabled(mapping.isGenerateCodes());
 			textField.getElement().addEventListener("click", e -> {
 			}).addEventData("event.stopPropagation()");
@@ -219,7 +222,7 @@ public class QuestionCodingView extends VerticalLayout {
 				mapping.setMinimunQuestionsWithCode(v != null && !v.isEmpty() ? Integer.parseInt(v) : 1);
 			});
 			return textField;
-		})).setHeader("Respuestas para nueva categoría").setWidth("22em").setFlexGrow(0);
+		})).setHeader("Respuestas para nueva categoría").setWidth("16em").setFlexGrow(0);
 		grid.addColumn(new ComponentRenderer<>(mapping -> {
 			TextArea textField = new TextArea();
 			textField.setValue(mapping.getQuestion() != null ? mapping.getQuestion() : "");


### PR DESCRIPTION
## Summary
This PR refines the layout and sizing of input fields in the question coding grid by adjusting TextField widths and column dimensions for better visual consistency and usability.

## Key Changes
- Changed TextField width from `setWidthFull()` to `setWidth("1ch")` with `min-width: 1ch` CSS style for three numeric input columns ("Códigos min", "Códigos max", and "Respuestas para nueva categoría")
- Reduced grid column widths:
  - "Códigos min" and "Códigos max" columns: from `11em` to `5em`
  - "Respuestas para nueva categoría" column: from `22em` to `16em`

## Implementation Details
- The TextFields now use a character-based width (`1ch`) instead of filling available space, preventing them from expanding unnecessarily
- Added explicit `min-width` CSS styling to ensure minimum field size is maintained
- Column width reductions align with the more compact TextField sizing, creating a more balanced and space-efficient grid layout

https://claude.ai/code/session_01T3onNWyvX28gSBfXoU8ito