### PR TITLE
Add Meta campaign cost tracking and display

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/Fieldwork.java
+++ b/src/main/java/uy/com/bay/utiles/data/Fieldwork.java
@@ -49,6 +49,8 @@ public class Fieldwork extends AbstractEntity {
 	private String doobloId;
 	private String alchemerId;
 
+	private Double campaignSpent;
+
 	@ElementCollection(fetch = FetchType.EAGER)
 	@CollectionTable(name = "fieldwork_completed_by_month", joinColumns = @JoinColumn(name = "fieldwork_id"))
 	@MapKeyColumn(name = "month")
@@ -173,5 +175,13 @@ public class Fieldwork extends AbstractEntity {
 
 	public void setCompletedByMonth(Map<Date, Integer> completedByMonth) {
 		this.completedByMonth = completedByMonth;
+	}
+
+	public Double getCampaignSpent() {
+		return campaignSpent;
+	}
+
+	public void setCampaignSpent(Double campaignSpent) {
+		this.campaignSpent = campaignSpent;
 	}
 }

--- a/src/main/java/uy/com/bay/utiles/data/repository/FieldworkRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/FieldworkRepository.java
@@ -32,4 +32,6 @@ public interface FieldworkRepository extends JpaRepository<Fieldwork, Long>, Jpa
 			@Param("startDate") LocalDate startDate);
 
 	List<Fieldwork> findAllByInitPlannedDateAfterAndAlchemerIdIsNotNull(LocalDate date);
+
+	List<Fieldwork> findAllByStudy_NameContainingIgnoreCase(String fragment);
 }

--- a/src/main/java/uy/com/bay/utiles/tasks/MetaCampaignCostUpdater.java
+++ b/src/main/java/uy/com/bay/utiles/tasks/MetaCampaignCostUpdater.java
@@ -1,0 +1,137 @@
+package uy.com.bay.utiles.tasks;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.annotation.PostConstruct;
+import uy.com.bay.utiles.data.Fieldwork;
+import uy.com.bay.utiles.data.repository.FieldworkRepository;
+import uy.com.bay.utiles.data.service.FieldworkService;
+
+@Component
+public class MetaCampaignCostUpdater {
+
+	private static final Logger logger = LoggerFactory.getLogger(MetaCampaignCostUpdater.class);
+
+	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+	private final FieldworkRepository fieldworkRepository;
+	private final FieldworkService fieldworkService;
+	private final RestTemplate restTemplate;
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Value("${meta.campaign.id}")
+	private String campaignId;
+
+	@Value("${meta.access.token}")
+	private String accessToken;
+
+	public MetaCampaignCostUpdater(FieldworkRepository fieldworkRepository, FieldworkService fieldworkService,
+			RestTemplateBuilder restTemplateBuilder) {
+		this.fieldworkRepository = fieldworkRepository;
+		this.fieldworkService = fieldworkService;
+		this.restTemplate = restTemplateBuilder.setConnectTimeout(java.time.Duration.ofSeconds(30))
+				.setReadTimeout(java.time.Duration.ofSeconds(60)).build();
+	}
+
+	@PostConstruct
+	public void init() {
+		logger.info("[SCHED] MetaCampaignCostUpdater bean initialized");
+	}
+
+	@Scheduled(cron = "0 0 4 * * *")
+	@Transactional
+	public void updateMetaCampaignCosts() {
+		logger.info("Starting MetaCampaignCostUpdater...");
+
+		LocalDate today = LocalDate.now();
+		String dateEnd = today.format(DATE_FORMATTER);
+		String dateInit = today.minusYears(2).format(DATE_FORMATTER);
+
+		String timeRange = String.format("{\"since\":\"%s\",\"until\":\"%s\"}", dateInit, dateEnd);
+
+		URI uri = UriComponentsBuilder
+				.fromHttpUrl("https://graph.facebook.com/v21.0/" + campaignId + "/campaigns")
+				.queryParam("access_token", accessToken)
+				.queryParam("fields", "name,status,insights{spend}")
+				.queryParam("time_range", timeRange)
+				.build()
+				.encode(StandardCharsets.UTF_8)
+				.toUri();
+
+		try {
+			String response = restTemplate.getForObject(uri, String.class);
+			if (response == null) {
+				logger.warn("MetaCampaignCostUpdater: empty response from Meta API");
+				return;
+			}
+
+			JsonNode root = objectMapper.readTree(response);
+			JsonNode data = root.path("data");
+			if (!data.isArray()) {
+				logger.warn("MetaCampaignCostUpdater: response does not contain a data array");
+				return;
+			}
+
+			for (JsonNode campaign : data) {
+				String name = campaign.path("name").asText("");
+				JsonNode insightsData = campaign.path("insights").path("data");
+				if (!insightsData.isArray() || insightsData.size() == 0) {
+					continue;
+				}
+				JsonNode spendNode = insightsData.get(0).path("spend");
+				if (spendNode.isMissingNode() || spendNode.isNull()) {
+					continue;
+				}
+
+				double spend;
+				try {
+					spend = Double.parseDouble(spendNode.asText("0"));
+				} catch (NumberFormatException e) {
+					logger.warn("MetaCampaignCostUpdater: could not parse spend value '{}'", spendNode.asText());
+					continue;
+				}
+
+				if (spend == 0d) {
+					continue;
+				}
+				if (name == null || !name.startsWith("S00")) {
+					continue;
+				}
+
+				int spaceIdx = name.indexOf(' ');
+				String fragment = spaceIdx > 0 ? name.substring(0, spaceIdx) : name;
+
+				List<Fieldwork> matches = fieldworkRepository.findAllByStudy_NameContainingIgnoreCase(fragment);
+				if (matches.isEmpty()) {
+					logger.info("MetaCampaignCostUpdater: no fieldwork found for fragment '{}'", fragment);
+					continue;
+				}
+				for (Fieldwork fw : matches) {
+					fw.setCampaignSpent(spend);
+					fieldworkService.save(fw);
+				}
+			}
+		} catch (Exception e) {
+			logger.error("MetaCampaignCostUpdater: error while updating Meta campaign costs", e);
+		}
+
+		logger.info("MetaCampaignCostUpdater finished.");
+	}
+}

--- a/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
+++ b/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
@@ -76,6 +76,7 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 
 	private IntegerField goalQuantity;
 	private IntegerField completed;
+	private TextField campaignSpent;
 	private TextArea obs;
 	private ComboBox<FieldworkStatus> status;
 	private ComboBox<FieldworkType> type;
@@ -135,6 +136,7 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 		grid.addColumn("type").setHeader("Tipo").setAutoWidth(true);
 		grid.addColumn(fw -> formatCurrency(getBudgetedCost(fw))).setHeader("Costo presupuestado").setAutoWidth(true);
 		grid.addColumn(fw -> formatCurrency(getActualCost(fw))).setHeader("Costo actual").setAutoWidth(true);
+		grid.addColumn(fw -> formatCurrency(fw.getCampaignSpent())).setHeader("Gasto Meta").setAutoWidth(true);
 
 		grid.setItems(query -> fieldworkService
 				.listWithBudget(VaadinSpringDataHelpers.toSpringPageRequest(query), buildSpecification()).stream());
@@ -156,6 +158,7 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 		binder.forField(doobloId).bind(Fieldwork::getDoobloId, Fieldwork::setDoobloId);
 		binder.forField(alchemerId).bind(Fieldwork::getAlchemerId, Fieldwork::setAlchemerId);
 		binder.forField(budgetEntry).bind(Fieldwork::getBudgetEntry, Fieldwork::setBudgetEntry);
+		binder.forField(campaignSpent).bind(fw -> formatCurrency(fw.getCampaignSpent()), null);
 		binder.bindInstanceFields(this);
 
 		cancel.addClickListener(e -> {
@@ -293,6 +296,8 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 		goalQuantity = new IntegerField("Cantidad Objetivo");
 		completed = new IntegerField("Completas");
 		completed.setReadOnly(true);
+		campaignSpent = new TextField("Gasto Meta");
+		campaignSpent.setReadOnly(true);
 		obs = new TextArea("Observaciones");
 		status = new ComboBox<>("Estado");
 		status.setItems(FieldworkStatus.values());
@@ -300,7 +305,7 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 		type.setItems(FieldworkType.values());
 
 		formLayout.add(study, budgetEntry, doobloId, alchemerId, initPlannedDate, endPlannedDate, goalQuantity,
-				completed, status, type, obs);
+				completed, campaignSpent, status, type, obs);
 
 		editorDiv.add(formLayout);
 		createButtonLayout(this.editorLayoutDiv);
@@ -454,7 +459,8 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 
 	private ByteArrayInputStream buildExcel(List<Fieldwork> data) throws IOException {
 		String[] columns = { "Estudio", "Observaciones", "Fecha Planificada Inicio", "Fecha Planificada Fin",
-				"Cantidad Objetivo", "Completadas", "Estado", "Tipo", "Costo presupuestado", "Costo actual" };
+				"Cantidad Objetivo", "Completadas", "Estado", "Tipo", "Costo presupuestado", "Costo actual",
+				"Gasto Meta" };
 		DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
 
 		try (Workbook workbook = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
@@ -515,6 +521,12 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 					row.createCell(9).setCellValue(actual);
 				} else {
 					row.createCell(9).setCellValue("");
+				}
+				Double campaignSpentValue = fw.getCampaignSpent();
+				if (campaignSpentValue != null) {
+					row.createCell(10).setCellValue(campaignSpentValue);
+				} else {
+					row.createCell(10).setCellValue("");
 				}
 			}
 


### PR DESCRIPTION
## Summary
This PR adds functionality to automatically fetch and track Meta (Facebook) advertising campaign spending costs, integrating them into the fieldwork management system.

## Key Changes
- **New scheduled task**: Added `MetaCampaignCostUpdater` component that runs daily at 4 AM to fetch campaign spending data from Meta's Graph API
  - Queries campaigns from the past 2 years
  - Parses campaign names (format: S00xxx) and matches them to fieldwork records
  - Updates fieldwork records with the corresponding campaign spending amounts
  
- **Data model enhancement**: Added `campaignSpent` field to the `Fieldwork` entity to store Meta campaign spending costs

- **UI updates**: 
  - Added "Gasto Meta" (Meta Spending) column to the fieldworks grid display
  - Added read-only `campaignSpent` field to the fieldwork editor form
  - Included campaign spending in Excel export functionality

- **Repository enhancement**: Added `findAllByStudy_NameContainingIgnoreCase()` query method to support campaign-to-fieldwork matching

## Implementation Details
- The scheduler uses a 2-year lookback window to capture historical spending data
- Campaign names must start with "S00" prefix to be processed
- Spending values are parsed as doubles with error handling for malformed data
- Zero-value spending entries are skipped to avoid unnecessary updates
- The task includes comprehensive logging for monitoring and debugging
- All database operations are wrapped in a single transaction for consistency

https://claude.ai/code/session_01Su2v1LYTdUS4hhk3ifWpuT