### PR TITLE
Set eager fetch strategy for fieldwork completed by month collection

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/Fieldwork.java
+++ b/src/main/java/uy/com/bay/utiles/data/Fieldwork.java
@@ -12,6 +12,7 @@ import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapKeyColumn;
@@ -51,7 +52,7 @@ public class Fieldwork extends AbstractEntity {
 	private String doobloId;
 	private String alchemerId;
 
-	@ElementCollection
+	@ElementCollection(fetch = FetchType.EAGER)
 	@CollectionTable(name = "fieldwork_completed_by_month", joinColumns = @JoinColumn(name = "fieldwork_id"))
 	@MapKeyColumn(name = "month")
 	@MapKeyTemporal(TemporalType.DATE)


### PR DESCRIPTION
## Summary
Updated the `@ElementCollection` annotation on the `completedByMonth` field in the `Fieldwork` entity to use eager fetching instead of the default lazy loading strategy.

## Key Changes
- Added `FetchType.EAGER` parameter to `@ElementCollection` annotation for the `completedByMonth` map collection
- This ensures the month-based completion data is loaded immediately with the parent `Fieldwork` entity, avoiding potential lazy loading issues

## Implementation Details
- The change applies to the `completedByMonth` field which stores fieldwork completion data indexed by month
- This is a performance/usability optimization that prevents N+1 query problems when accessing this collection
- The collection is backed by the `fieldwork_completed_by_month` table with proper join and key column mappings

https://claude.ai/code/session_01Hki2Exu7DyHR7NoG85k9Tj