### PR TITLE
Sync budget entry dates with fieldwork planned dates

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
+++ b/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
@@ -36,6 +36,8 @@ import uy.com.bay.utiles.data.FieldworkStatus;
 import uy.com.bay.utiles.data.FieldworkType;
 import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.data.service.FieldworkService;
+import uy.com.bay.utiles.entities.BudgetEntry;
+import uy.com.bay.utiles.services.BudgetEntryService;
 import uy.com.bay.utiles.services.StudyService;
 
 @Route("fieldworks/:fieldworkID?/:action?(edit)")
@@ -78,12 +80,14 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 	private final FieldworkService fieldworkService;
 	private final StudyService studyService;
 	private final uy.com.bay.utiles.services.AreaService areaService;
+	private final BudgetEntryService budgetEntryService;
 
 	public FieldworksView(FieldworkService fieldworkService, StudyService studyService,
-			uy.com.bay.utiles.services.AreaService areaService) {
+			uy.com.bay.utiles.services.AreaService areaService, BudgetEntryService budgetEntryService) {
 		this.fieldworkService = fieldworkService;
 		this.studyService = studyService;
 		this.areaService = areaService;
+		this.budgetEntryService = budgetEntryService;
 		addClassNames("fieldworks-view");
 
 		// Create UI
@@ -181,6 +185,15 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 						&& !this.fieldwork.getStudy().getFieldworks().contains(this.fieldwork)) {
 					this.fieldwork.getStudy().getFieldworks().add(this.fieldwork);
 					this.studyService.save(this.fieldwork.getStudy());
+				}
+
+				if (this.fieldwork.getStudy() != null && this.fieldwork.getStudy().getBudget() != null
+						&& this.fieldwork.getStudy().getBudget().getEntries() != null) {
+					for (BudgetEntry entry : this.fieldwork.getStudy().getBudget().getEntries()) {
+						entry.setInit(this.fieldwork.getInitPlannedDate());
+						entry.setEnd(this.fieldwork.getEndPlannedDate());
+						this.budgetEntryService.save(entry);
+					}
 				}
 
 				clearForm();


### PR DESCRIPTION
## Summary
This change adds functionality to automatically synchronize budget entry dates with fieldwork planned dates when a fieldwork is saved.

## Key Changes
- Added `BudgetEntryService` dependency injection to `FieldworksView`
- Imported `BudgetEntry` entity and `BudgetEntryService` service classes
- Added logic in the fieldwork save handler to iterate through all budget entries associated with the fieldwork's study and update their start and end dates to match the fieldwork's planned dates
- Each updated budget entry is persisted via the `BudgetEntryService`

## Implementation Details
The new functionality is triggered when a fieldwork is saved and includes null-safety checks to ensure the study, budget, and budget entries exist before attempting to update them. This ensures that whenever fieldwork planned dates are modified, all related budget entries are kept in sync with those dates.

https://claude.ai/code/session_01CmmQyzbCyQAsL81KkLpcah