### PR TITLE
Initialize lazy-loaded budget collections in GanttService

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/GanttService.java
+++ b/src/main/java/uy/com/bay/utiles/services/GanttService.java
@@ -1,8 +1,13 @@
 package uy.com.bay.utiles.services;
 
+import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uy.com.bay.utiles.data.Fieldwork;
+import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.data.repository.FieldworkRepository;
+import uy.com.bay.utiles.entities.Budget;
+import uy.com.bay.utiles.entities.BudgetEntry;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -16,7 +21,27 @@ public class GanttService {
         this.fieldworkRepository = fieldworkRepository;
     }
 
+    @Transactional(readOnly = true)
     public List<Fieldwork> getFieldworks(LocalDate startDate, LocalDate endDate) {
-        return fieldworkRepository.findAllByInitPlannedDateLessThanAndEndPlannedDateGreaterThan(endDate, startDate);
+        List<Fieldwork> fieldworks = fieldworkRepository
+                .findAllByInitPlannedDateLessThanAndEndPlannedDateGreaterThan(endDate, startDate);
+        for (Fieldwork fieldwork : fieldworks) {
+            Study study = fieldwork.getStudy();
+            if (study == null) {
+                continue;
+            }
+            Budget budget = study.getBudget();
+            if (budget == null) {
+                continue;
+            }
+            Hibernate.initialize(budget.getEntries());
+            for (BudgetEntry entry : budget.getEntries()) {
+                Hibernate.initialize(entry.getExtras());
+                Hibernate.initialize(entry.getExpenseRequests());
+                Hibernate.initialize(entry.getFieldworks());
+                Hibernate.initialize(entry.getOdooCosts());
+            }
+        }
+        return fieldworks;
     }
 }


### PR DESCRIPTION
## Summary
This PR adds explicit lazy-loading initialization for budget-related collections in the `GanttService.getFieldworks()` method to prevent LazyInitializationException errors when accessing these collections outside of a transaction context.

## Key Changes
- Added `@Transactional(readOnly = true)` annotation to `getFieldworks()` method to ensure proper transaction management
- Implemented explicit Hibernate initialization of nested collections:
  - Budget entries collection
  - Budget entry extras, expense requests, fieldworks, and odoo costs collections
- Added null-safety checks for Study and Budget objects before attempting to initialize collections
- Added necessary imports for `Hibernate`, `@Transactional`, `Study`, `Budget`, and `BudgetEntry` classes

## Implementation Details
The method now iterates through retrieved fieldworks and eagerly initializes all lazy-loaded collections within the transaction context. This prevents `LazyInitializationException` when these collections are accessed by consumers of this service method. The null checks ensure robustness when Study or Budget relationships are not populated.

https://claude.ai/code/session_01QAvE35LSLUECkWmHRxVNmo