### PR TITLE
Add cumulative budget difference sheet to export

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/BudgetPlanningExporter.java
+++ b/src/main/java/uy/com/bay/utiles/services/BudgetPlanningExporter.java
@@ -65,6 +65,8 @@ public class BudgetPlanningExporter {
 				totalizarConceptos, months, labelStyle, headerStyle, this::distribute);
 		writeSheet(workbook, "Ejecución presupuestal", entries, fechaDesde, fechaHasta, selectedStudies,
 				totalizarConceptos, months, labelStyle, headerStyle, this::distributeExecution);
+		writeSheet(workbook, "Presupuestado - Ejecutado ACUMULADO", entries, fechaDesde, fechaHasta, selectedStudies,
+				totalizarConceptos, months, labelStyle, headerStyle, this::distributeCumulativeDifference);
 
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		workbook.write(out);
@@ -315,6 +317,21 @@ public class BudgetPlanningExporter {
 			}
 		}
 
+		return result;
+	}
+
+	private double[] distributeCumulativeDifference(BudgetEntry entry, List<YearMonth> months) {
+		double[] result = new double[months.size()];
+		if (months.isEmpty()) {
+			return result;
+		}
+		double[] planned = distribute(entry, months);
+		double[] executed = distributeExecution(entry, months);
+		double accumulated = 0d;
+		for (int i = 0; i < months.size(); i++) {
+			accumulated += executed[i] - planned[i];
+			result[i] = accumulated;
+		}
 		return result;
 	}
 


### PR DESCRIPTION
## Summary
Added a new worksheet to the budget planning export that displays the cumulative difference between executed and planned budgets over time.

## Key Changes
- Added a new sheet titled "Presupuestado - Ejecutado ACUMULADO" to the workbook export
- Implemented `distributeCumulativeDifference()` method that calculates the running total of the difference between executed and planned amounts for each month
- The new sheet uses the same structure and styling as existing sheets but applies the cumulative difference distribution logic

## Implementation Details
- The `distributeCumulativeDifference()` method leverages existing `distribute()` and `distributeExecution()` methods to get planned and executed values
- It iterates through months, accumulating the monthly differences (executed - planned) to show cumulative variance over the budget period
- Returns an array of cumulative differences aligned with the provided months list

https://claude.ai/code/session_01XfZG1cYyNvwJRi16Gzrhjp