### PR TITLE
Add CRM team area tracking to studies and budget exports

### DIFF
--- a/src/main/frontend/themes/Utiles/views/proyectos-view.css
+++ b/src/main/frontend/themes/Utiles/views/proyectos-view.css
@@ -16,7 +16,7 @@
 .proyectos-view .editor-layout {
   display: flex;
   flex-direction: column;
-  width: 400px;
+  width: 700px;
 }
 
 .proyectos-view .editor {

--- a/src/main/java/uy/com/bay/utiles/data/Study.java
+++ b/src/main/java/uy/com/bay/utiles/data/Study.java
@@ -24,6 +24,7 @@ public class Study extends AbstractEntity {
 	private boolean showSurveyor;
 	private String clientName;
 	private double expectedRevenue;
+	private String area;
 
 	public boolean isShowSurveyor() {
 		return showSurveyor;
@@ -106,5 +107,13 @@ public class Study extends AbstractEntity {
 
 	public void setExpectedRevenue(double expectedRevenue) {
 		this.expectedRevenue = expectedRevenue;
+	}
+
+	public String getArea() {
+		return area;
+	}
+
+	public void setArea(String area) {
+		this.area = area;
 	}
 }

--- a/src/main/java/uy/com/bay/utiles/services/BudgetPlanningExporter.java
+++ b/src/main/java/uy/com/bay/utiles/services/BudgetPlanningExporter.java
@@ -129,6 +129,7 @@ public class BudgetPlanningExporter {
 
 		List<String> headers = new ArrayList<>();
 		headers.add("Estudio");
+		headers.add("Area");
 		if (includeInvoicedRevenue) {
 			headers.add("Ingreso Facturado");
 		}
@@ -158,7 +159,7 @@ public class BudgetPlanningExporter {
 		int invoicedRevenueOffset = includeInvoicedRevenue ? 1 : 0;
 		int expectedRevenueOffset = includeExpectedRevenue ? 1 : 0;
 		int extraOffset = invoicedRevenueOffset + expectedRevenueOffset;
-		int baseColumnsCount = (totalizarConceptos ? 2 : 3) + extraOffset;
+		int baseColumnsCount = (totalizarConceptos ? 3 : 4) + extraOffset;
 		int totalColumnIndex = includeTotalColumn ? baseColumnsCount : -1;
 		int firstMonthColumnIndex = baseColumnsCount + (includeTotalColumn ? 1 : 0);
 		double totalSum = 0d;
@@ -178,15 +179,16 @@ public class BudgetPlanningExporter {
 			for (AggregatedRow agg : aggregated) {
 				Row row = sheet.createRow(rowIndex++);
 				row.createCell(0).setCellValue(agg.estudio);
+				row.createCell(1).setCellValue(agg.area != null ? agg.area : "");
 				if (includeInvoicedRevenue) {
 					double invoicedValue = studiesWithInvoicedShown.add(agg.estudio) ? agg.invoicedRevenue : 0d;
-					row.createCell(1).setCellValue(invoicedValue);
+					row.createCell(2).setCellValue(invoicedValue);
 				}
 				if (includeExpectedRevenue) {
 					double expectedValue = studiesWithExpectedShown.add(agg.estudio) ? agg.expectedRevenue : 0d;
-					row.createCell(1 + invoicedRevenueOffset).setCellValue(expectedValue);
+					row.createCell(2 + invoicedRevenueOffset).setCellValue(expectedValue);
 				}
-				row.createCell(1 + extraOffset).setCellValue(agg.tipo);
+				row.createCell(2 + extraOffset).setCellValue(agg.tipo);
 				double rowTotal = 0d;
 				boolean isSalary = "Costo Salarial".equals(agg.tipo);
 				for (int i = 0; i < months.size(); i++) {
@@ -222,19 +224,20 @@ public class BudgetPlanningExporter {
 				Row row = sheet.createRow(rowIndex++);
 				String estudio = studyName(entry);
 				row.createCell(0).setCellValue(estudio);
+				row.createCell(1).setCellValue(area(entry));
 				if (includeInvoicedRevenue) {
 					double invoicedValue = studiesWithInvoicedShown.add(estudio)
 							? invoicedRevenue(entry, invoicedCache)
 							: 0d;
-					row.createCell(1).setCellValue(invoicedValue);
+					row.createCell(2).setCellValue(invoicedValue);
 				}
 				if (includeExpectedRevenue) {
 					double expectedValue = studiesWithExpectedShown.add(estudio) ? expectedRevenue(entry) : 0d;
-					row.createCell(1 + invoicedRevenueOffset).setCellValue(expectedValue);
+					row.createCell(2 + invoicedRevenueOffset).setCellValue(expectedValue);
 				}
-				row.createCell(1 + extraOffset).setCellValue(conceptName(entry));
+				row.createCell(2 + extraOffset).setCellValue(conceptName(entry));
 				String tipo = tipo(entry);
-				row.createCell(2 + extraOffset).setCellValue(tipo);
+				row.createCell(3 + extraOffset).setCellValue(tipo);
 
 				double[] distribution = distributor.apply(entry, months);
 				double rowTotal = 0d;
@@ -296,6 +299,14 @@ public class BudgetPlanningExporter {
 	private static String studyName(BudgetEntry entry) {
 		if (entry.getBudget() != null && entry.getBudget().getStudy() != null) {
 			return entry.getBudget().getStudy().getName();
+		}
+		return "";
+	}
+
+	private static String area(BudgetEntry entry) {
+		if (entry.getBudget() != null && entry.getBudget().getStudy() != null
+				&& entry.getBudget().getStudy().getArea() != null) {
+			return entry.getBudget().getStudy().getArea();
 		}
 		return "";
 	}
@@ -502,6 +513,7 @@ public class BudgetPlanningExporter {
 			AggregatedRow agg = map.computeIfAbsent(key, k -> new AggregatedRow(estudio, tipo, months.size()));
 			agg.total += entry.getTotal() != null ? entry.getTotal() : 0d;
 			agg.expectedRevenue = expectedRevenue(entry);
+			agg.area = area(entry);
 			if (includeInvoicedRevenue) {
 				agg.invoicedRevenue = invoicedRevenue(entry, invoicedCache);
 			}
@@ -520,6 +532,7 @@ public class BudgetPlanningExporter {
 	private static class AggregatedRow {
 		final String estudio;
 		final String tipo;
+		String area;
 		double total;
 		double expectedRevenue;
 		double invoicedRevenue;

--- a/src/main/java/uy/com/bay/utiles/services/OdooService.java
+++ b/src/main/java/uy/com/bay/utiles/services/OdooService.java
@@ -239,9 +239,16 @@ public class OdooService {
 
 					Object nameObj = accountMap.get("name");
 					if (nameObj != null) {
-						Double expectedRevenue = findLeadExpectedRevenueByName(uid, String.valueOf(nameObj));
-						if (expectedRevenue != null) {
-							accountMap.put("expected_revenue", expectedRevenue);
+						Map<String, Object> leadInfo = findLeadInfoByName(uid, String.valueOf(nameObj));
+						if (leadInfo != null) {
+							Object revenue = leadInfo.get("expected_revenue");
+							if (revenue instanceof Number) {
+								accountMap.put("expected_revenue", ((Number) revenue).doubleValue());
+							}
+							String teamName = findCrmTeamNameByLeadInfo(uid, leadInfo);
+							if (teamName != null) {
+								accountMap.put("crm_team", teamName);
+							}
 						}
 					}
 
@@ -268,7 +275,7 @@ public class OdooService {
 	}
 
 	@SuppressWarnings("unchecked")
-	private Double findLeadExpectedRevenueByName(Integer uid, String leadName) {
+	private Map<String, Object> findLeadInfoByName(Integer uid, String leadName) {
 		if (leadName == null || leadName.trim().isEmpty()) {
 			return null;
 		}
@@ -276,7 +283,7 @@ public class OdooService {
 			List<Object> domain = Collections.singletonList(Arrays.asList("name", "=", leadName));
 
 			HashMap<String, Object> keywordArgs = new HashMap<>();
-			keywordArgs.put("fields", Arrays.asList("id", "name", "expected_revenue"));
+			keywordArgs.put("fields", Arrays.asList("id", "name", "expected_revenue", "team_id"));
 			keywordArgs.put("limit", 1);
 
 			Object[] params = new Object[] { odooConfig.getDb(), uid, odooConfig.getPassword(), "crm.lead",
@@ -288,15 +295,78 @@ public class OdooService {
 			}
 			Object first = leadsRaw[0];
 			if (first instanceof Map) {
-				Object revenue = ((Map<String, Object>) first).get("expected_revenue");
-				if (revenue instanceof Number) {
-					return ((Number) revenue).doubleValue();
-				}
+				return (Map<String, Object>) first;
 			}
 		} catch (XmlRpcException e) {
 			logger.error("XmlRpcException while searching crm.lead by name '{}': {}", leadName, e.getMessage(), e);
 		} catch (Exception e) {
 			logger.error("Unexpected exception while searching crm.lead by name '{}': {}", leadName, e.getMessage(), e);
+		}
+		return null;
+	}
+
+	@SuppressWarnings("unchecked")
+	private String findCrmTeamNameByLeadInfo(Integer uid, Map<String, Object> leadInfo) {
+		if (leadInfo == null) {
+			return null;
+		}
+		Object teamIdObj = leadInfo.get("team_id");
+		if (teamIdObj == null || teamIdObj instanceof Boolean) {
+			return null;
+		}
+
+		Integer teamId = null;
+		String teamName = null;
+		if (teamIdObj instanceof Object[]) {
+			Object[] teamArr = (Object[]) teamIdObj;
+			if (teamArr.length >= 1 && teamArr[0] instanceof Number) {
+				teamId = ((Number) teamArr[0]).intValue();
+			}
+			if (teamArr.length >= 2 && teamArr[1] != null) {
+				teamName = String.valueOf(teamArr[1]);
+			}
+		} else if (teamIdObj instanceof List) {
+			List<Object> teamList = (List<Object>) teamIdObj;
+			if (!teamList.isEmpty() && teamList.get(0) instanceof Number) {
+				teamId = ((Number) teamList.get(0)).intValue();
+			}
+			if (teamList.size() >= 2 && teamList.get(1) != null) {
+				teamName = String.valueOf(teamList.get(1));
+			}
+		}
+
+		if (teamName != null && !teamName.trim().isEmpty()) {
+			return teamName;
+		}
+		if (teamId == null) {
+			return null;
+		}
+
+		try {
+			List<Object> domain = Collections.singletonList(Arrays.asList("id", "=", teamId));
+
+			HashMap<String, Object> keywordArgs = new HashMap<>();
+			keywordArgs.put("fields", Arrays.asList("id", "name"));
+			keywordArgs.put("limit", 1);
+
+			Object[] params = new Object[] { odooConfig.getDb(), uid, odooConfig.getPassword(), "crm.team",
+					"search_read", Collections.singletonList(domain), keywordArgs };
+
+			Object[] teamsRaw = (Object[]) objectClient.execute("execute_kw", params);
+			if (teamsRaw == null || teamsRaw.length == 0) {
+				return null;
+			}
+			Object first = teamsRaw[0];
+			if (first instanceof Map) {
+				Object name = ((Map<String, Object>) first).get("name");
+				if (name != null) {
+					return String.valueOf(name);
+				}
+			}
+		} catch (XmlRpcException e) {
+			logger.error("XmlRpcException while searching crm.team by id '{}': {}", teamId, e.getMessage(), e);
+		} catch (Exception e) {
+			logger.error("Unexpected exception while searching crm.team by id '{}': {}", teamId, e.getMessage(), e);
 		}
 		return null;
 	}

--- a/src/main/java/uy/com/bay/utiles/tasks/OdooProjectSyncTask.java
+++ b/src/main/java/uy/com/bay/utiles/tasks/OdooProjectSyncTask.java
@@ -207,6 +207,9 @@ public class OdooProjectSyncTask {
 					? ((Number) expectedRevenueObj).doubleValue()
 					: 0d;
 
+			Object areaObj = odooProjectMap.get("crm_team");
+			String area = areaObj == null ? null : String.valueOf(areaObj);
+
 			if (existing == null) {
 				Study newProyecto = new Study();
 				newProyecto.setOdooId(odooId);
@@ -219,6 +222,7 @@ public class OdooProjectSyncTask {
 
 				newProyecto.setClientName(clientName);
 				newProyecto.setExpectedRevenue(expectedRevenue);
+				newProyecto.setArea(area);
 
 				Study saved = proyectoService.save(newProyecto);
 				if (saved.getName() != null && !saved.getName().isEmpty()) {
@@ -238,6 +242,10 @@ public class OdooProjectSyncTask {
 				}
 				if (Double.compare(existing.getExpectedRevenue(), expectedRevenue) != 0) {
 					existing.setExpectedRevenue(expectedRevenue);
+					changed = true;
+				}
+				if (!Objects.equals(existing.getArea(), area)) {
+					existing.setArea(area);
 					changed = true;
 				}
 				if (changed) {

--- a/src/main/java/uy/com/bay/utiles/views/proyectos/ProyectosView.java
+++ b/src/main/java/uy/com/bay/utiles/views/proyectos/ProyectosView.java
@@ -68,6 +68,7 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 	private TextField clientName;
 	private TextField expectedRevenue;
 	private TextField invoiced;
+	private TextField area;
 
 	private Button addButton;
 	private TextField nameFilter;
@@ -337,6 +338,8 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 		editorLayoutDiv.add(editorDiv);
 
 		FormLayout formLayout = new FormLayout();
+		formLayout.setResponsiveSteps(new FormLayout.ResponsiveStep("0", 1),
+				new FormLayout.ResponsiveStep("500px", 2));
 		name = new TextField("Name");
 		name.setReadOnly(true);
 		odooId = new TextField("Odoo Id");
@@ -355,8 +358,10 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 		expectedRevenue.setReadOnly(true);
 		invoiced = new TextField("Facturado");
 		invoiced.setReadOnly(true);
+		area = new TextField("Area");
+		area.setReadOnly(true);
 		formLayout.add(name, odooId, budget, obs, showSurveyor, totalTransfered, totalReportedCost, clientName,
-				expectedRevenue, invoiced);
+				expectedRevenue, invoiced, area);
 
 		editorDiv.add(formLayout);
 		editorDiv.add(viewMovementsButton);


### PR DESCRIPTION
## Summary
This PR enhances the study management system to track and display CRM team information (area) alongside expected revenue data. The changes integrate team data from Odoo CRM into the study entity and propagate it through budget planning exports and the UI.

## Key Changes

- **OdooService**: Refactored `findLeadExpectedRevenueByName()` to `findLeadInfoByName()` to return complete lead information including the `team_id` field. Added new `findCrmTeamNameByLeadInfo()` method to extract and resolve CRM team names from lead data, handling both array and list representations of team references.

- **Study Entity**: Added `area` field with getter/setter methods to store the CRM team/area information associated with a study.

- **OdooProjectSyncTask**: Updated sync logic to extract the `crm_team` value from Odoo project maps and populate the new `area` field when creating or updating studies.

- **BudgetPlanningExporter**: 
  - Added "Area" column to exported budget sheets (second column after "Estudio")
  - Updated all column index calculations to account for the new area column
  - Added `area()` helper method to extract area information from budget entries
  - Updated `AggregatedRow` class to include area field

- **ProyectosView**: 
  - Added read-only `area` TextField to the study editor form
  - Updated FormLayout to use responsive steps for better layout on different screen sizes
  - Increased editor layout width from 400px to 700px to accommodate additional field

## Implementation Details

The CRM team resolution handles multiple data formats returned by Odoo (arrays and lists) and falls back to a database lookup if the team name isn't directly available in the lead data. The area information flows through the entire system: from Odoo sync → Study entity → Budget aggregation → Excel export and UI display.

https://claude.ai/code/session_01VdJsPeuMdT59DAk3TgHLJW