### PR TITLE
Refactor refreshCostsFromOdoo: limpiar OdooCosts antes de actualizar

### DIFF
--- a/src/main/java/uy/com/bay/utiles/repo/OdooCostRepository.java
+++ b/src/main/java/uy/com/bay/utiles/repo/OdooCostRepository.java
@@ -5,10 +5,13 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import uy.com.bay.utiles.entities.BudgetEntry;
 import uy.com.bay.utiles.entities.OdooCost;
 
 @Repository
 public interface OdooCostRepository extends JpaRepository<OdooCost, Long> {
 
     Optional<OdooCost> findByMoveId(String moveId);
+
+    void deleteByBudgetEntry(BudgetEntry budgetEntry);
 }

--- a/src/main/java/uy/com/bay/utiles/services/OdooCostService.java
+++ b/src/main/java/uy/com/bay/utiles/services/OdooCostService.java
@@ -3,7 +3,9 @@ package uy.com.bay.utiles.services;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import uy.com.bay.utiles.entities.BudgetEntry;
 import uy.com.bay.utiles.entities.OdooCost;
 import uy.com.bay.utiles.repo.OdooCostRepository;
 
@@ -22,5 +24,10 @@ public class OdooCostService {
 
     public Optional<OdooCost> findByMoveId(String moveId) {
         return repository.findByMoveId(moveId);
+    }
+
+    @Transactional
+    public void deleteByBudgetEntry(BudgetEntry budgetEntry) {
+        repository.deleteByBudgetEntry(budgetEntry);
     }
 }

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
@@ -54,7 +54,6 @@ import uy.com.bay.utiles.entities.Extra;
 import uy.com.bay.utiles.entities.OdooCost;
 import uy.com.bay.utiles.services.AlchemerSurveyResponseHelper;
 import uy.com.bay.utiles.services.BudgetConceptService;
-import uy.com.bay.utiles.services.BudgetEntryService;
 import uy.com.bay.utiles.services.BudgetExporter;
 import uy.com.bay.utiles.services.BudgetService;
 import uy.com.bay.utiles.services.OdooCostService;
@@ -78,7 +77,6 @@ public class BudgetForm extends VerticalLayout {
 	private final Binder<Budget> binder = new BeanValidationBinder<>(Budget.class);
 	private final BudgetConceptService budgetConceptService;
 	private final BudgetService budgetService;
-	private final BudgetEntryService budgetEntryService;
 	private final FieldworkService fieldworkService;
 	private final AlchemerSurveyResponseHelper alchemerSurveyResponseHelper;
 	private final Editor<BudgetEntry> editor;
@@ -91,12 +89,10 @@ public class BudgetForm extends VerticalLayout {
 	private final OdooCostService odooCostService;
 
 	public BudgetForm(StudyService studyService, BudgetConceptService budgetConceptService, BudgetService budgetService,
-			BudgetEntryService budgetEntryService, AlchemerSurveyResponseHelper alchemerSurveyResponseHelper,
-			FieldworkService fieldworkService, DoobloSurveyRetriever doobloSurveyRetriever, OdooService odooService,
-			OdooCostService odooCostService) {
+			AlchemerSurveyResponseHelper alchemerSurveyResponseHelper, FieldworkService fieldworkService,
+			DoobloSurveyRetriever doobloSurveyRetriever, OdooService odooService, OdooCostService odooCostService) {
 		this.budgetConceptService = budgetConceptService;
 		this.budgetService = budgetService;
-		this.budgetEntryService = budgetEntryService;
 		this.fieldworkService = fieldworkService;
 		this.alchemerSurveyResponseHelper = alchemerSurveyResponseHelper;
 		this.doobloSurveyRetriever = doobloSurveyRetriever;
@@ -205,8 +201,8 @@ public class BudgetForm extends VerticalLayout {
 			if (concept == null || concept.getOdooProductId() == null || concept.getOdooProductId().isEmpty()) {
 				continue;
 			}
+			odooCostService.deleteByBudgetEntry(budgetEntry);
 			budgetEntry.getOdooCosts().clear();
-			budgetEntryService.save(budgetEntry);
 			BigDecimal totalOdooCost = BigDecimal.ZERO;
 			List<Map<String, Object>> moveLines = odooService.getOdooAccountMoveLines(budgetStudy.getOdooId(),
 					concept.getOdooProductId(), budgetEntry.getInit(), budgetEntry.getEnd());

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
@@ -20,7 +20,6 @@ import uy.com.bay.utiles.data.service.FieldworkService;
 import uy.com.bay.utiles.entities.Budget;
 import uy.com.bay.utiles.services.AlchemerSurveyResponseHelper;
 import uy.com.bay.utiles.services.BudgetConceptService;
-import uy.com.bay.utiles.services.BudgetEntryService;
 import uy.com.bay.utiles.services.BudgetService;
 import uy.com.bay.utiles.services.OdooCostService;
 import uy.com.bay.utiles.services.OdooService;
@@ -38,17 +37,16 @@ public class BudgetView extends VerticalLayout implements BeforeEnterObserver {
 	private final BudgetForm form;
 	private final BudgetService budgetService;
 
-	public BudgetView(BudgetService budgetService, BudgetEntryService budgetEntryService, StudyService studyService,
-			BudgetConceptService budgetConceptService, AlchemerSurveyResponseHelper alchemerSurveyResponseHelper,
-			FieldworkService fieldworkService, DoobloSurveyRetriever doobloSurveyRetriever, OdooService odooService,
-			OdooCostService odooCostService) {
+	public BudgetView(BudgetService budgetService, StudyService studyService, BudgetConceptService budgetConceptService,
+			AlchemerSurveyResponseHelper alchemerSurveyResponseHelper, FieldworkService fieldworkService,
+			DoobloSurveyRetriever doobloSurveyRetriever, OdooService odooService, OdooCostService odooCostService) {
 		this.budgetService = budgetService;
 		addClassName("budget-view");
 		setSizeFull();
 		configureGrid();
 
-		form = new BudgetForm(studyService, budgetConceptService, budgetService, budgetEntryService,
-				alchemerSurveyResponseHelper, fieldworkService, doobloSurveyRetriever, odooService, odooCostService);
+		form = new BudgetForm(studyService, budgetConceptService, budgetService, alchemerSurveyResponseHelper,
+				fieldworkService, doobloSurveyRetriever, odooService, odooCostService);
 		form.addSaveListener(this::saveBudget);
 		form.addDeleteListener(this::deleteBudget);
 		form.addCloseListener(e -> closeEditor());


### PR DESCRIPTION
## Summary
- En `BudgetForm.refreshCostsFromOdoo`, antes de iterar las líneas de Odoo, se eliminan los `OdooCost` previos del `BudgetEntry` para evitar duplicados/residuos.
- La relación `BudgetEntry -> OdooCost` no tiene `orphanRemoval`, así que la baja se hace explícita vía repositorio: nuevo `OdooCostRepository.deleteByBudgetEntry` y método `OdooCostService.deleteByBudgetEntry` (transaccional). Luego se limpia el set en memoria.

## Test plan
- [ ] Abrir un presupuesto con entradas que ya tengan `OdooCost` asociados.
- [ ] Ejecutar "Refrescar costos" y verificar que las filas de `odoo_cost` viejas se borraron de la BD.
- [ ] Verificar que se insertaron los `OdooCost` actuales según las líneas devueltas por Odoo.
- [ ] Probar con un `BudgetEntry` cuyo `concept` no tenga `odooProductId`: no debe tocar sus costos.
- [ ] Confirmar que el total mostrado en el grid se actualiza correctamente.

https://claude.ai/code/session_01WLgBNrUHT9XtHU6RgmRuT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLgBNrUHT9XtHU6RgmRuT8)_