### PR TITLE
Add budget planning report export functionality

### DIFF
--- a/src/main/java/uy/com/bay/utiles/repo/BudgetEntryRepository.java
+++ b/src/main/java/uy/com/bay/utiles/repo/BudgetEntryRepository.java
@@ -1,5 +1,7 @@
 package uy.com.bay.utiles.repo;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,6 +9,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.entities.BudgetEntry;
 
 @Repository
@@ -14,6 +17,14 @@ public interface BudgetEntryRepository extends JpaRepository<BudgetEntry, Long> 
 
 	@Query("SELECT be FROM BudgetEntry be LEFT JOIN FETCH be.extras LEFT JOIN FETCH be.fieldworks LEFT JOIN FETCH be.expenseRequests WHERE be.id = :id")
 	Optional<BudgetEntry> findByIdWithExtras(@Param("id") Long id);
+
+	@Query("SELECT be FROM BudgetEntry be JOIN be.budget b JOIN b.study s WHERE be.end > :fechaDesde AND be.init < :fechaHasta")
+	List<BudgetEntry> findByDateRange(@Param("fechaDesde") LocalDate fechaDesde,
+			@Param("fechaHasta") LocalDate fechaHasta);
+
+	@Query("SELECT be FROM BudgetEntry be JOIN be.budget b JOIN b.study s WHERE be.end > :fechaDesde AND be.init < :fechaHasta AND s IN :studies")
+	List<BudgetEntry> findByDateRangeAndStudies(@Param("fechaDesde") LocalDate fechaDesde,
+			@Param("fechaHasta") LocalDate fechaHasta, @Param("studies") List<Study> studies);
 
 	@Modifying(clearAutomatically = true)
 	@Query("UPDATE Extra e SET e.budgetEntry = null WHERE e.budgetEntry.id IN (SELECT be.id FROM BudgetEntry be WHERE be.budget.id = :budgetId)")

--- a/src/main/java/uy/com/bay/utiles/services/BudgetEntryService.java
+++ b/src/main/java/uy/com/bay/utiles/services/BudgetEntryService.java
@@ -1,6 +1,10 @@
 package uy.com.bay.utiles.services;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
+import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.entities.BudgetEntry;
 import uy.com.bay.utiles.repo.BudgetEntryRepository;
 
@@ -15,5 +19,12 @@ public class BudgetEntryService {
 
     public BudgetEntry save(BudgetEntry entity) {
         return repository.save(entity);
+    }
+
+    public List<BudgetEntry> findForPlanningReport(LocalDate fechaDesde, LocalDate fechaHasta, List<Study> studies) {
+        if (studies == null || studies.isEmpty()) {
+            return repository.findByDateRange(fechaDesde, fechaHasta);
+        }
+        return repository.findByDateRangeAndStudies(fechaDesde, fechaHasta, studies);
     }
 }

--- a/src/main/java/uy/com/bay/utiles/services/BudgetPlanningExporter.java
+++ b/src/main/java/uy/com/bay/utiles/services/BudgetPlanningExporter.java
@@ -1,0 +1,213 @@
+package uy.com.bay.utiles.services;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.time.format.TextStyle;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.FillPatternType;
+import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.IndexedColors;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Service;
+
+import uy.com.bay.utiles.data.Study;
+import uy.com.bay.utiles.entities.BudgetEntry;
+
+@Service
+public class BudgetPlanningExporter {
+
+	private static final Locale ES_LOCALE = new Locale("es", "UY");
+	private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+
+	public InputStream export(List<BudgetEntry> entries, LocalDate fechaDesde, LocalDate fechaHasta,
+			List<Study> selectedStudies) throws IOException {
+		Workbook workbook = new XSSFWorkbook();
+		Sheet sheet = workbook.createSheet("Planificación presupuestal");
+
+		Font boldFont = workbook.createFont();
+		boldFont.setBold(true);
+
+		CellStyle labelStyle = workbook.createCellStyle();
+		labelStyle.setFont(boldFont);
+
+		CellStyle headerStyle = workbook.createCellStyle();
+		headerStyle.setFont(boldFont);
+		headerStyle.setFillForegroundColor(IndexedColors.GREY_25_PERCENT.getIndex());
+		headerStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);
+
+		int rowIndex = 0;
+
+		Row reporteRow = sheet.createRow(rowIndex++);
+		Cell reporteLabel = reporteRow.createCell(0);
+		reporteLabel.setCellValue("Reporte:");
+		reporteLabel.setCellStyle(labelStyle);
+		reporteRow.createCell(1).setCellValue("Planificación presupuestal");
+
+		Row creadoRow = sheet.createRow(rowIndex++);
+		Cell creadoLabel = creadoRow.createCell(0);
+		creadoLabel.setCellValue("Creado:");
+		creadoLabel.setCellStyle(labelStyle);
+		creadoRow.createCell(1).setCellValue(new SimpleDateFormat("dd/MM/yyyy").format(new Date()));
+
+		Row estudioRow = sheet.createRow(rowIndex++);
+		Cell estudioLabel = estudioRow.createCell(0);
+		estudioLabel.setCellValue("Estudio:");
+		estudioLabel.setCellStyle(labelStyle);
+		String estudiosTexto = (selectedStudies == null || selectedStudies.isEmpty()) ? "Todos"
+				: String.join(", ", selectedStudies.stream().map(Study::getName).toList());
+		estudioRow.createCell(1).setCellValue(estudiosTexto);
+
+		Row fechaInicioRow = sheet.createRow(rowIndex++);
+		Cell fechaInicioLabel = fechaInicioRow.createCell(0);
+		fechaInicioLabel.setCellValue("Fecha Inicio :");
+		fechaInicioLabel.setCellStyle(labelStyle);
+		fechaInicioRow.createCell(1).setCellValue(fechaDesde != null ? fechaDesde.format(DATE_FORMAT) : "");
+
+		Row fechaFinRow = sheet.createRow(rowIndex++);
+		Cell fechaFinLabel = fechaFinRow.createCell(0);
+		fechaFinLabel.setCellValue("Fecha Fin:");
+		fechaFinLabel.setCellStyle(labelStyle);
+		fechaFinRow.createCell(1).setCellValue(fechaHasta != null ? fechaHasta.format(DATE_FORMAT) : "");
+
+		rowIndex++;
+
+		List<YearMonth> months = monthsBetween(fechaDesde, fechaHasta);
+
+		List<String> headers = new ArrayList<>();
+		headers.add("Estudio");
+		headers.add("Concepto presupuesto");
+		headers.add("Tipo");
+		headers.add("Total");
+		for (YearMonth ym : months) {
+			String monthName = ym.getMonth().getDisplayName(TextStyle.FULL, ES_LOCALE);
+			monthName = monthName.substring(0, 1).toUpperCase(ES_LOCALE) + monthName.substring(1);
+			headers.add(monthName + "-" + ym.getYear());
+		}
+
+		Row headerRow = sheet.createRow(rowIndex++);
+		for (int i = 0; i < headers.size(); i++) {
+			Cell cell = headerRow.createCell(i);
+			cell.setCellValue(headers.get(i));
+			cell.setCellStyle(headerStyle);
+		}
+
+		List<BudgetEntry> sorted = new ArrayList<>(entries);
+		sorted.sort(Comparator
+				.comparing((BudgetEntry be) -> studyName(be), Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER))
+				.thenComparing(BudgetPlanningExporter::conceptName,
+						Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER))
+				.thenComparing(BudgetPlanningExporter::tipo,
+						Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
+
+		for (BudgetEntry entry : sorted) {
+			Row row = sheet.createRow(rowIndex++);
+			row.createCell(0).setCellValue(studyName(entry));
+			row.createCell(1).setCellValue(conceptName(entry));
+			row.createCell(2).setCellValue(tipo(entry));
+			row.createCell(3).setCellValue(entry.getTotal() != null ? entry.getTotal() : 0d);
+
+			double[] distribution = distribute(entry, months);
+			for (int i = 0; i < months.size(); i++) {
+				row.createCell(4 + i).setCellValue(distribution[i]);
+			}
+		}
+
+		for (int i = 0; i < headers.size(); i++) {
+			sheet.autoSizeColumn(i);
+		}
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		workbook.write(out);
+		workbook.close();
+		return new ByteArrayInputStream(out.toByteArray());
+	}
+
+	private static String studyName(BudgetEntry entry) {
+		if (entry.getBudget() != null && entry.getBudget().getStudy() != null) {
+			return entry.getBudget().getStudy().getName();
+		}
+		return "";
+	}
+
+	private static String conceptName(BudgetEntry entry) {
+		if (entry.getConcept() != null && entry.getConcept().getName() != null) {
+			return entry.getConcept().getName();
+		}
+		return "";
+	}
+
+	private static String tipo(BudgetEntry entry) {
+		if (entry.getConcept() != null && entry.getConcept().isSalaryCost()) {
+			return "Costo Salarial";
+		}
+		return "Otros costos";
+	}
+
+	private static List<YearMonth> monthsBetween(LocalDate fechaDesde, LocalDate fechaHasta) {
+		List<YearMonth> months = new ArrayList<>();
+		if (fechaDesde == null || fechaHasta == null || fechaHasta.isBefore(fechaDesde)) {
+			return months;
+		}
+		YearMonth current = YearMonth.from(fechaDesde);
+		YearMonth last = YearMonth.from(fechaHasta);
+		while (!current.isAfter(last)) {
+			months.add(current);
+			current = current.plusMonths(1);
+		}
+		return months;
+	}
+
+	private double[] distribute(BudgetEntry entry, List<YearMonth> months) {
+		double[] result = new double[months.size()];
+		if (months.isEmpty()) {
+			return result;
+		}
+		Double total = entry.getTotal();
+		if (total == null || total == 0d) {
+			return result;
+		}
+		LocalDate init = entry.getInit();
+		LocalDate end = entry.getEnd();
+		if (init == null || end == null || end.isBefore(init)) {
+			return result;
+		}
+
+		YearMonth initYm = YearMonth.from(init);
+		YearMonth endYm = YearMonth.from(end);
+
+		int spannedCount = 0;
+		YearMonth cursor = initYm;
+		while (!cursor.isAfter(endYm)) {
+			spannedCount++;
+			cursor = cursor.plusMonths(1);
+		}
+		if (spannedCount == 0) {
+			return result;
+		}
+
+		double perMonth = total / spannedCount;
+		for (int i = 0; i < months.size(); i++) {
+			YearMonth ym = months.get(i);
+			if (!ym.isBefore(initYm) && !ym.isAfter(endYm)) {
+				result[i] = perMonth;
+			}
+		}
+		return result;
+	}
+}

--- a/src/main/java/uy/com/bay/utiles/views/MainLayout.java
+++ b/src/main/java/uy/com/bay/utiles/views/MainLayout.java
@@ -32,11 +32,14 @@ import com.vaadin.flow.theme.lumo.LumoUtility;
 
 import uy.com.bay.utiles.data.User;
 import uy.com.bay.utiles.security.AuthenticatedUser;
+import uy.com.bay.utiles.services.BudgetEntryService;
+import uy.com.bay.utiles.services.BudgetPlanningExporter;
 import uy.com.bay.utiles.services.ExcelExportService;
 import uy.com.bay.utiles.services.ExtraService;
 import uy.com.bay.utiles.services.JournalEntryService;
 import uy.com.bay.utiles.services.StudyService;
 import uy.com.bay.utiles.services.SurveyorService;
+import uy.com.bay.utiles.views.budget.BudgetPlanningReportDialog;
 import uy.com.bay.utiles.views.expenses.ReportesDialog;
 import uy.com.bay.utiles.views.extras.ExtrasReportDialog;
 
@@ -57,10 +60,13 @@ public class MainLayout extends AppLayout {
 	private final JournalEntryService journalEntryService;
 	private final ExtraService extraService;
 	private final ExcelExportService excelExportService;
+	private final BudgetEntryService budgetEntryService;
+	private final BudgetPlanningExporter budgetPlanningExporter;
 
 	public MainLayout(AuthenticatedUser authenticatedUser, AccessAnnotationChecker accessChecker,
 			SurveyorService surveyorService, StudyService studyService, JournalEntryService journalEntryService,
-			ExtraService extraService, ExcelExportService excelExportService) {
+			ExtraService extraService, ExcelExportService excelExportService, BudgetEntryService budgetEntryService,
+			BudgetPlanningExporter budgetPlanningExporter) {
 		this.authenticatedUser = authenticatedUser;
 		this.accessChecker = accessChecker;
 		this.surveyorService = surveyorService;
@@ -68,6 +74,8 @@ public class MainLayout extends AppLayout {
 		this.journalEntryService = journalEntryService;
 		this.extraService = extraService;
 		this.excelExportService = excelExportService;
+		this.budgetEntryService = budgetEntryService;
+		this.budgetPlanningExporter = budgetPlanningExporter;
 
 		setPrimarySection(Section.DRAWER);
 		addDrawerContent();
@@ -173,6 +181,14 @@ public class MainLayout extends AppLayout {
 		SideNavItem crearPresupuestoItem = new SideNavItem("Listar", "budgets");
 		crearPresupuestoItem.setPrefixComponent(new Icon("vaadin", "plus"));
 		presupuestosItem.addItem(crearPresupuestoItem);
+		SideNavItem reportePlanificacionItem = new SideNavItem("Reporte planificación presupuestal");
+		reportePlanificacionItem.setPrefixComponent(new Icon("vaadin", "file-chart"));
+		reportePlanificacionItem.getElement().addEventListener("click", e -> {
+			BudgetPlanningReportDialog dialog = new BudgetPlanningReportDialog(studyService, budgetEntryService,
+					budgetPlanningExporter);
+			dialog.open();
+		});
+		presupuestosItem.addItem(reportePlanificacionItem);
 		nav.addItem(presupuestosItem);
 
 		SideNavItem surveyorPortalItem = new SideNavItem("Portal Encuestador");

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetPlanningReportDialog.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetPlanningReportDialog.java
@@ -1,0 +1,95 @@
+package uy.com.bay.utiles.views.budget;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Locale;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.component.html.Anchor;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.server.StreamResource;
+
+import uy.com.bay.utiles.data.Study;
+import uy.com.bay.utiles.entities.BudgetEntry;
+import uy.com.bay.utiles.services.BudgetEntryService;
+import uy.com.bay.utiles.services.BudgetPlanningExporter;
+import uy.com.bay.utiles.services.StudyService;
+
+public class BudgetPlanningReportDialog extends Dialog {
+
+	private final DatePicker fechaDesde = new DatePicker("Fecha desde");
+	private final DatePicker fechaHasta = new DatePicker("Fecha hasta");
+	private final MultiSelectComboBox<Study> estudios = new MultiSelectComboBox<>("Estudios");
+
+	public BudgetPlanningReportDialog(StudyService studyService, BudgetEntryService budgetEntryService,
+			BudgetPlanningExporter exporter) {
+		setHeaderTitle("Reporte planificación presupuestal");
+
+		Locale esLocale = new Locale("es", "UY");
+		DatePicker.DatePickerI18n dateI18n = new DatePicker.DatePickerI18n();
+		dateI18n.setDateFormat("dd/MM/yyyy");
+
+		fechaDesde.setLocale(esLocale);
+		fechaDesde.setI18n(dateI18n);
+		fechaDesde.setRequiredIndicatorVisible(true);
+
+		fechaHasta.setLocale(esLocale);
+		fechaHasta.setI18n(dateI18n);
+		fechaHasta.setRequiredIndicatorVisible(true);
+
+		estudios.setItems(studyService.findAll());
+		estudios.setItemLabelGenerator(s -> s == null ? "" : s.getName());
+
+		FormLayout layout = new FormLayout();
+		layout.add(fechaDesde, fechaHasta, estudios);
+		add(layout);
+
+		Button descargar = new Button("Descargar");
+		descargar.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+		descargar.addClickListener(e -> generarReporte(budgetEntryService, exporter));
+
+		Button cerrar = new Button("Cerrar", e -> close());
+		cerrar.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+
+		getFooter().add(cerrar, descargar);
+	}
+
+	private void generarReporte(BudgetEntryService budgetEntryService, BudgetPlanningExporter exporter) {
+		if (fechaDesde.getValue() == null) {
+			Notification.show("Debe ingresar la Fecha desde.");
+			return;
+		}
+		if (fechaHasta.getValue() == null) {
+			Notification.show("Debe ingresar la Fecha hasta.");
+			return;
+		}
+
+		List<Study> selectedStudies = estudios.getValue().isEmpty() ? null : List.copyOf(estudios.getValue());
+		List<BudgetEntry> entries = budgetEntryService.findForPlanningReport(fechaDesde.getValue(),
+				fechaHasta.getValue(), selectedStudies);
+
+		if (entries.isEmpty()) {
+			Notification.show("No hay datos para generar el reporte con los filtros seleccionados.");
+			return;
+		}
+
+		try {
+			InputStream in = exporter.export(entries, fechaDesde.getValue(), fechaHasta.getValue(), selectedStudies);
+			StreamResource resource = new StreamResource("planificacion-presupuestal.xlsx", () -> in);
+			Anchor downloadLink = new Anchor(resource, "");
+			downloadLink.getElement().setAttribute("download", true);
+			downloadLink.getStyle().set("display", "none");
+			add(downloadLink);
+			downloadLink.getElement().callJsFunction("click");
+		} catch (IOException ex) {
+			Notification.show("Error al generar el archivo de Excel.");
+			ex.printStackTrace();
+		}
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds a new budget planning report feature that allows users to export budget entries filtered by date range and studies to an Excel file.

## Key Changes
- **New Service: BudgetPlanningExporter** - Generates Excel workbooks containing budget planning data with:
  - Report metadata (creation date, selected studies, date range)
  - Monthly distribution columns for the specified date range
  - Budget entries sorted by study, concept, and type
  - Automatic distribution of budget totals across months based on entry date ranges

- **New Dialog: BudgetPlanningReportDialog** - Provides UI for users to:
  - Select date range (from/to dates)
  - Filter by multiple studies (optional)
  - Generate and download the Excel report with validation

- **Repository Enhancement** - Added two new query methods to `BudgetEntryRepository`:
  - `findByDateRange()` - Retrieves entries within a date range
  - `findByDateRangeAndStudies()` - Retrieves entries filtered by date range and specific studies

- **Service Enhancement** - Added `findForPlanningReport()` method to `BudgetEntryService` to handle the logic of selecting the appropriate repository query based on study filters

- **UI Integration** - Updated `MainLayout` to include a new navigation item "Reporte planificación presupuestal" that opens the budget planning report dialog

## Notable Implementation Details
- Budget amounts are evenly distributed across the months they span (from init to end date)
- Month headers are displayed in Spanish locale with proper capitalization
- The report includes both salary costs and other costs categorized by type
- Excel formatting includes bold headers with grey background and auto-sized columns
- Proper null handling for optional date ranges and study filters

https://claude.ai/code/session_01DvRugzMwbyAMqdmfQVWY5v