### PR TITLE
Add date range filtering to survey completion tracking

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/AlchemerSurveyResponseHelper.java
+++ b/src/main/java/uy/com/bay/utiles/services/AlchemerSurveyResponseHelper.java
@@ -1,7 +1,14 @@
 package uy.com.bay.utiles.services;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,20 +52,57 @@ public class AlchemerSurveyResponseHelper {
         this.objectMapper = objectMapper;
     }
 
-    public Integer getCompletedSurveys(String surveyId) {
-        try {
-            String url = String.format(
-                    "https://api.alchemer.com/v5/survey/%s/surveyresponse?api_token=%s&api_token_secret=%s"
-                            + "&filter[field][0]=status&filter[operator][0]==&filter[value][0]=Complete",
-                    surveyId, apiToken, apiTokenSecret);
-
-            String response = restTemplate.getForObject(url, String.class);
-            JsonNode root = objectMapper.readTree(response);
-            return root.path("total_count").asInt();
-        } catch (Exception e) {
-            LOGGER.error("Error fetching completed surveys from Alchemer API for surveyId {}", surveyId, e);
-            return 0;
+    public Map<Date, Integer> getCompletedSurveys(String surveyId, Date startDate, Date endDate) {
+        Map<Date, Integer> result = new LinkedHashMap<>();
+        if (startDate == null || endDate == null || startDate.after(endDate)) {
+            return result;
         }
+
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+        Calendar cursor = Calendar.getInstance();
+        cursor.setTime(startDate);
+        cursor.set(Calendar.DAY_OF_MONTH, 1);
+        cursor.set(Calendar.HOUR_OF_DAY, 0);
+        cursor.set(Calendar.MINUTE, 0);
+        cursor.set(Calendar.SECOND, 0);
+        cursor.set(Calendar.MILLISECOND, 0);
+
+        while (!cursor.getTime().after(endDate)) {
+            Date monthStart = cursor.getTime();
+
+            Calendar monthEndCal = (Calendar) cursor.clone();
+            monthEndCal.set(Calendar.DAY_OF_MONTH, monthEndCal.getActualMaximum(Calendar.DAY_OF_MONTH));
+            monthEndCal.set(Calendar.HOUR_OF_DAY, 23);
+            monthEndCal.set(Calendar.MINUTE, 59);
+            monthEndCal.set(Calendar.SECOND, 59);
+            Date monthEnd = monthEndCal.getTime();
+
+            try {
+                String startStr = URLEncoder.encode(dateFormat.format(monthStart), StandardCharsets.UTF_8);
+                String endStr = URLEncoder.encode(dateFormat.format(monthEnd), StandardCharsets.UTF_8);
+
+                String url = String.format(
+                        "https://api.alchemer.com/v5/survey/%s/surveyresponse?api_token=%s&api_token_secret=%s"
+                                + "&filter[field][0]=date_submitted&filter[operator][0]=>=&filter[value][0]=%s"
+                                + "&filter[field][1]=date_submitted&filter[operator][1]=<=&filter[value][1]=%s"
+                                + "&filter[field][2]=status&filter[operator][2]==&filter[value][2]=Complete"
+                                + "&resultsperpage=1",
+                        surveyId, apiToken, apiTokenSecret, startStr, endStr);
+
+                String response = restTemplate.getForObject(url, String.class);
+                JsonNode root = objectMapper.readTree(response);
+                result.put(monthStart, root.path("total_count").asInt());
+            } catch (Exception e) {
+                LOGGER.error("Error fetching completed surveys from Alchemer API for surveyId {} month {}",
+                        surveyId, monthStart, e);
+                result.put(monthStart, 0);
+            }
+
+            cursor.add(Calendar.MONTH, 1);
+        }
+
+        return result;
     }
 
     public String buildSurveyResponseJson(int surveyId, String phoneNumber) throws JsonProcessingException {


### PR DESCRIPTION
## Summary
Enhanced the `getCompletedSurveys` method to support date range filtering and return monthly aggregated results instead of a single total count. This allows tracking survey completion trends over time periods.

## Key Changes
- **Method signature update**: Changed return type from `Integer` to `Map<Date, Integer>` and added `startDate` and `endDate` parameters
- **Date range validation**: Added null checks and validation to ensure start date is not after end date
- **Monthly aggregation**: Implemented logic to iterate through each month within the date range and fetch completion counts separately
- **Enhanced API filtering**: Updated Alchemer API query to filter by `date_submitted` field with >= and <= operators, in addition to status filtering
- **URL encoding**: Added proper URL encoding for date parameters using `URLEncoder` with UTF-8 charset
- **Improved error handling**: Enhanced error logging to include the specific month being processed for better debugging

## Implementation Details
- Uses `Calendar` to handle month-by-month iteration and properly set month boundaries (first day at 00:00:00 to last day at 23:59:59)
- Returns a `LinkedHashMap` to preserve insertion order of monthly results
- Sets `resultsperpage=1` in API request since only the total count is needed
- Gracefully handles API errors by recording 0 for months where the request fails

https://claude.ai/code/session_01CLrvhoJTNWhSiuSRKBrEWS