### PR TITLE
Fix LazyInitializationException al guardar BudgetEntry inline

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
@@ -329,9 +329,14 @@ public class BudgetForm extends VerticalLayout {
 			editor.save();
 			Budget budget = binder.getBean();
 			if (budget != null) {
-				Budget updatedBudget = budgetService.save(budget);
-				binder.setBean(updatedBudget);
-				entriesGrid.setItems(updatedBudget.getEntries());
+				Budget savedBudget = budgetService.save(budget);
+				budgetService.findByIdWithEntries(savedBudget.getId()).ifPresentOrElse(refreshed -> {
+					binder.setBean(refreshed);
+					entriesGrid.setItems(refreshed.getEntries());
+				}, () -> {
+					binder.setBean(savedBudget);
+					entriesGrid.setItems(savedBudget.getEntries());
+				});
 				updateTotal();
 			}
 		});


### PR DESCRIPTION
## Summary
- Tras `budgetService.save(budget)` en el botón "Guardar" del editor inline (`BudgetForm.configureGrid`), el Budget retornado tiene las colecciones lazy desconectadas de la sesión Hibernate.
- Eso provocaba `LazyInitializationException` al renderizar la columna "Gastado" (`entry.getExtras()`, `entry.getExpenseRequests()`, `entry.getFieldworks()`, `entry.getOdooCosts()`) y al ejecutar `updateTotal()` (que llama a `BudgetEntry.getSpent()`).
- Solución: recargar el Budget con `budgetService.findByIdWithEntries(savedBudget.getId())` (que ya inicializa esas colecciones vía `Hibernate.initialize`) antes de `binder.setBean` y `entriesGrid.setItems`.

## Test plan
- [ ] Editar un `BudgetEntry` inline en un Budget existente y presionar "Guardar"; verificar que no se lance `LazyInitializationException` y que la columna "Gastado" y los totales se actualicen correctamente.
- [ ] Crear un nuevo concepto desde "Agregar concepto", guardar y verificar que los datos persistan y la grilla se refresque sin errores.

https://claude.ai/code/session_017ZBbGFt3rrWqtiWNVD6ic9

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZBbGFt3rrWqtiWNVD6ic9)_