### PR TITLE
Refactor Dooblo getCompletedSurveys to return monthly counts

### DIFF
--- a/src/main/java/uy/com/bay/utiles/tasks/DoobloSurveyRetriever.java
+++ b/src/main/java/uy/com/bay/utiles/tasks/DoobloSurveyRetriever.java
@@ -1,9 +1,13 @@
 package uy.com.bay.utiles.tasks;
 
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Base64;
+import java.util.Calendar;
 import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import org.slf4j.Logger;
@@ -179,26 +183,60 @@ public class DoobloSurveyRetriever {
 		}
 	}
 
-	public Integer getCompletedSurveys(String surveyId) {
-		try {
-			HttpEntity<String> entity = createAuthHeaders();
-			String interviewsUrl = String
-					.format("http://api.dooblo.net/newapi/SurveyInterviewIDs?surveyIDs=%s&completed=True", surveyId);
-			ResponseEntity<String> interviewsResponse = restTemplate.exchange(interviewsUrl, HttpMethod.GET, entity,
-					String.class);
-			LOGGER.info("Successfully retrieved interview IDs for SurveyID {}. Response: {}", surveyId,
-					interviewsResponse.getBody());
-
-			ObjectMapper mapper = new ObjectMapper();
-			JsonNode interviewsRoot = mapper.readTree(interviewsResponse.getBody());
-			if (interviewsRoot.isArray()) {
-				return interviewsRoot.size();
-			}
-			return 0;
-		} catch (Exception e) {
-			LOGGER.error("Failed to retrieve completed surveys for SurveyID: {}", surveyId, e);
-			return 0;
+	public Map<Date, Integer> getCompletedSurveys(String surveyId, Date fromDate, Date toDate) {
+		Map<Date, Integer> result = new LinkedHashMap<>();
+		if (fromDate == null || toDate == null || fromDate.after(toDate)) {
+			return result;
 		}
+
+		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		HttpEntity<String> entity = createAuthHeaders();
+		ObjectMapper mapper = new ObjectMapper();
+
+		Calendar cursor = Calendar.getInstance();
+		cursor.setTime(fromDate);
+		cursor.set(Calendar.DAY_OF_MONTH, 1);
+		cursor.set(Calendar.HOUR_OF_DAY, 0);
+		cursor.set(Calendar.MINUTE, 0);
+		cursor.set(Calendar.SECOND, 0);
+		cursor.set(Calendar.MILLISECOND, 0);
+
+		while (!cursor.getTime().after(toDate)) {
+			Date monthStart = cursor.getTime();
+
+			Calendar monthEndCal = (Calendar) cursor.clone();
+			monthEndCal.set(Calendar.DAY_OF_MONTH, monthEndCal.getActualMaximum(Calendar.DAY_OF_MONTH));
+			monthEndCal.set(Calendar.HOUR_OF_DAY, 23);
+			monthEndCal.set(Calendar.MINUTE, 59);
+			monthEndCal.set(Calendar.SECOND, 59);
+			Date monthEnd = monthEndCal.getTime();
+
+			try {
+				String fromStr = URLEncoder.encode(dateFormat.format(monthStart), StandardCharsets.UTF_8);
+				String toStr = URLEncoder.encode(dateFormat.format(monthEnd), StandardCharsets.UTF_8);
+
+				String interviewsUrl = String.format(
+						"http://api.dooblo.net/newapi/SurveyInterviewIDsByLastModified?surveyIDs=%s&completed=True&fromDate=%s&toDate=%s",
+						surveyId, fromStr, toStr);
+
+				ResponseEntity<String> interviewsResponse = restTemplate.exchange(interviewsUrl, HttpMethod.GET, entity,
+						String.class);
+				LOGGER.info("Successfully retrieved interview IDs for SurveyID {} between {} and {}. Response: {}",
+						surveyId, monthStart, monthEnd, interviewsResponse.getBody());
+
+				JsonNode interviewsRoot = mapper.readTree(interviewsResponse.getBody());
+				int count = (interviewsRoot != null && interviewsRoot.isArray()) ? interviewsRoot.size() : 0;
+				result.put(monthStart, count);
+			} catch (Exception e) {
+				LOGGER.error("Failed to retrieve completed surveys for SurveyID {} for month {}", surveyId, monthStart,
+						e);
+				result.put(monthStart, 0);
+			}
+
+			cursor.add(Calendar.MONTH, 1);
+		}
+
+		return result;
 	}
 
 	private HttpEntity<String> createAuthHeaders() {

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
@@ -169,8 +169,9 @@ public class BudgetForm extends VerticalLayout {
 						}
 					} else {
 						if (fieldwork.getDoobloId() != null && !fieldwork.getDoobloId().isEmpty()) {
-							Integer completedSurveys = doobloSurveyRetriever
-									.getCompletedSurveys(fieldwork.getDoobloId());
+							Integer completedSurveys = 0;
+//							doobloSurveyRetriever
+//									.getCompletedSurveys(fieldwork.getDoobloId(), fromDate, toDate);
 //							fieldwork.setCompleted(completedSurveys);
 							fieldworkService.save(fieldwork);
 							if (completedSurveys != null && budgetEntry.getAmmount() != null) {


### PR DESCRIPTION
## Summary
- `DoobloSurveyRetriever.getCompletedSurveys` ahora recibe `(String surveyId, Date fromDate, Date toDate)` y devuelve `Map<Date, Integer>` con la cantidad de respuestas completas por mes.
- Cambia el endpoint a `SurveyInterviewIDsByLastModified` y agrega `fromDate`/`toDate` (formato `yyyy-MM-dd HH:mm:ss`, URL-encoded) en los límites de cada mes del rango.
- Itera mes a mes desde el inicio del primer mes hasta `toDate`, guardando el conteo por `monthStart` en el `Map` (mismo patrón que `AlchemerSurveyResponseHelper.getCompletedSurveys`).
- En `BudgetForm.refreshSpentFromAlchemerAndDooblo` se comentó la invocación a Dooblo (espejo del bloque de Alchemer ya comentado) para mantener la compilación; queda pendiente cablear `fromDate`/`toDate` cuando se reactive.

## Test plan
- [ ] `mvn -DskipTests compile` pasa sin errores.
- [ ] Probar manualmente `getCompletedSurveys(surveyId, fromDate, toDate)` con un rango multi-mes y verificar que el `Map` contiene una entrada por cada mes con el conteo esperado.
- [ ] Verificar que las URLs generadas usan `SurveyInterviewIDsByLastModified` y los parámetros `fromDate`/`toDate` van URL-encoded en formato `yyyy-MM-dd HH:mm:ss`.

https://claude.ai/code/session_017bkc8Zb4WZSDckxiR1tvkW

---
_Generated by [Claude Code](https://claude.ai/code/session_017bkc8Zb4WZSDckxiR1tvkW)_