### PR TITLE
Reintentar transcripción ante errores 504/5xx y 429 de OpenAI

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/OpenAiService.java
+++ b/src/main/java/uy/com/bay/utiles/services/OpenAiService.java
@@ -27,6 +27,8 @@ import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
@@ -73,7 +75,9 @@ public class OpenAiService {
 	}
 
 	protected String callApi(byte[] bytes, String filename) {
-		int maxRetries = 3;
+		int maxRetries = 5;
+		long baseBackoffMs = 5_000L;
+		long maxBackoffMs = 120_000L;
 		for (int attempt = 1; attempt <= maxRetries; attempt++) {
 			try {
 				RestTemplate restTemplate = buildRestTemplate();
@@ -104,19 +108,56 @@ public class OpenAiService {
 
 				return response.getBody();
 			} catch (ResourceAccessException e) {
-				logger.warn("API call failed (attempt {}/{}): {}", attempt, maxRetries, e.getMessage());
+				// Errores transitorios a nivel de red/socket (timeouts de lectura, conexión)
+				logger.warn("API call failed - network error (attempt {}/{}): {}", attempt, maxRetries, e.getMessage());
 				if (attempt == maxRetries) {
 					throw e;
 				}
-				try {
-					Thread.sleep(1000L * attempt);
-				} catch (InterruptedException ie) {
-					Thread.currentThread().interrupt();
+				sleepBeforeRetry(backoffMs(baseBackoffMs, maxBackoffMs, attempt));
+			} catch (HttpServerErrorException | HttpClientErrorException.TooManyRequests e) {
+				// 5xx (incluye 504 Gateway Timeout) y 429 Too Many Requests son reintentables
+				logger.warn("API call failed - server returned {} (attempt {}/{}): {}", e.getStatusCode(), attempt,
+						maxRetries, e.getMessage());
+				if (attempt == maxRetries) {
 					throw e;
 				}
+				long retryAfterMs = parseRetryAfterMs(e.getResponseHeaders());
+				long backoff = retryAfterMs > 0 ? Math.min(retryAfterMs, maxBackoffMs)
+						: backoffMs(baseBackoffMs, maxBackoffMs, attempt);
+				sleepBeforeRetry(backoff);
 			}
 		}
 		throw new RuntimeException("API call failed after retries");
+	}
+
+	private static long backoffMs(long baseMs, long maxMs, int attempt) {
+		long backoff = baseMs * (1L << (attempt - 1)); // exponencial: base, 2x, 4x, ...
+		return Math.min(backoff, maxMs);
+	}
+
+	private static long parseRetryAfterMs(HttpHeaders headers) {
+		if (headers == null) {
+			return -1L;
+		}
+		String retryAfter = headers.getFirst(HttpHeaders.RETRY_AFTER);
+		if (retryAfter == null || retryAfter.isBlank()) {
+			return -1L;
+		}
+		try {
+			return Long.parseLong(retryAfter.trim()) * 1000L;
+		} catch (NumberFormatException ignored) {
+			// El header puede venir como fecha HTTP; en ese caso usamos el backoff por defecto
+			return -1L;
+		}
+	}
+
+	private static void sleepBeforeRetry(long millis) {
+		try {
+			Thread.sleep(millis);
+		} catch (InterruptedException ie) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("Interrumpido durante reintentos al servicio de transcripción", ie);
+		}
 	}
 
 	public String transcribeAudioTotal(AudioFile audioFile) throws Exception {


### PR DESCRIPTION
## Problema

La transcripción fallaba con un **504 Gateway Timeout** del endpoint `/v1/audio/transcriptions` de OpenAI. El bucle de reintentos en `OpenAiService.callApi` solo capturaba `ResourceAccessException` (errores de red del lado cliente: timeouts de conexión/lectura). Un 504 llega como una respuesta HTTP real, que `RestTemplate` expone como `HttpServerErrorException$GatewayTimeout`, por lo que no se reintentaba y se propagaba de inmediato — aunque la propia respuesta de OpenAI lo marca como `"retryable": true` con `"retry_after": 120`.

## Cambios (`OpenAiService.callApi`)

- Ahora también se reintenta ante **`HttpServerErrorException`** (todos los 5xx, incluido el 504) y **`HttpClientErrorException.TooManyRequests`** (429).
- **Backoff exponencial** (5s → 10s → 20s …, con tope de 120s) y se aumentó el máximo de reintentos de 3 a 5.
- Se respeta el header **`Retry-After`** cuando el servidor lo envía (con tope de 120s); si no, se usa el backoff exponencial.
- Los errores de red (`ResourceAccessException`) se siguen reintentando, ahora con el mismo esquema de backoff.

Se extrajeron los helpers `backoffMs`, `parseRetryAfterMs` y `sleepBeforeRetry` para mantener el bucle legible. La lógica está a nivel de `callApi`, por lo que cubre las rutas de transcripción de un solo envío, por chunks WAV y por chunks de bytes.

https://claude.ai/code/session_015LRYDun8jiZRkDqSgiAy6P

---
_Generated by [Claude Code](https://claude.ai/code/session_015LRYDun8jiZRkDqSgiAy6P)_