### PR TITLE
Add salaryCost flag to BudgetConcept

### DIFF
--- a/src/main/java/uy/com/bay/utiles/entities/BudgetConcept.java
+++ b/src/main/java/uy/com/bay/utiles/entities/BudgetConcept.java
@@ -12,6 +12,7 @@ public class BudgetConcept extends AbstractEntity {
     private String name;
     private String description;
     private String odooProductId;
+    private boolean salaryCost;
 
     @Enumerated(EnumType.STRING)
     private MatchType matchType;
@@ -46,5 +47,13 @@ public class BudgetConcept extends AbstractEntity {
 
     public void setMatchType(MatchType matchType) {
         this.matchType = matchType;
+    }
+
+    public boolean isSalaryCost() {
+        return salaryCost;
+    }
+
+    public void setSalaryCost(boolean salaryCost) {
+        this.salaryCost = salaryCost;
     }
 }

--- a/src/main/java/uy/com/bay/utiles/views/budgetconcept/BudgetConceptView.java
+++ b/src/main/java/uy/com/bay/utiles/views/budgetconcept/BudgetConceptView.java
@@ -48,6 +48,7 @@ public class BudgetConceptView extends Div implements BeforeEnterObserver {
 	private TextArea description;
 	private TextField odooProductId;
 	private ComboBox<MatchType> matchType;
+	private Checkbox salaryCost;
 	
 
 	private final Button cancel = new Button("Cerrar");
@@ -177,9 +178,9 @@ public class BudgetConceptView extends Div implements BeforeEnterObserver {
 		odooProductId = new TextField("Id de producto ODOO");
 		matchType = new ComboBox<>("Tipo de Coincidencia");
 		matchType.setItems(MatchType.values());
-		
+		salaryCost = new Checkbox("Costo Salarial");
 
-		formLayout.add(name, description, odooProductId, matchType);
+		formLayout.add(name, description, odooProductId, matchType, salaryCost);
 
 		editorDiv.add(formLayout);
 		createButtonLayout(editorLayoutDiv);


### PR DESCRIPTION
## Summary
- Agrega un atributo `boolean salaryCost` a la entidad `BudgetConcept` con sus getters/setters (`isSalaryCost`/`setSalaryCost`).
- Expone el campo en `BudgetConceptView` como un `Checkbox` con etiqueta "Costo Salarial" dentro del `FormLayout`. El binder lo enlaza automáticamente vía `bindInstanceFields`.

## Test plan
- [ ] Abrir la vista de Conceptos de Presupuesto.
- [ ] Crear un nuevo concepto, marcar el checkbox "Costo Salarial" y guardar.
- [ ] Reabrir el concepto y verificar que el checkbox conserva el valor.
- [ ] Editar un concepto existente, alternar el checkbox y verificar la persistencia.

https://claude.ai/code/session_013zLdAhLpvpw6DFE16qifCZ

---
_Generated by [Claude Code](https://claude.ai/code/session_013zLdAhLpvpw6DFE16qifCZ)_