### PR TITLE
Adjust BudgetView layout flex grow and form width

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
@@ -70,8 +70,9 @@ public class BudgetView extends VerticalLayout implements BeforeEnterObserver {
 
 	private Component getContent() {
 		HorizontalLayout content = new HorizontalLayout(grid, form);
-		content.setFlexGrow(3, grid);
+		content.setFlexGrow(1, grid);
 		content.setFlexGrow(1, form);
+		form.setWidth("50%");
 		content.addClassNames("content");
 		content.setSizeFull();
 		return content;


### PR DESCRIPTION
## Summary
Updated the layout proportions in BudgetView to provide a more balanced distribution of space between the grid and form components.

## Key Changes
- Changed grid flex grow from 3 to 1, making it equal to the form's flex grow ratio
- Set explicit form width to 50% to ensure consistent sizing
- This results in a 50/50 split of available space between grid and form components

## Implementation Details
The changes modify the `getContent()` method's HorizontalLayout configuration. Previously, the grid was allocated 3x more space than the form (3:1 ratio). Now both components share equal flex grow values (1:1), with an explicit width constraint on the form to guarantee the intended 50/50 layout distribution.

https://claude.ai/code/session_013zLdAhLpvpw6DFE16qifCZ