### PR TITLE
Persist budget after saving entry inline editor

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
@@ -325,7 +325,16 @@ public class BudgetForm extends VerticalLayout {
 		Grid.Column<BudgetEntry> totalColumn = entriesGrid.addColumn(entry -> currencyFormat.format(entry.getTotal()))
 				.setHeader("Total").setResizable(true);
 
-		Button saveButton = new Button("Guardar", e -> editor.save());
+		Button saveButton = new Button("Guardar", e -> {
+			editor.save();
+			Budget budget = binder.getBean();
+			if (budget != null) {
+				Budget updatedBudget = budgetService.save(budget);
+				binder.setBean(updatedBudget);
+				entriesGrid.setItems(updatedBudget.getEntries());
+				updateTotal();
+			}
+		});
 		HorizontalLayout actions = new HorizontalLayout(saveButton);
 		actions.setPadding(false);
 


### PR DESCRIPTION
## Summary
- Refactor del botón "Guardar" del editor inline en `BudgetForm.configureGrid()` (`src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java:328`).
- Luego de `editor.save()`, ahora persiste el `Budget` actual obtenido desde `binder.getBean()` mediante `budgetService.save(...)`, reasigna el bean del binder con la entidad actualizada y refresca el grid y los totales.

## Test plan
- [ ] Abrir un Budget existente, editar un BudgetEntry inline y presionar "Guardar"; verificar que los cambios queden persistidos al recargar.
- [ ] Crear un nuevo concepto desde "Agregar concepto", completar campos, presionar "Guardar" del editor y confirmar que se guarda como parte del Budget.
- [ ] Verificar que totales (`totalAmountLabel` / `totalSpentLabel`) se actualicen tras guardar.

https://claude.ai/code/session_017ZBbGFt3rrWqtiWNVD6ic9

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZBbGFt3rrWqtiWNVD6ic9)_