### PR TITLE
Fix invoice tax calculation using price fields from Odoo

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/OdooService.java
+++ b/src/main/java/uy/com/bay/utiles/services/OdooService.java
@@ -369,7 +369,7 @@ public class OdooService {
 			}
 
 			List<String> fieldsToFetch = Arrays.asList("id", "date", "move_id", "name", "analytic_account_id",
-					"currency_id", "amount_untaxed", "amount_tax", "amount_total");
+					"currency_id", "price_subtotal", "price_total");
 
 			List<Object> domain = new ArrayList<>();
 			domain.add(Arrays.asList("move_id.move_type", "in", Arrays.asList("out_invoice", "out_refund")));

--- a/src/main/java/uy/com/bay/utiles/tasks/OdooProjectSyncTask.java
+++ b/src/main/java/uy/com/bay/utiles/tasks/OdooProjectSyncTask.java
@@ -78,9 +78,13 @@ public class OdooProjectSyncTask {
 				}
 			}
 
-			invoice.setAmountUntaxed(toDouble(line.get("amount_untaxed")));
-			invoice.setTax(toDouble(line.get("amount_tax")));
-			invoice.setAmountTotal(toDouble(line.get("amount_total")));
+			Double priceSubtotal = toDouble(line.get("price_subtotal"));
+			Double priceTotal = toDouble(line.get("price_total"));
+			invoice.setAmountUntaxed(priceSubtotal);
+			invoice.setAmountTotal(priceTotal);
+			if (priceSubtotal != null && priceTotal != null) {
+				invoice.setTax(priceTotal - priceSubtotal);
+			}
 			invoice.setCurrency(extractRelationName(line.get("currency_id")));
 
 			studyInvoiceService.save(invoice);


### PR DESCRIPTION
## Summary
Updated the invoice synchronization logic to use the correct Odoo fields (`price_subtotal` and `price_total`) for calculating invoice amounts and taxes, replacing the previously used fields that were causing incorrect calculations.

## Key Changes
- **OdooProjectSyncTask.java**: Modified `updateInvoices()` method to:
  - Use `price_subtotal` instead of `amount_untaxed` for the untaxed amount
  - Use `price_total` instead of `amount_total` for the total amount
  - Calculate tax as the difference between `price_total` and `price_subtotal` instead of using the `amount_tax` field directly
  - Added null-safety check before calculating tax to prevent NullPointerException

- **OdooService.java**: Updated `getOdooInvoiceAccountMoveLines()` method to:
  - Fetch `price_subtotal` and `price_total` fields instead of `amount_untaxed`, `amount_tax`, and `amount_total`
  - Reduced the number of fields fetched from Odoo API for better performance

## Implementation Details
The tax calculation is now derived from the price fields rather than fetched directly, which provides a more accurate representation of the actual tax amount based on the line-level pricing information from Odoo.

https://claude.ai/code/session_013QT7czQb8XWK3uvqacFHvK