### PR TITLE
Add delay to survey retrieval loop to prevent rate limiting

### DIFF
--- a/src/main/java/uy/com/bay/utiles/tasks/DoobloSurveyRetriever.java
+++ b/src/main/java/uy/com/bay/utiles/tasks/DoobloSurveyRetriever.java
@@ -212,6 +212,8 @@ public class DoobloSurveyRetriever {
 			Date monthEnd = monthEndCal.getTime();
 
 			try {
+				Thread.sleep(600);
+
 				String fromStr = URLEncoder.encode(dateFormat.format(monthStart), StandardCharsets.UTF_8);
 				String toStr = URLEncoder.encode(dateFormat.format(monthEnd), StandardCharsets.UTF_8);
 


### PR DESCRIPTION
## Summary
Added a 600ms delay in the survey retrieval loop to prevent potential rate limiting issues when fetching completed surveys from the Dooble API.

## Key Changes
- Added `Thread.sleep(600)` before each API request in the `getCompletedSurveys` method to introduce a delay between consecutive requests

## Implementation Details
The delay is inserted at the beginning of the try block, ensuring that every iteration of the monthly survey retrieval loop pauses for 600 milliseconds before making the next API call. This helps prevent overwhelming the external service with rapid consecutive requests and reduces the likelihood of hitting rate limits.

https://claude.ai/code/session_01ScKZF8uxvbzHuzmNXUwLJd