### PR TITLE
Recarga el Budget en el binder tras refrescar costos desde Odoo

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
@@ -196,14 +196,13 @@ public class BudgetForm extends VerticalLayout {
 		if (budgetStudy == null || budgetStudy.getOdooId() == null || budgetStudy.getOdooId().isEmpty()) {
 			return;
 		}
+		Long budgetId = binder.getBean().getId();
 		for (BudgetEntry budgetEntry : binder.getBean().getEntries()) {
 			BudgetConcept concept = budgetEntry.getConcept();
 			if (concept == null || concept.getOdooProductId() == null || concept.getOdooProductId().isEmpty()) {
 				continue;
 			}
 			odooCostService.deleteByBudgetEntry(budgetEntry);
-			budgetEntry.getOdooCosts().clear();
-			BigDecimal totalOdooCost = BigDecimal.ZERO;
 			List<Map<String, Object>> moveLines = odooService.getOdooAccountMoveLines(budgetStudy.getOdooId(),
 					concept.getOdooProductId(), budgetEntry.getInit(), budgetEntry.getEnd());
 			for (Map<String, Object> line : moveLines) {
@@ -225,12 +224,16 @@ public class BudgetForm extends VerticalLayout {
 				cost.setBalance(odooValueToBigDecimal(line.get("balance")));
 				cost.setBudgetEntry(budgetEntry);
 				odooCostService.save(cost);
-				if (cost.getBalance() != null) {
-					totalOdooCost = totalOdooCost.add(cost.getBalance());
-				}
 			}
 		}
-		entriesGrid.setItems(binder.getBean().getEntries());
+		if (budgetId != null) {
+			budgetService.findByIdWithEntries(budgetId).ifPresent(refreshed -> {
+				binder.setBean(refreshed);
+				entriesGrid.setItems(refreshed.getEntries());
+			});
+		} else {
+			entriesGrid.setItems(binder.getBean().getEntries());
+		}
 		updateTotal();
 	}
 


### PR DESCRIPTION
## Summary
- Arregla `EntityNotFoundException` al guardar un Budget después de ejecutar "Refrescar costos".
- El `PersistentSet` de Hibernate en memoria conservaba el snapshot con los IDs de los `OdooCost` ya eliminados, así que al hacer `merge` del Budget detached, Hibernate intentaba reanclarlos por ID y reventaba.
- Tras procesar todas las entradas en `BudgetForm.refreshCostsFromOdoo`, se recarga el Budget desde la BD con `budgetService.findByIdWithEntries(budgetId)` y se asigna al binder con `binder.setBean(refreshed)`. Las colecciones quedan limpias y el save posterior funciona.
- Se quita la variable `BigDecimal totalOdooCost` que había quedado sin uso.

## Test plan
- [ ] Abrir un presupuesto con `OdooCost` previamente cargados.
- [ ] Click en "Refrescar costos" y luego en "Guardar": el Budget se persiste sin errores.
- [ ] Verificar que el grid muestra los `OdooCost` actualizados desde Odoo.
- [ ] Repetir el flujo varias veces seguidas (refresh + save) sin reabrir el presupuesto.

https://claude.ai/code/session_01WLgBNrUHT9XtHU6RgmRuT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLgBNrUHT9XtHU6RgmRuT8)_