### PR TITLE
Validar columna 'CaseId' al cargar archivo en QuestionCodingView

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/questioncoding/QuestionCodingView.java
+++ b/src/main/java/uy/com/bay/utiles/views/questioncoding/QuestionCodingView.java
@@ -119,6 +119,23 @@ public class QuestionCodingView extends VerticalLayout {
 				Workbook workbook = new XSSFWorkbook(new ByteArrayInputStream(surveyFileContent));
 				Sheet sheet = workbook.getSheetAt(0);
 				Row headerRow = sheet.getRow(0);
+				boolean hasCaseId = false;
+				if (headerRow != null) {
+					for (Cell cell : headerRow) {
+						if (cell.getCellType() == CellType.STRING
+								&& "CaseId".equals(cell.getStringCellValue())) {
+							hasCaseId = true;
+							break;
+						}
+					}
+				}
+				if (!hasCaseId) {
+					surveyFileContent = null;
+					fileName = null;
+					Notification.show("Error: el archivo no contiene una columna 'CaseId'.", 5000,
+							Notification.Position.MIDDLE);
+					return;
+				}
 				columnMappings = new ArrayList<>();
 				for (Cell cell : headerRow) {
 					columnMappings.add(new ColumnMapping(cell.getStringCellValue()));


### PR DESCRIPTION
## Summary
- Tras obtener el `Workbook` en el Paso 1 de `QuestionCodingView`, se valida que la fila de encabezado contenga una celda con valor `"CaseId"`.
- Si no se encuentra, se limpia el contenido cargado (`surveyFileContent`/`fileName`) y se notifica el error al usuario, abortando la carga.

## Test plan
- [ ] Cargar un archivo Excel sin columna `CaseId` y verificar que aparece la notificación de error y el botón "Abrir template" queda deshabilitado.
- [ ] Cargar un archivo Excel con columna `CaseId` y verificar que la carga procede normalmente y el grid se puebla.

https://claude.ai/code/session_01V4CJtJYmpPBwxT9J8sxKFQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4CJtJYmpPBwxT9J8sxKFQ)_