### PR TITLE
Add BudgetEntryService dependency and clear Odoo costs on refresh

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
@@ -54,6 +54,7 @@ import uy.com.bay.utiles.entities.Extra;
 import uy.com.bay.utiles.entities.OdooCost;
 import uy.com.bay.utiles.services.AlchemerSurveyResponseHelper;
 import uy.com.bay.utiles.services.BudgetConceptService;
+import uy.com.bay.utiles.services.BudgetEntryService;
 import uy.com.bay.utiles.services.BudgetExporter;
 import uy.com.bay.utiles.services.BudgetService;
 import uy.com.bay.utiles.services.OdooCostService;
@@ -77,6 +78,7 @@ public class BudgetForm extends VerticalLayout {
 	private final Binder<Budget> binder = new BeanValidationBinder<>(Budget.class);
 	private final BudgetConceptService budgetConceptService;
 	private final BudgetService budgetService;
+	private final BudgetEntryService budgetEntryService;
 	private final FieldworkService fieldworkService;
 	private final AlchemerSurveyResponseHelper alchemerSurveyResponseHelper;
 	private final Editor<BudgetEntry> editor;
@@ -89,10 +91,12 @@ public class BudgetForm extends VerticalLayout {
 	private final OdooCostService odooCostService;
 
 	public BudgetForm(StudyService studyService, BudgetConceptService budgetConceptService, BudgetService budgetService,
-			AlchemerSurveyResponseHelper alchemerSurveyResponseHelper, FieldworkService fieldworkService,
-			DoobloSurveyRetriever doobloSurveyRetriever, OdooService odooService, OdooCostService odooCostService) {
+			BudgetEntryService budgetEntryService, AlchemerSurveyResponseHelper alchemerSurveyResponseHelper,
+			FieldworkService fieldworkService, DoobloSurveyRetriever doobloSurveyRetriever, OdooService odooService,
+			OdooCostService odooCostService) {
 		this.budgetConceptService = budgetConceptService;
 		this.budgetService = budgetService;
+		this.budgetEntryService = budgetEntryService;
 		this.fieldworkService = fieldworkService;
 		this.alchemerSurveyResponseHelper = alchemerSurveyResponseHelper;
 		this.doobloSurveyRetriever = doobloSurveyRetriever;
@@ -201,6 +205,8 @@ public class BudgetForm extends VerticalLayout {
 			if (concept == null || concept.getOdooProductId() == null || concept.getOdooProductId().isEmpty()) {
 				continue;
 			}
+			budgetEntry.getOdooCosts().clear();
+			budgetEntryService.save(budgetEntry);
 			BigDecimal totalOdooCost = BigDecimal.ZERO;
 			List<Map<String, Object>> moveLines = odooService.getOdooAccountMoveLines(budgetStudy.getOdooId(),
 					concept.getOdooProductId(), budgetEntry.getInit(), budgetEntry.getEnd());

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
@@ -20,6 +20,7 @@ import uy.com.bay.utiles.data.service.FieldworkService;
 import uy.com.bay.utiles.entities.Budget;
 import uy.com.bay.utiles.services.AlchemerSurveyResponseHelper;
 import uy.com.bay.utiles.services.BudgetConceptService;
+import uy.com.bay.utiles.services.BudgetEntryService;
 import uy.com.bay.utiles.services.BudgetService;
 import uy.com.bay.utiles.services.OdooCostService;
 import uy.com.bay.utiles.services.OdooService;
@@ -37,16 +38,17 @@ public class BudgetView extends VerticalLayout implements BeforeEnterObserver {
 	private final BudgetForm form;
 	private final BudgetService budgetService;
 
-	public BudgetView(BudgetService budgetService, StudyService studyService, BudgetConceptService budgetConceptService,
-			AlchemerSurveyResponseHelper alchemerSurveyResponseHelper, FieldworkService fieldworkService,
-			DoobloSurveyRetriever doobloSurveyRetriever, OdooService odooService, OdooCostService odooCostService) {
+	public BudgetView(BudgetService budgetService, BudgetEntryService budgetEntryService, StudyService studyService,
+			BudgetConceptService budgetConceptService, AlchemerSurveyResponseHelper alchemerSurveyResponseHelper,
+			FieldworkService fieldworkService, DoobloSurveyRetriever doobloSurveyRetriever, OdooService odooService,
+			OdooCostService odooCostService) {
 		this.budgetService = budgetService;
 		addClassName("budget-view");
 		setSizeFull();
 		configureGrid();
 
-		form = new BudgetForm(studyService, budgetConceptService, budgetService, alchemerSurveyResponseHelper,
-				fieldworkService, doobloSurveyRetriever, odooService, odooCostService);
+		form = new BudgetForm(studyService, budgetConceptService, budgetService, budgetEntryService,
+				alchemerSurveyResponseHelper, fieldworkService, doobloSurveyRetriever, odooService, odooCostService);
 		form.addSaveListener(this::saveBudget);
 		form.addDeleteListener(this::deleteBudget);
 		form.addCloseListener(e -> closeEditor());


### PR DESCRIPTION
## Summary
This PR introduces `BudgetEntryService` as a dependency to the budget view and form components, and implements logic to clear cached Odoo costs when refreshing cost data from Odoo.

## Key Changes
- Added `BudgetEntryService` as a constructor parameter to `BudgetView` and `BudgetForm`
- Injected `BudgetEntryService` into `BudgetForm` as a private field
- Updated constructor signatures in both classes to include the new service dependency
- Implemented cost clearing logic in `refreshCostsFromOdoo()` method:
  - Clear existing Odoo costs from each budget entry before fetching fresh data
  - Persist the cleared state by saving the budget entry

## Implementation Details
The changes ensure that when Odoo costs are refreshed, any stale cost data is removed before new data is fetched and populated. This prevents duplicate or outdated cost entries from accumulating in the budget entries.

https://claude.ai/code/session_01WLgBNrUHT9XtHU6RgmRuT8