### PR TITLE
Fix lazy loading issues in budget entry planning report query

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/BudgetEntryService.java
+++ b/src/main/java/uy/com/bay/utiles/services/BudgetEntryService.java
@@ -3,8 +3,10 @@ package uy.com.bay.utiles.services;
 import java.time.LocalDate;
 import java.util.List;
 
+import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import uy.com.bay.utiles.data.Fieldwork;
 import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.entities.BudgetEntry;
 import uy.com.bay.utiles.repo.BudgetEntryRepository;
@@ -30,10 +32,20 @@ public class BudgetEntryService {
         });
     }
 
+    @Transactional(readOnly = true)
     public List<BudgetEntry> findForPlanningReport(LocalDate fechaDesde, LocalDate fechaHasta, List<Study> studies) {
-        if (studies == null || studies.isEmpty()) {
-            return repository.findByDateRange(fechaDesde, fechaHasta);
+        List<BudgetEntry> entries = (studies == null || studies.isEmpty())
+                ? repository.findByDateRange(fechaDesde, fechaHasta)
+                : repository.findByDateRangeAndStudies(fechaDesde, fechaHasta, studies);
+        for (BudgetEntry entry : entries) {
+            Hibernate.initialize(entry.getExtras());
+            Hibernate.initialize(entry.getExpenseRequests());
+            Hibernate.initialize(entry.getOdooCosts());
+            Hibernate.initialize(entry.getFieldworks());
+            for (Fieldwork fieldwork : entry.getFieldworks()) {
+                Hibernate.initialize(fieldwork.getCompletedByMonth());
+            }
         }
-        return repository.findByDateRangeAndStudies(fechaDesde, fechaHasta, studies);
+        return entries;
     }
 }


### PR DESCRIPTION
## Summary
This PR addresses lazy loading issues in the `findForPlanningReport` method by explicitly initializing related collections and adding proper transaction management.

## Key Changes
- Added `@Transactional(readOnly = true)` annotation to the `findForPlanningReport` method to ensure proper transaction context
- Refactored the conditional logic to use a ternary operator for cleaner code
- Added explicit Hibernate initialization for all lazy-loaded collections:
  - `extras`
  - `expenseRequests`
  - `odooCosts`
  - `fieldworks`
- Added nested initialization for `completedByMonth` within each `Fieldwork` object to prevent lazy loading exceptions when accessing nested collections

## Implementation Details
The method now eagerly initializes all related collections within the transaction context before returning the results. This prevents `LazyInitializationException` errors that would occur if these collections were accessed outside the transaction scope. The nested initialization of `fieldwork.getCompletedByMonth()` ensures that deeply nested relationships are also available to callers.

https://claude.ai/code/session_01HfECWk9cBWxiaAY6mxEqvZ