### PR TITLE
Refactor row lookup to use CaseId instead of row index

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/questioncoding/QuestionCodingView.java
+++ b/src/main/java/uy/com/bay/utiles/views/questioncoding/QuestionCodingView.java
@@ -728,32 +728,27 @@ public class QuestionCodingView extends VerticalLayout {
 
 			for (Question question : codedResponse.getQuestions()) {
 				for (Coding coding : question.getCodings()) {
-					try {
-						int responseId = Integer.parseInt(coding.getResponseId());
-						Row dataRow = sheet.getRow(responseId);
-						if (dataRow == null) {
-							dataRow = sheet.createRow(responseId);
-						}
+					String responseId = coding.getResponseId();
+					Row dataRow = findRowByCaseId(sheet, responseId);
+					if (dataRow == null) {
+						logger.warn("No se encontró fila con CaseId: {}", responseId);
+						continue;
+					}
 
-						int codeIndex = 0;
-						for (AssignedCode assignedCode : coding.getCodes()) {
-							codeIndex++;
-							int codeColumnIndex = this.getOrCreateColumnIndex(headerRow,
-									question.getQuestionId() + "-" + codeIndex + "-" + "CODIGO");
+					int codeIndex = 0;
+					for (AssignedCode assignedCode : coding.getCodes()) {
+						codeIndex++;
+						int codeColumnIndex = this.getOrCreateColumnIndex(headerRow,
+								question.getQuestionId() + "-" + codeIndex + "-" + "CODIGO");
 
-							int commentColumnIndex = this.getOrCreateColumnIndex(headerRow,
-									question.getQuestionId() + "-" + codeIndex + "-" + "COMENTARIO");
+						int commentColumnIndex = this.getOrCreateColumnIndex(headerRow,
+								question.getQuestionId() + "-" + codeIndex + "-" + "COMENTARIO");
 
-							Cell codeCell = dataRow.createCell(codeColumnIndex);
-							codeCell.setCellValue(assignedCode.getAssignedCode());
+						Cell codeCell = dataRow.createCell(codeColumnIndex);
+						codeCell.setCellValue(assignedCode.getAssignedCode());
 
-							Cell commentCell = dataRow.createCell(commentColumnIndex);
-							commentCell.setCellValue(assignedCode.getComment());
-						}
-					} catch (NumberFormatException e) {
-						e.printStackTrace();
-						logger.error(e.getMessage());
-						System.err.println("Invalid response_id format: " + coding.getResponseId());
+						Cell commentCell = dataRow.createCell(commentColumnIndex);
+						commentCell.setCellValue(assignedCode.getComment());
 					}
 				}
 			}
@@ -810,6 +805,47 @@ public class QuestionCodingView extends VerticalLayout {
 			}
 		}
 		return data;
+	}
+
+	private static Row findRowByCaseId(Sheet sheet, String caseId) {
+		if (sheet == null || caseId == null) {
+			return null;
+		}
+		Row headerRow = sheet.getRow(0);
+		if (headerRow == null) {
+			return null;
+		}
+		int caseIdColumnIndex = -1;
+		for (Cell cell : headerRow) {
+			if (cell.getCellType() == CellType.STRING
+					&& "CaseId".equalsIgnoreCase(cell.getStringCellValue().trim())) {
+				caseIdColumnIndex = cell.getColumnIndex();
+				break;
+			}
+		}
+		if (caseIdColumnIndex == -1) {
+			return null;
+		}
+		for (int i = 1; i <= sheet.getLastRowNum(); i++) {
+			Row row = sheet.getRow(i);
+			if (row == null) {
+				continue;
+			}
+			Cell cell = row.getCell(caseIdColumnIndex);
+			if (cell == null) {
+				continue;
+			}
+			String value;
+			if (cell.getCellType() == CellType.NUMERIC) {
+				value = String.valueOf((long) cell.getNumericCellValue());
+			} else {
+				value = cell.getStringCellValue();
+			}
+			if (caseId.equals(value)) {
+				return row;
+			}
+		}
+		return null;
 	}
 
 	private static int getOrCreateColumnIndex(Row headerRow, String headerName) {


### PR DESCRIPTION
## Summary
Refactored the `updateSurveyWithCodedResponses` method to look up spreadsheet rows by CaseId value instead of assuming responseId is a numeric row index. This improves robustness and eliminates error handling for invalid numeric formats.

## Key Changes
- **Removed try-catch block**: Eliminated NumberFormatException handling that was parsing responseId as an integer row index
- **Introduced `findRowByCaseId` method**: New helper method that searches for rows by matching the CaseId column value instead of using row numbers
  - Validates sheet and caseId parameters
  - Locates the CaseId column header dynamically
  - Iterates through rows to find a matching CaseId value
  - Handles both numeric and string cell types for CaseId comparison
- **Improved error handling**: Replaced exception printing with a warning log when no matching row is found, allowing processing to continue gracefully
- **Code cleanup**: Removed unnecessary indentation from the inner loop after extracting row lookup logic

## Implementation Details
- The `findRowByCaseId` method performs a linear search through the sheet, making it O(n) but more flexible than index-based lookup
- CaseId comparison is case-insensitive for the column header but case-sensitive for the value match
- Numeric CaseId values are converted to long strings for comparison to handle both data types consistently

https://claude.ai/code/session_013x6S8zbnwnniPTwRmY69M8