### PR TITLE
Add expected revenue display to budget export and project view

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/BudgetPlanningExporter.java
+++ b/src/main/java/uy/com/bay/utiles/services/BudgetPlanningExporter.java
@@ -62,11 +62,11 @@ public class BudgetPlanningExporter {
 		List<YearMonth> months = monthsBetween(fechaDesde, fechaHasta);
 
 		writeSheet(workbook, "Planificación presupuestal", entries, fechaDesde, fechaHasta, selectedStudies,
-				totalizarConceptos, months, labelStyle, headerStyle, this::distribute, true);
+				totalizarConceptos, months, labelStyle, headerStyle, this::distribute, true, true);
 		writeSheet(workbook, "Ejecución presupuestal", entries, fechaDesde, fechaHasta, selectedStudies,
-				totalizarConceptos, months, labelStyle, headerStyle, this::distributeExecution, true);
+				totalizarConceptos, months, labelStyle, headerStyle, this::distributeExecution, true, false);
 		writeSheet(workbook, "Presupuestado - Ejecutado ACUMULADO", entries, fechaDesde, fechaHasta, selectedStudies,
-				totalizarConceptos, months, labelStyle, headerStyle, this::distributeCumulativeDifference, false);
+				totalizarConceptos, months, labelStyle, headerStyle, this::distributeCumulativeDifference, false, false);
 
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		workbook.write(out);
@@ -77,7 +77,8 @@ public class BudgetPlanningExporter {
 	private void writeSheet(Workbook workbook, String sheetName, List<BudgetEntry> entries, LocalDate fechaDesde,
 			LocalDate fechaHasta, List<Study> selectedStudies, boolean totalizarConceptos, List<YearMonth> months,
 			CellStyle labelStyle, CellStyle headerStyle,
-			BiFunction<BudgetEntry, List<YearMonth>, double[]> distributor, boolean includeTotalColumn) {
+			BiFunction<BudgetEntry, List<YearMonth>, double[]> distributor, boolean includeTotalColumn,
+			boolean includeExpectedRevenue) {
 		Sheet sheet = workbook.createSheet(sheetName);
 
 		int rowIndex = 0;
@@ -118,6 +119,9 @@ public class BudgetPlanningExporter {
 
 		List<String> headers = new ArrayList<>();
 		headers.add("Estudio");
+		if (includeExpectedRevenue) {
+			headers.add("Ingreso esperado");
+		}
 		if (!totalizarConceptos) {
 			headers.add("Concepto presupuesto");
 		}
@@ -138,7 +142,8 @@ public class BudgetPlanningExporter {
 			cell.setCellStyle(headerStyle);
 		}
 
-		int baseColumnsCount = totalizarConceptos ? 2 : 3;
+		int expectedRevenueOffset = includeExpectedRevenue ? 1 : 0;
+		int baseColumnsCount = (totalizarConceptos ? 2 : 3) + expectedRevenueOffset;
 		int totalColumnIndex = includeTotalColumn ? baseColumnsCount : -1;
 		int firstMonthColumnIndex = baseColumnsCount + (includeTotalColumn ? 1 : 0);
 		double totalSum = 0d;
@@ -149,7 +154,10 @@ public class BudgetPlanningExporter {
 			for (AggregatedRow agg : aggregated) {
 				Row row = sheet.createRow(rowIndex++);
 				row.createCell(0).setCellValue(agg.estudio);
-				row.createCell(1).setCellValue(agg.tipo);
+				if (includeExpectedRevenue) {
+					row.createCell(1).setCellValue(agg.expectedRevenue);
+				}
+				row.createCell(1 + expectedRevenueOffset).setCellValue(agg.tipo);
 				double rowTotal = 0d;
 				for (int i = 0; i < months.size(); i++) {
 					row.createCell(firstMonthColumnIndex + i).setCellValue(agg.monthly[i]);
@@ -173,8 +181,11 @@ public class BudgetPlanningExporter {
 			for (BudgetEntry entry : sorted) {
 				Row row = sheet.createRow(rowIndex++);
 				row.createCell(0).setCellValue(studyName(entry));
-				row.createCell(1).setCellValue(conceptName(entry));
-				row.createCell(2).setCellValue(tipo(entry));
+				if (includeExpectedRevenue) {
+					row.createCell(1).setCellValue(expectedRevenue(entry));
+				}
+				row.createCell(1 + expectedRevenueOffset).setCellValue(conceptName(entry));
+				row.createCell(2 + expectedRevenueOffset).setCellValue(tipo(entry));
 
 				double[] distribution = distributor.apply(entry, months);
 				double rowTotal = 0d;
@@ -217,6 +228,13 @@ public class BudgetPlanningExporter {
 			return entry.getBudget().getStudy().getName();
 		}
 		return "";
+	}
+
+	private static double expectedRevenue(BudgetEntry entry) {
+		if (entry.getBudget() != null && entry.getBudget().getStudy() != null) {
+			return entry.getBudget().getStudy().getExpectedRevenue();
+		}
+		return 0d;
 	}
 
 	private static String conceptName(BudgetEntry entry) {
@@ -401,6 +419,7 @@ public class BudgetPlanningExporter {
 			String key = estudio + "||" + tipo;
 			AggregatedRow agg = map.computeIfAbsent(key, k -> new AggregatedRow(estudio, tipo, months.size()));
 			agg.total += entry.getTotal() != null ? entry.getTotal() : 0d;
+			agg.expectedRevenue = expectedRevenue(entry);
 			double[] distribution = distributor.apply(entry, months);
 			for (int i = 0; i < months.size(); i++) {
 				agg.monthly[i] += distribution[i];
@@ -417,6 +436,7 @@ public class BudgetPlanningExporter {
 		final String estudio;
 		final String tipo;
 		double total;
+		double expectedRevenue;
 		final double[] monthly;
 
 		AggregatedRow(String estudio, String tipo, int monthCount) {

--- a/src/main/java/uy/com/bay/utiles/views/proyectos/ProyectosView.java
+++ b/src/main/java/uy/com/bay/utiles/views/proyectos/ProyectosView.java
@@ -64,6 +64,8 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 	private Checkbox showSurveyor;
 	private TextField totalTransfered;
 	private TextField totalReportedCost;
+	private TextField clientName;
+	private TextField expectedRevenue;
 
 	private Button addButton;
 	private TextField nameFilter;
@@ -332,7 +334,12 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 		totalTransfered.setReadOnly(true);
 		totalReportedCost = new TextField("Total de gastos rendidos");
 		totalReportedCost.setReadOnly(true);
-		formLayout.add(name, odooId, budget, obs, showSurveyor, totalTransfered, totalReportedCost);
+		clientName = new TextField("Cliente");
+		clientName.setReadOnly(true);
+		expectedRevenue = new TextField("Ingreso esperado");
+		expectedRevenue.setReadOnly(true);
+		formLayout.add(name, odooId, budget, obs, showSurveyor, totalTransfered, totalReportedCost, clientName,
+				expectedRevenue);
 
 		editorDiv.add(formLayout);
 		editorDiv.add(viewMovementsButton);
@@ -388,9 +395,13 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 		if (value != null) {
 			totalTransfered.setValue(Double.valueOf(value.getTotalTransfered()).toString());
 			totalReportedCost.setValue(Double.valueOf(value.getTotalReportedCost()).toString());
+			clientName.setValue(value.getClientName() != null ? value.getClientName() : "");
+			expectedRevenue.setValue(Double.valueOf(value.getExpectedRevenue()).toString());
 		} else {
 			totalTransfered.setValue("");
 			totalReportedCost.setValue("");
+			clientName.setValue("");
+			expectedRevenue.setValue("");
 		}
 		if (this.editorLayoutDiv != null) {
 			this.editorLayoutDiv.setVisible(value != null);


### PR DESCRIPTION
## Summary
This PR adds support for displaying expected revenue information in budget planning exports and the projects view. The expected revenue is now conditionally included in exported sheets and displayed as a read-only field in the project editor.

## Key Changes

- **Budget Export Enhancement**: Modified `BudgetPlanningExporter` to conditionally include expected revenue column in exported sheets
  - Added `includeExpectedRevenue` parameter to `writeSheet()` method
  - "Planificación presupuestal" sheet includes expected revenue (true)
  - "Ejecución presupuestal" and "Presupuestado - Ejecutado ACUMULADO" sheets exclude it (false)
  - Dynamically adjusts column indices based on whether expected revenue is included
  - Added `expectedRevenue()` helper method to extract revenue from budget entries
  - Updated `AggregatedRow` class to store expected revenue values

- **Projects View UI**: Enhanced `ProyectosView` to display additional study information
  - Added read-only `clientName` field to display the client name
  - Added read-only `expectedRevenue` field to display expected revenue
  - Both fields are populated when a study is selected in the form
  - Fields are cleared when no study is selected

## Implementation Details

- Expected revenue column is inserted after the "Estudio" column when enabled, with proper offset calculations for subsequent columns
- The implementation maintains backward compatibility by using boolean flags to control feature inclusion
- All new fields in the UI are read-only, indicating they are display-only information

https://claude.ai/code/session_01KuC6eXNry7wfp2BEdhYy1J