### PR TITLE
Refactor Meta campaign costs tracking to Study level

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/Fieldwork.java
+++ b/src/main/java/uy/com/bay/utiles/data/Fieldwork.java
@@ -49,8 +49,6 @@ public class Fieldwork extends AbstractEntity {
 	private String doobloId;
 	private String alchemerId;
 
-	private Double campaignSpent;
-
 	@ElementCollection(fetch = FetchType.EAGER)
 	@CollectionTable(name = "fieldwork_completed_by_month", joinColumns = @JoinColumn(name = "fieldwork_id"))
 	@MapKeyColumn(name = "month")
@@ -175,13 +173,5 @@ public class Fieldwork extends AbstractEntity {
 
 	public void setCompletedByMonth(Map<Date, Integer> completedByMonth) {
 		this.completedByMonth = completedByMonth;
-	}
-
-	public Double getCampaignSpent() {
-		return campaignSpent;
-	}
-
-	public void setCampaignSpent(Double campaignSpent) {
-		this.campaignSpent = campaignSpent;
 	}
 }

--- a/src/main/java/uy/com/bay/utiles/data/Study.java
+++ b/src/main/java/uy/com/bay/utiles/data/Study.java
@@ -1,11 +1,21 @@
 package uy.com.bay.utiles.data;
 
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.MapKeyTemporal;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.TemporalType;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import uy.com.bay.utiles.entities.Budget;
 
 @Entity
@@ -25,6 +35,13 @@ public class Study extends AbstractEntity {
 	private String clientName;
 	private double expectedRevenue;
 	private String area;
+
+	@ElementCollection(fetch = FetchType.EAGER)
+	@CollectionTable(name = "study_meta_cost_by_date", joinColumns = @JoinColumn(name = "study_id"))
+	@MapKeyColumn(name = "cost_date")
+	@MapKeyTemporal(TemporalType.DATE)
+	@Column(name = "cost")
+	private Map<Date, Double> metaCostByDate = new HashMap<>();
 
 	public boolean isShowSurveyor() {
 		return showSurveyor;
@@ -115,5 +132,13 @@ public class Study extends AbstractEntity {
 
 	public void setArea(String area) {
 		this.area = area;
+	}
+
+	public Map<Date, Double> getMetaCostByDate() {
+		return metaCostByDate;
+	}
+
+	public void setMetaCostByDate(Map<Date, Double> metaCostByDate) {
+		this.metaCostByDate = metaCostByDate;
 	}
 }

--- a/src/main/java/uy/com/bay/utiles/data/StudyRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/StudyRepository.java
@@ -2,13 +2,11 @@ package uy.com.bay.utiles.data;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import uy.com.bay.utiles.entities.Budget;
 
-import java.util.Optional;
-
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,5 +17,12 @@ public interface StudyRepository extends JpaRepository<Study, Long>, JpaSpecific
     List<Study> findAllByShowSurveyor(boolean showSurveyor);
 
     Optional<Study> findByOdooId(String odooId);
+
+    Optional<Study> findFirstByNameStartingWith(String prefix);
+
+    Optional<Study> findByName(String name);
+
+    @Query("SELECT DISTINCT s FROM Study s JOIN s.metaCostByDate m WHERE KEY(m) BETWEEN :from AND :to")
+    List<Study> findAllWithMetaCostBetween(@Param("from") Date from, @Param("to") Date to);
 
 }

--- a/src/main/java/uy/com/bay/utiles/data/repository/FieldworkRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/FieldworkRepository.java
@@ -32,6 +32,4 @@ public interface FieldworkRepository extends JpaRepository<Fieldwork, Long>, Jpa
 			@Param("startDate") LocalDate startDate);
 
 	List<Fieldwork> findAllByInitPlannedDateAfterAndAlchemerIdIsNotNull(LocalDate date);
-
-	List<Fieldwork> findAllByStudy_NameContainingIgnoreCase(String fragment);
 }

--- a/src/main/java/uy/com/bay/utiles/services/StudyService.java
+++ b/src/main/java/uy/com/bay/utiles/services/StudyService.java
@@ -1,5 +1,6 @@
 package uy.com.bay.utiles.services;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -65,5 +66,17 @@ public class StudyService {
 
     public Optional<Study> findByOdooId(String odooId) {
         return repository.findByOdooId(odooId);
+    }
+
+    public Optional<Study> findFirstByNameStartingWith(String prefix) {
+        return repository.findFirstByNameStartingWith(prefix);
+    }
+
+    public Optional<Study> findByName(String name) {
+        return repository.findByName(name);
+    }
+
+    public List<Study> findAllWithMetaCostBetween(Date from, Date to) {
+        return repository.findAllWithMetaCostBetween(from, to);
     }
 }

--- a/src/main/java/uy/com/bay/utiles/tasks/MetaCampaignCostUpdater.java
+++ b/src/main/java/uy/com/bay/utiles/tasks/MetaCampaignCostUpdater.java
@@ -3,8 +3,12 @@ package uy.com.bay.utiles.tasks;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,9 +24,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.annotation.PostConstruct;
-import uy.com.bay.utiles.data.Fieldwork;
-import uy.com.bay.utiles.data.repository.FieldworkRepository;
-import uy.com.bay.utiles.data.service.FieldworkService;
+import uy.com.bay.utiles.data.Study;
+import uy.com.bay.utiles.data.StudyRepository;
 
 @Component
 public class MetaCampaignCostUpdater {
@@ -30,9 +33,9 @@ public class MetaCampaignCostUpdater {
 	private static final Logger logger = LoggerFactory.getLogger(MetaCampaignCostUpdater.class);
 
 	private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+	private static final String CENTRAL_STUDY_NAME = "S0000- CENTRAL";
 
-	private final FieldworkRepository fieldworkRepository;
-	private final FieldworkService fieldworkService;
+	private final StudyRepository studyRepository;
 	private final RestTemplate restTemplate;
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -42,10 +45,8 @@ public class MetaCampaignCostUpdater {
 	@Value("${meta.access.token}")
 	private String accessToken;
 
-	public MetaCampaignCostUpdater(FieldworkRepository fieldworkRepository, FieldworkService fieldworkService,
-			RestTemplateBuilder restTemplateBuilder) {
-		this.fieldworkRepository = fieldworkRepository;
-		this.fieldworkService = fieldworkService;
+	public MetaCampaignCostUpdater(StudyRepository studyRepository, RestTemplateBuilder restTemplateBuilder) {
+		this.studyRepository = studyRepository;
 		this.restTemplate = restTemplateBuilder.setConnectTimeout(java.time.Duration.ofSeconds(30))
 				.setReadTimeout(java.time.Duration.ofSeconds(60)).build();
 	}
@@ -73,6 +74,7 @@ public class MetaCampaignCostUpdater {
 
 		String nextUrl = uri.toString();
 		int pageCount = 0;
+		Map<String, Double> aggregated = new HashMap<>();
 		try {
 			while (nextUrl != null) {
 				pageCount++;
@@ -90,7 +92,10 @@ public class MetaCampaignCostUpdater {
 					break;
 				}
 
-				processCampaigns(data);
+				Map<String, Double> pageResult = processCampaigns(data);
+				for (Map.Entry<String, Double> entry : pageResult.entrySet()) {
+					aggregated.merge(entry.getKey(), entry.getValue(), Double::sum);
+				}
 
 				JsonNode nextNode = root.path("paging").path("next");
 				if (nextNode.isMissingNode() || nextNode.isNull()) {
@@ -106,10 +111,13 @@ public class MetaCampaignCostUpdater {
 			logger.error("MetaCampaignCostUpdater: error while updating Meta campaign costs", e);
 		}
 
+		applyAggregatedSpendToStudies(aggregated);
+
 		logger.info("MetaCampaignCostUpdater finished after {} page(s).", pageCount);
 	}
 
-	private void processCampaigns(JsonNode data) {
+	private Map<String, Double> processCampaigns(JsonNode data) {
+		Map<String, Double> result = new HashMap<>();
 		for (JsonNode campaign : data) {
 
 			String campaignName = campaign.path("campaign_name").asText("");
@@ -135,15 +143,42 @@ public class MetaCampaignCostUpdater {
 
 			int spaceIdx = campaignName.indexOf(' ');
 			String fragment = spaceIdx > 0 ? campaignName.substring(0, spaceIdx) : campaignName;
-			List<Fieldwork> matches = fieldworkRepository.findAllByStudy_NameContainingIgnoreCase(fragment);
-			if (matches.isEmpty()) {
-				logger.info("MetaCampaignCostUpdater: no fieldwork found for fragment '{}'", fragment);
-				continue;
+			result.merge(fragment, spend, Double::sum);
+		}
+		return result;
+	}
+
+	private void applyAggregatedSpendToStudies(Map<String, Double> aggregated) {
+		Date today = Date.from(LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant());
+		for (Map.Entry<String, Double> entry : aggregated.entrySet()) {
+			String fragment = entry.getKey();
+			Double totalSpend = entry.getValue();
+
+			Optional<Study> studyOpt = studyRepository.findFirstByNameStartingWith(fragment);
+			if (studyOpt.isEmpty()) {
+				studyOpt = studyRepository.findByName(CENTRAL_STUDY_NAME);
+				if (studyOpt.isEmpty()) {
+					Study central = new Study();
+					central.setName(CENTRAL_STUDY_NAME);
+					studyOpt = Optional.of(studyRepository.save(central));
+				}
 			}
-			for (Fieldwork fw : matches) {
-				fw.setCampaignSpent(spend);
-				fieldworkService.save(fw);
+
+			Study study = studyOpt.get();
+			double previousSum = 0d;
+			if (study.getMetaCostByDate() != null) {
+				for (Double v : study.getMetaCostByDate().values()) {
+					if (v != null) {
+						previousSum += v;
+					}
+				}
 			}
+			double delta = totalSpend - previousSum;
+			if (study.getMetaCostByDate() == null) {
+				study.setMetaCostByDate(new HashMap<>());
+			}
+			study.getMetaCostByDate().merge(today, delta, Double::sum);
+			studyRepository.save(study);
 		}
 	}
 }

--- a/src/main/java/uy/com/bay/utiles/views/MainLayout.java
+++ b/src/main/java/uy/com/bay/utiles/views/MainLayout.java
@@ -266,6 +266,13 @@ public class MainLayout extends AppLayout {
 		toolsItem.addItem(supervisionTasksItem);
 		nav.addItem(toolsItem);
 
+		SideNavItem metaItem = new SideNavItem("Meta");
+		metaItem.setPrefixComponent(new Icon("vaadin", "money"));
+		SideNavItem listarCostosItem = new SideNavItem("Listar costos", "meta-costs");
+		listarCostosItem.setPrefixComponent(new Icon("vaadin", "list"));
+		metaItem.addItem(listarCostosItem);
+		nav.addItem(metaItem);
+
 		SideNavItem whatsappItem = new SideNavItem("Whatsapp");
 		whatsappItem.setPrefixComponent(new Icon("vaadin", "comments"));
 		SideNavItem sendMessagesItem = new SideNavItem("Enviar mensajes", "whatsapp-sender");

--- a/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
+++ b/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
@@ -3,12 +3,9 @@ package uy.com.bay.utiles.views.fieldworks;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.Currency;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -79,7 +76,6 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 
 	private IntegerField goalQuantity;
 	private IntegerField completed;
-	private TextField campaignSpent;
 	private TextArea obs;
 	private ComboBox<FieldworkStatus> status;
 	private ComboBox<FieldworkType> type;
@@ -99,7 +95,6 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 	private Fieldwork fieldwork;
 	private Div editorLayoutDiv;
 	private final NumberFormat currencyFormat;
-	private final NumberFormat usCurrencyFormat;
 	private final FieldworkService fieldworkService;
 	private final StudyService studyService;
 	private final BudgetEntryService budgetEntryService;
@@ -114,17 +109,7 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 		currencyFormat = NumberFormat.getCurrencyInstance(new Locale("es", "UY"));
 		currencyFormat.setMinimumFractionDigits(0);
 		currencyFormat.setMaximumFractionDigits(0);
-		
-		usCurrencyFormat =  NumberFormat.getCurrencyInstance(Locale.US);
-		usCurrencyFormat.setCurrency(Currency.getInstance("USD"));
 
-	    DecimalFormat decimalFormat = (DecimalFormat) usCurrencyFormat;
-	    DecimalFormatSymbols symbols = decimalFormat.getDecimalFormatSymbols();
-	    symbols.setCurrencySymbol("USD ");
-	    decimalFormat.setDecimalFormatSymbols(symbols);
-	    
-		usCurrencyFormat.setMinimumFractionDigits(0);
-		usCurrencyFormat.setMaximumFractionDigits(0);
 		addClassNames("fieldworks-view");
 		setHeight("100%");
 
@@ -151,7 +136,6 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 		grid.addColumn("type").setHeader("Tipo").setAutoWidth(true);
 		grid.addColumn(fw -> formatCurrency(getBudgetedCost(fw))).setHeader("Costo presupuestado").setAutoWidth(true);
 		grid.addColumn(fw -> formatCurrency(getActualCost(fw))).setHeader("Costo actual").setAutoWidth(true);
-		grid.addColumn(fw -> formatUSCurrency(fw.getCampaignSpent())).setHeader("Gasto Meta").setAutoWidth(true);
 
 		grid.setItems(query -> fieldworkService
 				.listWithBudget(VaadinSpringDataHelpers.toSpringPageRequest(query), buildSpecification()).stream());
@@ -173,7 +157,6 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 		binder.forField(doobloId).bind(Fieldwork::getDoobloId, Fieldwork::setDoobloId);
 		binder.forField(alchemerId).bind(Fieldwork::getAlchemerId, Fieldwork::setAlchemerId);
 		binder.forField(budgetEntry).bind(Fieldwork::getBudgetEntry, Fieldwork::setBudgetEntry);
-		binder.forField(campaignSpent).bind(fw -> formatCurrency(fw.getCampaignSpent()), null);
 		binder.bindInstanceFields(this);
 
 		cancel.addClickListener(e -> {
@@ -311,8 +294,6 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 		goalQuantity = new IntegerField("Cantidad Objetivo");
 		completed = new IntegerField("Completas");
 		completed.setReadOnly(true);
-		campaignSpent = new TextField("Gasto Meta");
-		campaignSpent.setReadOnly(true);
 		obs = new TextArea("Observaciones");
 		status = new ComboBox<>("Estado");
 		status.setItems(FieldworkStatus.values());
@@ -320,7 +301,7 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 		type.setItems(FieldworkType.values());
 
 		formLayout.add(study, budgetEntry, doobloId, alchemerId, initPlannedDate, endPlannedDate, goalQuantity,
-				completed, campaignSpent, status, type, obs);
+				completed, status, type, obs);
 
 		editorDiv.add(formLayout);
 		createButtonLayout(this.editorLayoutDiv);
@@ -450,13 +431,6 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 		return currencyFormat.format(value);
 	}
 
-	private String formatUSCurrency(Double value) {
-		if (value == null) {
-			return "";
-		}
-		return usCurrencyFormat.format(value);
-	}
-
 	private void exportToExcel() {
 		try {
 			StreamResource sr = new StreamResource("solicitudes-de-campo.xlsx", () -> {
@@ -481,8 +455,7 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 
 	private ByteArrayInputStream buildExcel(List<Fieldwork> data) throws IOException {
 		String[] columns = { "Estudio", "Observaciones", "Fecha Planificada Inicio", "Fecha Planificada Fin",
-				"Cantidad Objetivo", "Completadas", "Estado", "Tipo", "Costo presupuestado", "Costo actual",
-				"Gasto Meta" };
+				"Cantidad Objetivo", "Completadas", "Estado", "Tipo", "Costo presupuestado", "Costo actual" };
 		DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
 
 		try (Workbook workbook = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
@@ -543,12 +516,6 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 					row.createCell(9).setCellValue(actual);
 				} else {
 					row.createCell(9).setCellValue("");
-				}
-				Double campaignSpentValue = fw.getCampaignSpent();
-				if (campaignSpentValue != null) {
-					row.createCell(10).setCellValue(campaignSpentValue);
-				} else {
-					row.createCell(10).setCellValue("");
 				}
 			}
 

--- a/src/main/java/uy/com/bay/utiles/views/meta/MetaCostsView.java
+++ b/src/main/java/uy/com/bay/utiles/views/meta/MetaCostsView.java
@@ -1,0 +1,182 @@
+package uy.com.bay.utiles.views.meta;
+
+import java.text.NumberFormat;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.GridVariant;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H3;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+import jakarta.annotation.security.RolesAllowed;
+import uy.com.bay.utiles.data.Study;
+import uy.com.bay.utiles.services.StudyService;
+
+@PageTitle("Costos Meta")
+@Route("meta-costs")
+@RolesAllowed("ADMIN")
+public class MetaCostsView extends Div {
+
+	private final StudyService studyService;
+	private final DatePicker fromDate;
+	private final DatePicker toDate;
+	private final Grid<StudyMetaCostRow> grid = new Grid<>(StudyMetaCostRow.class, false);
+	private final NumberFormat currencyFormat;
+
+	public MetaCostsView(StudyService studyService) {
+		this.studyService = studyService;
+		currencyFormat = NumberFormat.getCurrencyInstance(new Locale("es", "UY"));
+		currencyFormat.setMinimumFractionDigits(0);
+		currencyFormat.setMaximumFractionDigits(0);
+
+		addClassNames("meta-costs-view");
+		setSizeFull();
+
+		int currentYear = LocalDate.now().getYear();
+		fromDate = new DatePicker("Desde");
+		fromDate.setValue(LocalDate.of(currentYear, 1, 1));
+		toDate = new DatePicker("Hasta");
+		toDate.setValue(LocalDate.of(currentYear, 12, 31));
+
+		fromDate.addValueChangeListener(e -> refreshGrid());
+		toDate.addValueChangeListener(e -> refreshGrid());
+
+		HorizontalLayout filterLayout = new HorizontalLayout(fromDate, toDate);
+		filterLayout.setAlignItems(com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment.END);
+
+		grid.addColumn(StudyMetaCostRow::getStudyName).setHeader("Estudio").setAutoWidth(true);
+		grid.addColumn(row -> formatCurrency(row.getTotalCost())).setHeader("Costo").setAutoWidth(true);
+		grid.addComponentColumn(row -> {
+			Button detailButton = new Button(new Icon(VaadinIcon.SEARCH));
+			detailButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+			detailButton.addClickListener(e -> openDetailDialog(row));
+			return detailButton;
+		}).setHeader("Ver detalle").setAutoWidth(true);
+		grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
+		grid.setSizeFull();
+
+		VerticalLayout wrapper = new VerticalLayout(filterLayout, grid);
+		wrapper.setSizeFull();
+		wrapper.setFlexGrow(1, grid);
+		add(wrapper);
+
+		refreshGrid();
+	}
+
+	private void refreshGrid() {
+		grid.setItems(loadRows());
+	}
+
+	private List<StudyMetaCostRow> loadRows() {
+		LocalDate from = fromDate.getValue();
+		LocalDate to = toDate.getValue();
+		if (from == null || to == null) {
+			return List.of();
+		}
+		Date fromDateValue = Date.from(from.atStartOfDay(ZoneId.systemDefault()).toInstant());
+		Date toDateValue = Date.from(to.atStartOfDay(ZoneId.systemDefault()).toInstant());
+
+		List<Study> studies = studyService.findAllWithMetaCostBetween(fromDateValue, toDateValue);
+		List<StudyMetaCostRow> rows = new ArrayList<>();
+		for (Study study : studies) {
+			Map<Date, Double> costs = study.getMetaCostByDate();
+			if (costs == null || costs.isEmpty()) {
+				continue;
+			}
+			double total = 0d;
+			List<Map.Entry<Date, Double>> filteredEntries = new ArrayList<>();
+			for (Map.Entry<Date, Double> entry : costs.entrySet()) {
+				Date key = entry.getKey();
+				Double value = entry.getValue();
+				if (key == null || value == null) {
+					continue;
+				}
+				if (!key.before(fromDateValue) && !key.after(toDateValue)) {
+					total += value;
+					filteredEntries.add(entry);
+				}
+			}
+			if (filteredEntries.isEmpty()) {
+				continue;
+			}
+			rows.add(new StudyMetaCostRow(study, total, filteredEntries));
+		}
+		rows.sort(Comparator.comparing(StudyMetaCostRow::getStudyName, String.CASE_INSENSITIVE_ORDER));
+		return rows;
+	}
+
+	private void openDetailDialog(StudyMetaCostRow row) {
+		Dialog dialog = new Dialog();
+		dialog.setHeaderTitle("Detalle de costos - " + row.getStudyName());
+		dialog.setWidth("520px");
+
+		Grid<Map.Entry<Date, Double>> detailGrid = new Grid<>();
+		DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+		detailGrid.addColumn(entry -> entry.getKey() == null ? ""
+				: entry.getKey().toInstant().atZone(ZoneId.systemDefault()).toLocalDate().format(dateFormatter))
+				.setHeader("Fecha").setAutoWidth(true);
+		detailGrid.addColumn(entry -> formatCurrency(entry.getValue())).setHeader("Costo").setAutoWidth(true);
+
+		List<Map.Entry<Date, Double>> entries = new ArrayList<>(row.getEntries());
+		entries.sort(Comparator.comparing(Map.Entry::getKey));
+		detailGrid.setItems(entries);
+		detailGrid.setAllRowsVisible(true);
+
+		VerticalLayout content = new VerticalLayout(new H3(row.getStudyName()), detailGrid);
+		content.setPadding(false);
+		dialog.add(content);
+
+		Button close = new Button("Cerrar", e -> dialog.close());
+		dialog.getFooter().add(close);
+		dialog.open();
+	}
+
+	private String formatCurrency(Double value) {
+		if (value == null) {
+			return "";
+		}
+		return currencyFormat.format(value);
+	}
+
+	private static class StudyMetaCostRow {
+		private final Study study;
+		private final double totalCost;
+		private final List<Map.Entry<Date, Double>> entries;
+
+		StudyMetaCostRow(Study study, double totalCost, List<Map.Entry<Date, Double>> entries) {
+			this.study = study;
+			this.totalCost = totalCost;
+			this.entries = entries;
+		}
+
+		public String getStudyName() {
+			return study.getName();
+		}
+
+		public double getTotalCost() {
+			return totalCost;
+		}
+
+		public List<Map.Entry<Date, Double>> getEntries() {
+			return entries;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
This PR refactors the Meta campaign cost tracking system to store costs at the Study level instead of the Fieldwork level, and introduces a new view to display aggregated Meta costs by study.

## Key Changes

- **New MetaCostsView**: Added a new admin-only view (`meta-costs` route) that displays Meta campaign costs aggregated by study with date range filtering and detailed cost breakdowns
- **Study entity enhancement**: Added `metaCostByDate` map field to store Meta costs by date, with proper JPA annotations for persistence
- **MetaCampaignCostUpdater refactoring**: 
  - Changed from updating individual Fieldwork records to aggregating costs at the Study level
  - Now matches campaign fragments to Studies using `findFirstByNameStartingWith()`
  - Falls back to a "S0000- CENTRAL" study for unmatched campaigns
  - Stores daily cost deltas in the Study's `metaCostByDate` map
- **StudyRepository enhancements**: Added query methods:
  - `findFirstByNameStartingWith()` for campaign fragment matching
  - `findByName()` for exact study lookup
  - `findAllWithMetaCostBetween()` for date range queries
- **StudyService updates**: Added corresponding service methods for new repository queries
- **FieldworksView cleanup**: 
  - Removed `campaignSpent` field and related UI components
  - Removed "Gasto Meta" column from grid and Excel export
  - Removed US currency formatting logic
- **Navigation update**: Added new "Meta" section to main layout with "Listar costos" menu item
- **Fieldwork entity cleanup**: Removed `campaignSpent` field

## Implementation Details

- Meta costs are now stored as a map of dates to cost amounts at the Study level, allowing historical tracking
- The cost updater aggregates all campaign spending for a given day and stores the delta from previous totals
- Unmatched campaigns are consolidated into a central study to prevent data loss
- The new view provides date range filtering (defaults to current year) and drill-down capability to see daily cost breakdowns

https://claude.ai/code/session_01TLvnnr9Ltxq7nnLwrcj7PT