### PR TITLE
Fix optimistic locking error when syncing BudgetEntry dates

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/BudgetEntryService.java
+++ b/src/main/java/uy/com/bay/utiles/services/BudgetEntryService.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.entities.BudgetEntry;
 import uy.com.bay.utiles.repo.BudgetEntryRepository;
@@ -19,6 +20,14 @@ public class BudgetEntryService {
 
     public BudgetEntry save(BudgetEntry entity) {
         return repository.save(entity);
+    }
+
+    @Transactional
+    public void updateDates(Long entryId, LocalDate init, LocalDate end) {
+        repository.findById(entryId).ifPresent(entry -> {
+            entry.setInit(init);
+            entry.setEnd(end);
+        });
     }
 
     public List<BudgetEntry> findForPlanningReport(LocalDate fechaDesde, LocalDate fechaHasta, List<Study> studies) {

--- a/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
+++ b/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
@@ -190,9 +190,8 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 				if (this.fieldwork.getStudy() != null && this.fieldwork.getStudy().getBudget() != null
 						&& this.fieldwork.getStudy().getBudget().getEntries() != null) {
 					for (BudgetEntry entry : this.fieldwork.getStudy().getBudget().getEntries()) {
-						entry.setInit(this.fieldwork.getInitPlannedDate());
-						entry.setEnd(this.fieldwork.getEndPlannedDate());
-						this.budgetEntryService.save(entry);
+						this.budgetEntryService.updateDates(entry.getId(),
+								this.fieldwork.getInitPlannedDate(), this.fieldwork.getEndPlannedDate());
 					}
 				}
 


### PR DESCRIPTION
## Summary
- Fixes `ObjectOptimisticLockingFailureException` thrown from `FieldworksView` when saving a fieldwork that triggers the BudgetEntry date sync loop.
- The previous code mutated detached `BudgetEntry` instances loaded with the form and called `repository.save()`, which `merge`d with a stale `@Version` whenever the in-memory copy drifted from the DB (concurrent update, or side effects from the preceding `fieldworkService.save()` / `studyService.save()` cascades).
- Adds `BudgetEntryService.updateDates(id, init, end)` annotated `@Transactional`. It re-fetches the entry by id so updates run on a managed entity with the current version; Hibernate's dirty checking flushes the changes on commit.
- Updates the loop in `FieldworksView` to call the new method by id instead of saving the detached entity.

## Test plan
- [ ] Edit an existing fieldwork (whose study has a budget with entries) and change the planned start/end dates; confirm save succeeds and the budget entries' init/end dates are updated.
- [ ] Edit a fieldwork whose budget entries were modified in another tab/session in between and confirm no `ObjectOptimisticLockingFailureException` is logged.
- [ ] Create a new fieldwork attached to a study with budget entries and confirm save succeeds.
- [ ] `./mvnw compile` succeeds (verified locally).

https://claude.ai/code/session_018aKFKV7E2rrD56fdH7TPDn

---
_Generated by [Claude Code](https://claude.ai/code/session_018aKFKV7E2rrD56fdH7TPDn)_