### PR TITLE
Fix LazyInitializationException in FieldworksView budget cost columns

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/service/FieldworkService.java
+++ b/src/main/java/uy/com/bay/utiles/data/service/FieldworkService.java
@@ -1,12 +1,16 @@
 package uy.com.bay.utiles.data.service;
 
+import org.hibernate.Hibernate;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uy.com.bay.utiles.data.Fieldwork;
 import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.data.repository.FieldworkRepository;
+import uy.com.bay.utiles.entities.Budget;
+import uy.com.bay.utiles.entities.BudgetEntry;
 
 import java.util.List;
 import java.util.Optional;
@@ -38,6 +42,32 @@ public class FieldworkService {
 
     public Page<Fieldwork> list(Pageable pageable, Specification<Fieldwork> filter) {
         return repository.findAll(filter, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Fieldwork> listWithBudget(Pageable pageable, Specification<Fieldwork> filter) {
+        Page<Fieldwork> page = repository.findAll(filter, pageable);
+        for (Fieldwork fw : page.getContent()) {
+            initializeBudget(fw);
+        }
+        return page;
+    }
+
+    private void initializeBudget(Fieldwork fw) {
+        if (fw.getBudgetEntry() == null || fw.getBudgetEntry().getBudget() == null) {
+            return;
+        }
+        Budget budget = fw.getBudgetEntry().getBudget();
+        Hibernate.initialize(budget.getEntries());
+        for (BudgetEntry entry : budget.getEntries()) {
+            Hibernate.initialize(entry.getExtras());
+            Hibernate.initialize(entry.getExpenseRequests());
+            Hibernate.initialize(entry.getFieldworks());
+            Hibernate.initialize(entry.getOdooCosts());
+            for (Fieldwork inner : entry.getFieldworks()) {
+                Hibernate.initialize(inner.getCompletedByMonth());
+            }
+        }
     }
 
     public int count() {

--- a/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
+++ b/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
@@ -132,7 +132,7 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 		grid.addColumn(fw -> formatCurrency(getActualCost(fw))).setHeader("Costo actual").setAutoWidth(true);
 
 		grid.setItems(query -> fieldworkService
-				.list(VaadinSpringDataHelpers.toSpringPageRequest(query), buildSpecification()).stream());
+				.listWithBudget(VaadinSpringDataHelpers.toSpringPageRequest(query), buildSpecification()).stream());
 		grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
 		grid.setSizeFull();
 
@@ -429,7 +429,8 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 		try {
 			StreamResource sr = new StreamResource("solicitudes-de-campo.xlsx", () -> {
 				try {
-					List<Fieldwork> data = fieldworkService.list(Pageable.unpaged(), buildSpecification()).getContent();
+					List<Fieldwork> data = fieldworkService.listWithBudget(Pageable.unpaged(), buildSpecification())
+							.getContent();
 					return buildExcel(data);
 				} catch (IOException ex) {
 					Notification.show("Error al generar el archivo Excel.", 3000, Notification.Position.TOP_CENTER);


### PR DESCRIPTION
## Summary
Las columnas "Costo presupuestado" y "Costo actual" agregadas en #296 disparan `LazyInitializationException` al renderizar el grid: `Budget.getSpent()` recorre los `entries` (eager) y para cada uno llama `BudgetEntry.getSpent()`, que itera las colecciones lazy `extras`, `expenseRequests`, `fieldworks` y `odooCosts` cuando la sesión Hibernate ya está cerrada.

## Fix
- Nuevo método `FieldworkService.listWithBudget(Pageable, Specification)` con `@Transactional(readOnly = true)` que inicializa las colecciones lazy de cada `BudgetEntry` con `Hibernate.initialize(...)` antes de devolver la página.
- `FieldworksView` ahora usa `listWithBudget(...)` tanto para el grid como para el export a Excel.

## Test plan
- [ ] Abrir la vista "Solicitudes de campo" y verificar que el grid carga sin errores.
- [ ] Verificar que las columnas "Costo presupuestado" y "Costo actual" muestran valores.
- [ ] Cambiar filtros y confirmar que el grid se refresca correctamente.
- [ ] Presionar "Exportar" y abrir el `.xlsx` resultante.

https://claude.ai/code/session_01WcxjEWxBqja5JJtJRaCS4n

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcxjEWxBqja5JJtJRaCS4n)_