### PR TITLE
Widen Proyectos editor, use 2-column form and spaced action buttons

### DIFF
--- a/src/main/frontend/themes/Utiles/views/proyectos-view.css
+++ b/src/main/frontend/themes/Utiles/views/proyectos-view.css
@@ -16,7 +16,15 @@
 .proyectos-view .editor-layout {
   display: flex;
   flex-direction: column;
-  width: 700px;
+  width: 1000px;
+}
+
+.proyectos-view .view-actions-layout {
+  width: 100%;
+  flex-wrap: wrap;
+  gap: var(--lumo-space-m);
+  padding-top: var(--lumo-space-m);
+  padding-bottom: var(--lumo-space-m);
 }
 
 .proyectos-view .editor {

--- a/src/main/java/uy/com/bay/utiles/views/proyectos/ProyectosView.java
+++ b/src/main/java/uy/com/bay/utiles/views/proyectos/ProyectosView.java
@@ -360,14 +360,17 @@ public class ProyectosView extends Div implements BeforeEnterObserver {
 		invoiced.setReadOnly(true);
 		area = new TextField("Area");
 		area.setReadOnly(true);
-		formLayout.add(name, odooId, budget, obs, showSurveyor, totalTransfered, totalReportedCost, clientName,
+		formLayout.add(name, odooId, budget, showSurveyor, obs, totalTransfered, totalReportedCost, clientName,
 				expectedRevenue, invoiced, area);
+		formLayout.setColspan(obs, 2);
+
+		HorizontalLayout viewActionsLayout = new HorizontalLayout(viewMovementsButton, viewFieldworksButton,
+				viewBudgetButton, viewInvoicesButton);
+		viewActionsLayout.setClassName("view-actions-layout");
+		viewActionsLayout.setSpacing(true);
 
 		editorDiv.add(formLayout);
-		editorDiv.add(viewMovementsButton);
-		editorDiv.add(viewFieldworksButton);
-		editorDiv.add(viewBudgetButton);
-		editorDiv.add(viewInvoicesButton);
+		editorDiv.add(viewActionsLayout);
 		createButtonLayout(this.editorLayoutDiv);
 
 		splitLayout.addToSecondary(this.editorLayoutDiv);


### PR DESCRIPTION
## Summary
- Widen the right-hand editor panel in `ProyectosView` from 700px to 1000px so there is room for two columns.
- Arrange form fields in 2 columns (with `Observaciones` spanning both) for a more compact, balanced layout.
- Group the four action buttons (`Ver movimientos de gastos`, `Ver solicitudes de campo`, `Ver presupuesto`, `Ver Facturas`) in a `HorizontalLayout` with proper spacing instead of stacking them vertically.

## Test plan
- [ ] Open Proyectos view, select a project, verify the editor panel is wider.
- [ ] Verify form fields render in 2 columns and Observaciones spans the full width.
- [ ] Verify the four "Ver ..." action buttons appear in a single horizontal row with spacing between them.
- [ ] Verify Save / Borrar / Cancel still work at the bottom.

https://claude.ai/code/session_01PXmfLRXj9gmnVEUeEEkWq8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXmfLRXj9gmnVEUeEEkWq8)_