### PR TITLE
Increase budget form width to 70%

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
@@ -71,8 +71,8 @@ public class BudgetView extends VerticalLayout implements BeforeEnterObserver {
 	private Component getContent() {
 		HorizontalLayout content = new HorizontalLayout(grid, form);
 		content.setFlexGrow(1, grid);
-		content.setFlexGrow(1, form);
-		form.setWidth("50%");
+		content.setFlexGrow(2, form);
+		form.setWidth("70%");
 		content.addClassNames("content");
 		content.setSizeFull();
 		return content;


### PR DESCRIPTION
## Summary
- Aumenta el ancho del form del editor de presupuestos del 50% al 70% para que el form domine el espacio sobre el grid.
- Ajusta los `flexGrow` del `HorizontalLayout` (grid: 1, form: 2) acompañando el cambio de ancho.

## Test plan
- [ ] Abrir la vista de Presupuestos.
- [ ] Hacer clic en una fila del grid (o en "Crear") para abrir el editor.
- [ ] Verificar que el form ocupe ~70% del ancho disponible y el grid ~30%.

https://claude.ai/code/session_013zLdAhLpvpw6DFE16qifCZ

---
_Generated by [Claude Code](https://claude.ai/code/session_013zLdAhLpvpw6DFE16qifCZ)_