### PR TITLE
Add Totalizar conceptos option to budget planning report

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/BudgetPlanningExporter.java
+++ b/src/main/java/uy/com/bay/utiles/services/BudgetPlanningExporter.java
@@ -12,8 +12,10 @@ import java.time.format.TextStyle;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
@@ -36,7 +38,7 @@ public class BudgetPlanningExporter {
 	private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("dd/MM/yyyy");
 
 	public InputStream export(List<BudgetEntry> entries, LocalDate fechaDesde, LocalDate fechaHasta,
-			List<Study> selectedStudies) throws IOException {
+			List<Study> selectedStudies, boolean totalizarConceptos) throws IOException {
 		Workbook workbook = new XSSFWorkbook();
 		Sheet sheet = workbook.createSheet("Planificación presupuestal");
 
@@ -91,7 +93,9 @@ public class BudgetPlanningExporter {
 
 		List<String> headers = new ArrayList<>();
 		headers.add("Estudio");
-		headers.add("Concepto presupuesto");
+		if (!totalizarConceptos) {
+			headers.add("Concepto presupuesto");
+		}
 		headers.add("Tipo");
 		headers.add("Total");
 		for (YearMonth ym : months) {
@@ -107,24 +111,37 @@ public class BudgetPlanningExporter {
 			cell.setCellStyle(headerStyle);
 		}
 
-		List<BudgetEntry> sorted = new ArrayList<>(entries);
-		sorted.sort(Comparator
-				.comparing((BudgetEntry be) -> studyName(be), Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER))
-				.thenComparing(BudgetPlanningExporter::conceptName,
-						Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER))
-				.thenComparing(BudgetPlanningExporter::tipo,
-						Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
+		if (totalizarConceptos) {
+			List<AggregatedRow> aggregated = aggregateByStudyAndTipo(entries, months);
+			for (AggregatedRow agg : aggregated) {
+				Row row = sheet.createRow(rowIndex++);
+				row.createCell(0).setCellValue(agg.estudio);
+				row.createCell(1).setCellValue(agg.tipo);
+				row.createCell(2).setCellValue(agg.total);
+				for (int i = 0; i < months.size(); i++) {
+					row.createCell(3 + i).setCellValue(agg.monthly[i]);
+				}
+			}
+		} else {
+			List<BudgetEntry> sorted = new ArrayList<>(entries);
+			sorted.sort(Comparator
+					.comparing((BudgetEntry be) -> studyName(be), Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER))
+					.thenComparing(BudgetPlanningExporter::conceptName,
+							Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER))
+					.thenComparing(BudgetPlanningExporter::tipo,
+							Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
 
-		for (BudgetEntry entry : sorted) {
-			Row row = sheet.createRow(rowIndex++);
-			row.createCell(0).setCellValue(studyName(entry));
-			row.createCell(1).setCellValue(conceptName(entry));
-			row.createCell(2).setCellValue(tipo(entry));
-			row.createCell(3).setCellValue(entry.getTotal() != null ? entry.getTotal() : 0d);
+			for (BudgetEntry entry : sorted) {
+				Row row = sheet.createRow(rowIndex++);
+				row.createCell(0).setCellValue(studyName(entry));
+				row.createCell(1).setCellValue(conceptName(entry));
+				row.createCell(2).setCellValue(tipo(entry));
+				row.createCell(3).setCellValue(entry.getTotal() != null ? entry.getTotal() : 0d);
 
-			double[] distribution = distribute(entry, months);
-			for (int i = 0; i < months.size(); i++) {
-				row.createCell(4 + i).setCellValue(distribution[i]);
+				double[] distribution = distribute(entry, months);
+				for (int i = 0; i < months.size(); i++) {
+					row.createCell(4 + i).setCellValue(distribution[i]);
+				}
 			}
 		}
 
@@ -209,5 +226,38 @@ public class BudgetPlanningExporter {
 			}
 		}
 		return result;
+	}
+
+	private List<AggregatedRow> aggregateByStudyAndTipo(List<BudgetEntry> entries, List<YearMonth> months) {
+		Map<String, AggregatedRow> map = new LinkedHashMap<>();
+		for (BudgetEntry entry : entries) {
+			String estudio = studyName(entry);
+			String tipo = tipo(entry);
+			String key = estudio + "||" + tipo;
+			AggregatedRow agg = map.computeIfAbsent(key, k -> new AggregatedRow(estudio, tipo, months.size()));
+			agg.total += entry.getTotal() != null ? entry.getTotal() : 0d;
+			double[] distribution = distribute(entry, months);
+			for (int i = 0; i < months.size(); i++) {
+				agg.monthly[i] += distribution[i];
+			}
+		}
+		List<AggregatedRow> list = new ArrayList<>(map.values());
+		list.sort(Comparator
+				.comparing((AggregatedRow a) -> a.estudio, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER))
+				.thenComparing(a -> a.tipo, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
+		return list;
+	}
+
+	private static class AggregatedRow {
+		final String estudio;
+		final String tipo;
+		double total;
+		final double[] monthly;
+
+		AggregatedRow(String estudio, String tipo, int monthCount) {
+			this.estudio = estudio;
+			this.tipo = tipo;
+			this.monthly = new double[monthCount];
+		}
 	}
 }

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetPlanningReportDialog.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetPlanningReportDialog.java
@@ -7,6 +7,7 @@ import java.util.Locale;
 
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.combobox.MultiSelectComboBox;
 import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.dialog.Dialog;
@@ -26,6 +27,7 @@ public class BudgetPlanningReportDialog extends Dialog {
 	private final DatePicker fechaDesde = new DatePicker("Fecha desde");
 	private final DatePicker fechaHasta = new DatePicker("Fecha hasta");
 	private final MultiSelectComboBox<Study> estudios = new MultiSelectComboBox<>("Estudios");
+	private final Checkbox totalizarConceptos = new Checkbox("Totalizar conceptos");
 
 	public BudgetPlanningReportDialog(StudyService studyService, BudgetEntryService budgetEntryService,
 			BudgetPlanningExporter exporter) {
@@ -47,7 +49,7 @@ public class BudgetPlanningReportDialog extends Dialog {
 		estudios.setItemLabelGenerator(s -> s == null ? "" : s.getName());
 
 		FormLayout layout = new FormLayout();
-		layout.add(fechaDesde, fechaHasta, estudios);
+		layout.add(fechaDesde, fechaHasta, estudios, totalizarConceptos);
 		add(layout);
 
 		Button descargar = new Button("Descargar");
@@ -80,7 +82,8 @@ public class BudgetPlanningReportDialog extends Dialog {
 		}
 
 		try {
-			InputStream in = exporter.export(entries, fechaDesde.getValue(), fechaHasta.getValue(), selectedStudies);
+			InputStream in = exporter.export(entries, fechaDesde.getValue(), fechaHasta.getValue(), selectedStudies,
+					totalizarConceptos.getValue());
 			StreamResource resource = new StreamResource("planificacion-presupuestal.xlsx", () -> in);
 			Anchor downloadLink = new Anchor(resource, "");
 			downloadLink.getElement().setAttribute("download", true);


### PR DESCRIPTION
When checked, the exported report drops the "Concepto presupuesto" column and aggregates totals by Estudio and Tipo.