### PR TITLE
Fix UnsupportedOperationException en MetaCostsView por java.sql.Date

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/meta/MetaCostsView.java
+++ b/src/main/java/uy/com/bay/utiles/views/meta/MetaCostsView.java
@@ -131,7 +131,8 @@ public class MetaCostsView extends Div {
 		Grid<Map.Entry<Date, Double>> detailGrid = new Grid<>();
 		DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
 		detailGrid.addColumn(entry -> entry.getKey() == null ? ""
-				: entry.getKey().toInstant().atZone(ZoneId.systemDefault()).toLocalDate().format(dateFormatter))
+				: java.time.Instant.ofEpochMilli(entry.getKey().getTime()).atZone(ZoneId.systemDefault()).toLocalDate()
+						.format(dateFormatter))
 				.setHeader("Fecha").setAutoWidth(true);
 		detailGrid.addColumn(entry -> formatCurrency(entry.getValue())).setHeader("Costo").setAutoWidth(true);
 


### PR DESCRIPTION
## Summary
- JPA devuelve `java.sql.Date` como key de `Study.metaCostByDate`, y `java.sql.Date.toInstant()` lanza `UnsupportedOperationException`.
- Construyo el `Instant` con `Instant.ofEpochMilli(entry.getKey().getTime())` en el render del detalle de costos.

## Test plan
- [ ] Abrir vista "Listar costos" del menú "Meta".
- [ ] Pulsar la lupa de una fila con costos para abrir el diálogo de detalle y verificar que la columna "Fecha" se renderiza sin errores en el log.

https://claude.ai/code/session_01TLvnnr9Ltxq7nnLwrcj7PT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLvnnr9Ltxq7nnLwrcj7PT)_