### PR TITLE
Use explicit widths for grid and form to enforce 70/30 split

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
@@ -70,8 +70,7 @@ public class BudgetView extends VerticalLayout implements BeforeEnterObserver {
 
 	private Component getContent() {
 		HorizontalLayout content = new HorizontalLayout(grid, form);
-		content.setFlexGrow(1, grid);
-		content.setFlexGrow(2, form);
+		grid.setWidth("30%");
 		form.setWidth("70%");
 		content.addClassNames("content");
 		content.setSizeFull();


### PR DESCRIPTION
## Summary
- Reemplaza los `setFlexGrow` por anchos explícitos (`grid: 30%`, `form: 70%`) para evitar el conflicto con `grid.setSizeFull()`.
- Sin este cambio, el `flex-basis` del grid era 100% y el del form 70% (170% total), lo que hacía que flexbox los encogiera proporcionalmente y se vieran ~50/50 en lugar de 70/30.

## Test plan
- [ ] Abrir la vista de Presupuestos.
- [ ] Hacer clic en una fila del grid (o en "Crear") para abrir el editor.
- [ ] Verificar que el form ocupe ~70% del ancho disponible y el grid ~30%.

https://claude.ai/code/session_013zLdAhLpvpw6DFE16qifCZ

---
_Generated by [Claude Code](https://claude.ai/code/session_013zLdAhLpvpw6DFE16qifCZ)_