### PR TITLE
Add null/blank validation for AI responses and transcriptions

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/SupervisionTaskProcessorService.java
+++ b/src/main/java/uy/com/bay/utiles/services/SupervisionTaskProcessorService.java
@@ -103,6 +103,10 @@ public class SupervisionTaskProcessorService {
 
 			// Transcripción
 			String transcription = openAiService.transcribeAudioTotal(audioFile);
+			if (transcription == null || transcription.isBlank()) {
+				throw new IllegalStateException(
+						"La transcripción del audio devolvió un resultado vacío para la tarea " + task.getId());
+			}
 			task.setOutput(prettyPrint(transcription));
 
 			// Segmentos diarize
@@ -133,6 +137,11 @@ public class SupervisionTaskProcessorService {
 			task.setFullPrompt(formattedPrompt);
 
 			String response = callChatClientWithRetry(formattedPrompt);
+
+			if (response == null || response.isBlank()) {
+				throw new IllegalStateException(
+						"La evaluación AI devolvió una respuesta vacía para la tarea " + task.getId());
+			}
 
 			task.setEvaluationOutput(prettyPrint(response));
 
@@ -282,6 +291,9 @@ public class SupervisionTaskProcessorService {
 	}
 
 	public String prettyPrint(String json) throws Exception {
+		if (json == null || json.isBlank()) {
+			return json;
+		}
 		ObjectMapper mapper = new ObjectMapper();
 		Object jsonObject = mapper.readValue(json, Object.class);
 		ObjectWriter writer = mapper.writerWithDefaultPrettyPrinter();


### PR DESCRIPTION
## Summary
This PR adds defensive null and blank string validation checks for critical AI-generated responses in the supervision task processing pipeline to prevent downstream errors and provide clearer error messages.

## Key Changes
- **Transcription validation**: Added null/blank check after audio transcription to ensure valid output before processing
- **AI evaluation validation**: Added null/blank check after chat client response to catch empty AI evaluations early
- **JSON pretty-print safety**: Added null/blank guard in `prettyPrint()` method to handle edge cases gracefully and prevent JSON parsing errors

## Implementation Details
- All validations throw `IllegalStateException` with descriptive messages that include the task ID for easier debugging
- The `prettyPrint()` method now returns the input as-is if it's null or blank, avoiding unnecessary processing and potential exceptions
- These checks are placed immediately after external service calls (OpenAI transcription and chat client) to fail fast with meaningful error context

https://claude.ai/code/session_015LRYDun8jiZRkDqSgiAy6P