### PR TITLE
Add completedByMonth map to Fieldwork entity

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/Fieldwork.java
+++ b/src/main/java/uy/com/bay/utiles/data/Fieldwork.java
@@ -2,12 +2,21 @@ package uy.com.bay.utiles.data;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.MapKeyTemporal;
+import jakarta.persistence.TemporalType;
 import uy.com.bay.utiles.entities.BudgetEntry;
 
 @Entity
@@ -42,6 +51,13 @@ public class Fieldwork extends AbstractEntity {
 
 	private String doobloId;
 	private String alchemerId;
+
+	@ElementCollection
+	@CollectionTable(name = "fieldwork_completed_by_month", joinColumns = @JoinColumn(name = "fieldwork_id"))
+	@MapKeyColumn(name = "month")
+	@MapKeyTemporal(TemporalType.DATE)
+	@Column(name = "completed")
+	private Map<Date, Integer> completedByMonth = new HashMap<>();
 
 	public String getDoobloId() {
 		return doobloId;
@@ -158,5 +174,13 @@ public class Fieldwork extends AbstractEntity {
 
 	public void setBudgetEntry(BudgetEntry budgetEntry) {
 		this.budgetEntry = budgetEntry;
+	}
+
+	public Map<Date, Integer> getCompletedByMonth() {
+		return completedByMonth;
+	}
+
+	public void setCompletedByMonth(Map<Date, Integer> completedByMonth) {
+		this.completedByMonth = completedByMonth;
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `completedByMonth` (`Map<Date, Integer>`) attribute to the `Fieldwork` entity to track completion counts per month.
- Persists the map via `@ElementCollection` in a new `fieldwork_completed_by_month` table, following the existing pattern used in `SupervisionTask`.

## Test plan
- [ ] Verify schema generation creates `fieldwork_completed_by_month` table with `fieldwork_id`, `month` (DATE), and `completed` columns.
- [ ] Persist a `Fieldwork` with several month/count entries and reload it, confirming the map is restored correctly.
- [ ] Confirm existing `Fieldwork` records load without errors (empty map by default).

https://claude.ai/code/session_01Dawo21BapH7oJCxgbtmHyK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dawo21BapH7oJCxgbtmHyK)_