### PR TITLE
Add Job Orders and Providers management features

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/JobOrder.java
+++ b/src/main/java/uy/com/bay/utiles/data/JobOrder.java
@@ -1,0 +1,55 @@
+package uy.com.bay.utiles.data;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class JobOrder extends AbstractEntity {
+
+    private LocalDate created;
+
+    @ManyToOne
+    @JoinColumn(name = "study_id")
+    private Study study;
+
+    private Integer hours;
+
+    @ManyToOne
+    @JoinColumn(name = "provider_id")
+    private Provider provider;
+
+    public LocalDate getCreated() {
+        return created;
+    }
+
+    public void setCreated(LocalDate created) {
+        this.created = created;
+    }
+
+    public Study getStudy() {
+        return study;
+    }
+
+    public void setStudy(Study study) {
+        this.study = study;
+    }
+
+    public Integer getHours() {
+        return hours;
+    }
+
+    public void setHours(Integer hours) {
+        this.hours = hours;
+    }
+
+    public Provider getProvider() {
+        return provider;
+    }
+
+    public void setProvider(Provider provider) {
+        this.provider = provider;
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/data/Provider.java
+++ b/src/main/java/uy/com/bay/utiles/data/Provider.java
@@ -1,0 +1,40 @@
+package uy.com.bay.utiles.data;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+
+@Entity
+public class Provider extends AbstractEntity {
+
+    private String name;
+
+    private Integer monthlyCapacity;
+
+    @Enumerated(EnumType.STRING)
+    private ProviderType type;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getMonthlyCapacity() {
+        return monthlyCapacity;
+    }
+
+    public void setMonthlyCapacity(Integer monthlyCapacity) {
+        this.monthlyCapacity = monthlyCapacity;
+    }
+
+    public ProviderType getType() {
+        return type;
+    }
+
+    public void setType(ProviderType type) {
+        this.type = type;
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/data/ProviderType.java
+++ b/src/main/java/uy/com/bay/utiles/data/ProviderType.java
@@ -1,0 +1,6 @@
+package uy.com.bay.utiles.data;
+
+public enum ProviderType {
+    HORA,
+    PROYECTO
+}

--- a/src/main/java/uy/com/bay/utiles/data/repository/JobOrderRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/JobOrderRepository.java
@@ -1,0 +1,8 @@
+package uy.com.bay.utiles.data.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import uy.com.bay.utiles.data.JobOrder;
+
+public interface JobOrderRepository extends JpaRepository<JobOrder, Long>, JpaSpecificationExecutor<JobOrder> {
+}

--- a/src/main/java/uy/com/bay/utiles/data/repository/ProviderRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/ProviderRepository.java
@@ -1,0 +1,8 @@
+package uy.com.bay.utiles.data.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import uy.com.bay.utiles.data.Provider;
+
+public interface ProviderRepository extends JpaRepository<Provider, Long>, JpaSpecificationExecutor<Provider> {
+}

--- a/src/main/java/uy/com/bay/utiles/services/JobOrderService.java
+++ b/src/main/java/uy/com/bay/utiles/services/JobOrderService.java
@@ -1,0 +1,49 @@
+package uy.com.bay.utiles.services;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+import uy.com.bay.utiles.data.JobOrder;
+import uy.com.bay.utiles.data.repository.JobOrderRepository;
+
+@Service
+public class JobOrderService {
+
+    private final JobOrderRepository repository;
+
+    public JobOrderService(JobOrderRepository repository) {
+        this.repository = repository;
+    }
+
+    public Optional<JobOrder> get(Long id) {
+        return repository.findById(id);
+    }
+
+    public JobOrder save(JobOrder entity) {
+        return repository.save(entity);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+
+    public Page<JobOrder> list(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+    public Page<JobOrder> list(Pageable pageable, Specification<JobOrder> filter) {
+        return repository.findAll(filter, pageable);
+    }
+
+    public int count() {
+        return (int) repository.count();
+    }
+
+    public List<JobOrder> findAll() {
+        return repository.findAll();
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/services/ProviderService.java
+++ b/src/main/java/uy/com/bay/utiles/services/ProviderService.java
@@ -1,0 +1,49 @@
+package uy.com.bay.utiles.services;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+import uy.com.bay.utiles.data.Provider;
+import uy.com.bay.utiles.data.repository.ProviderRepository;
+
+@Service
+public class ProviderService {
+
+    private final ProviderRepository repository;
+
+    public ProviderService(ProviderRepository repository) {
+        this.repository = repository;
+    }
+
+    public Optional<Provider> get(Long id) {
+        return repository.findById(id);
+    }
+
+    public Provider save(Provider entity) {
+        return repository.save(entity);
+    }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
+
+    public Page<Provider> list(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+    public Page<Provider> list(Pageable pageable, Specification<Provider> filter) {
+        return repository.findAll(filter, pageable);
+    }
+
+    public int count() {
+        return (int) repository.count();
+    }
+
+    public List<Provider> findAll() {
+        return repository.findAll();
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/views/MainLayout.java
+++ b/src/main/java/uy/com/bay/utiles/views/MainLayout.java
@@ -273,6 +273,16 @@ public class MainLayout extends AppLayout {
 		metaItem.addItem(listarCostosItem);
 		nav.addItem(metaItem);
 
+		SideNavItem workOrdersItem = new SideNavItem("Ordenes de trabajo");
+		workOrdersItem.setPrefixComponent(new Icon("vaadin", "clipboard-text"));
+		SideNavItem providersItem = new SideNavItem("Proveedores", "providers");
+		providersItem.setPrefixComponent(new Icon("vaadin", "factory"));
+		workOrdersItem.addItem(providersItem);
+		SideNavItem listarJobOrdersItem = new SideNavItem("Listar", "joborders");
+		listarJobOrdersItem.setPrefixComponent(new Icon("vaadin", "list"));
+		workOrdersItem.addItem(listarJobOrdersItem);
+		nav.addItem(workOrdersItem);
+
 		SideNavItem whatsappItem = new SideNavItem("Whatsapp");
 		whatsappItem.setPrefixComponent(new Icon("vaadin", "comments"));
 		SideNavItem sendMessagesItem = new SideNavItem("Enviar mensajes", "whatsapp-sender");

--- a/src/main/java/uy/com/bay/utiles/views/joborders/JobOrdersView.java
+++ b/src/main/java/uy/com/bay/utiles/views/joborders/JobOrdersView.java
@@ -1,0 +1,275 @@
+package uy.com.bay.utiles.views.joborders;
+
+import java.util.Optional;
+
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.confirmdialog.ConfirmDialog;
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.GridVariant;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.notification.Notification.Position;
+import com.vaadin.flow.component.notification.NotificationVariant;
+import com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.splitlayout.SplitLayout;
+import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.data.binder.BeanValidationBinder;
+import com.vaadin.flow.data.binder.ValidationException;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.spring.data.VaadinSpringDataHelpers;
+
+import jakarta.annotation.security.RolesAllowed;
+import uy.com.bay.utiles.data.JobOrder;
+import uy.com.bay.utiles.data.Provider;
+import uy.com.bay.utiles.data.Study;
+import uy.com.bay.utiles.services.JobOrderService;
+import uy.com.bay.utiles.services.ProviderService;
+import uy.com.bay.utiles.services.StudyService;
+
+@PageTitle("Órdenes de Trabajo")
+@Route("joborders/:jobOrderID?/:action?(edit)")
+@RolesAllowed("ADMIN")
+public class JobOrdersView extends Div implements BeforeEnterObserver {
+
+    private final String JOBORDER_ID = "jobOrderID";
+    private final String JOBORDER_EDIT_ROUTE_TEMPLATE = "joborders/%s/edit";
+
+    private final Grid<JobOrder> grid = new Grid<>(JobOrder.class, false);
+
+    private DatePicker created;
+    private ComboBox<Study> study;
+    private IntegerField hours;
+    private ComboBox<Provider> provider;
+
+    private Button addButton;
+
+    private final Button cancel = new Button("Cerrar");
+    private final Button save = new Button("Guardar");
+    private Button deleteButton;
+
+    private final BeanValidationBinder<JobOrder> binder;
+
+    private JobOrder jobOrder;
+    private Div editorLayoutDiv;
+
+    private final JobOrderService jobOrderService;
+    private final StudyService studyService;
+    private final ProviderService providerService;
+
+    public JobOrdersView(JobOrderService jobOrderService, StudyService studyService, ProviderService providerService) {
+        this.jobOrderService = jobOrderService;
+        this.studyService = studyService;
+        this.providerService = providerService;
+        this.binder = new BeanValidationBinder<>(JobOrder.class);
+        addClassNames("joborders-view");
+
+        SplitLayout splitLayout = new SplitLayout();
+
+        addButton = new Button("Crear");
+        addButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+
+        deleteButton = new Button("Borrar");
+        deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR);
+        deleteButton.setEnabled(false);
+
+        setupButtonListeners();
+
+        createGridLayout(splitLayout);
+        createEditorLayout(splitLayout);
+
+        add(splitLayout);
+
+        grid.addColumn("created").setHeader("Fecha").setAutoWidth(true);
+        grid.addColumn(jo -> jo.getStudy() != null ? jo.getStudy().getName() : "").setHeader("Estudio")
+                .setAutoWidth(true);
+        grid.addColumn("hours").setHeader("Horas").setAutoWidth(true);
+        grid.addColumn(jo -> jo.getProvider() != null ? jo.getProvider().getName() : "").setHeader("Proveedor")
+                .setAutoWidth(true);
+
+        grid.setItems(query -> jobOrderService.list(VaadinSpringDataHelpers.toSpringPageRequest(query)).stream());
+        grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
+
+        grid.asSingleSelect().addValueChangeListener(event -> {
+            if (event.getValue() != null) {
+                UI.getCurrent().navigate(String.format(JOBORDER_EDIT_ROUTE_TEMPLATE, event.getValue().getId()));
+            } else {
+                clearForm();
+                UI.getCurrent().navigate(JobOrdersView.class);
+            }
+        });
+
+        binder.bindInstanceFields(this);
+    }
+
+    private void setupButtonListeners() {
+        addButton.addClickListener(e -> {
+            clearForm();
+            this.jobOrder = new JobOrder();
+            binder.readBean(this.jobOrder);
+            if (this.editorLayoutDiv != null) {
+                this.editorLayoutDiv.setVisible(true);
+            }
+            if (this.deleteButton != null) {
+                this.deleteButton.setEnabled(false);
+            }
+        });
+
+        deleteButton.addClickListener(e -> {
+            if (this.jobOrder != null && this.jobOrder.getId() != null) {
+                ConfirmDialog dialog = new ConfirmDialog();
+                dialog.setHeader("Confirmar Borrado");
+                dialog.setText(
+                        "¿Estás seguro de que quieres borrar esta orden de trabajo? Esta acción no se puede deshacer.");
+                dialog.setCancelable(true);
+                dialog.setConfirmText("Borrar");
+                dialog.setConfirmButtonTheme("error primary");
+
+                dialog.addConfirmListener(event -> {
+                    try {
+                        jobOrderService.delete(this.jobOrder.getId());
+                        clearForm();
+                        refreshGrid();
+                        Notification.show("Orden de trabajo borrada exitosamente.", 3000,
+                                Notification.Position.BOTTOM_START);
+                        UI.getCurrent().navigate(JobOrdersView.class);
+                    } catch (Exception ex) {
+                        Notification
+                                .show("Error al borrar la orden de trabajo: " + ex.getMessage(), 5000,
+                                        Notification.Position.MIDDLE)
+                                .addThemeVariants(NotificationVariant.LUMO_ERROR);
+                    }
+                });
+                dialog.open();
+            }
+        });
+
+        cancel.addClickListener(e -> {
+            clearForm();
+            refreshGrid();
+            UI.getCurrent().navigate(JobOrdersView.class);
+        });
+
+        save.addClickListener(e -> {
+            try {
+                if (this.jobOrder == null) {
+                    this.jobOrder = new JobOrder();
+                }
+                binder.writeBean(this.jobOrder);
+                jobOrderService.save(this.jobOrder);
+                clearForm();
+                refreshGrid();
+                Notification.show("Orden de trabajo guardada.");
+                UI.getCurrent().navigate(JobOrdersView.class);
+            } catch (ObjectOptimisticLockingFailureException exception) {
+                Notification n = Notification.show(
+                        "Error al guardar la orden de trabajo. Alguien más actualizó el registro mientras realizaba cambios.");
+                n.setPosition(Position.MIDDLE);
+                n.addThemeVariants(NotificationVariant.LUMO_ERROR);
+            } catch (ValidationException validationException) {
+                Notification.show("Fallo al guardar. Verifique que todos los valores son válidos.");
+            }
+        });
+    }
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        Optional<Long> jobOrderId = event.getRouteParameters().get(JOBORDER_ID).map(Long::parseLong);
+        if (jobOrderId.isPresent()) {
+            Optional<JobOrder> jobOrderFromBackend = jobOrderService.get(jobOrderId.get());
+            if (jobOrderFromBackend.isPresent()) {
+                populateForm(jobOrderFromBackend.get());
+            } else {
+                Notification.show(
+                        String.format("La orden de trabajo solicitada no fue encontrada, ID = %s", jobOrderId.get()),
+                        3000, Notification.Position.BOTTOM_START);
+                refreshGrid();
+                event.forwardTo(JobOrdersView.class);
+            }
+        }
+    }
+
+    private void createEditorLayout(SplitLayout splitLayout) {
+        this.editorLayoutDiv = new Div();
+        this.editorLayoutDiv.setClassName("editor-layout");
+
+        Div editorDiv = new Div();
+        editorDiv.setClassName("editor");
+        editorLayoutDiv.add(editorDiv);
+
+        FormLayout formLayout = new FormLayout();
+        created = new DatePicker("Fecha");
+        study = new ComboBox<>("Estudio");
+        study.setItems(studyService.findAll());
+        study.setItemLabelGenerator(Study::getName);
+        hours = new IntegerField("Horas");
+        provider = new ComboBox<>("Proveedor");
+        provider.setItems(providerService.findAll());
+        provider.setItemLabelGenerator(Provider::getName);
+
+        formLayout.add(created, study, hours, provider);
+
+        editorDiv.add(formLayout);
+        createButtonLayout(this.editorLayoutDiv);
+
+        splitLayout.addToSecondary(this.editorLayoutDiv);
+        this.editorLayoutDiv.setVisible(false);
+    }
+
+    private void createButtonLayout(Div editorLayoutDiv) {
+        HorizontalLayout buttonLayout = new HorizontalLayout();
+        buttonLayout.setClassName("button-layout");
+        cancel.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+        save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+
+        buttonLayout.add(save, deleteButton, cancel);
+        editorLayoutDiv.add(buttonLayout);
+    }
+
+    private void createGridLayout(SplitLayout splitLayout) {
+        Div wrapper = new Div();
+        wrapper.setClassName("grid-wrapper");
+        wrapper.setWidthFull();
+
+        H2 title = new H2("Órdenes de Trabajo");
+        HorizontalLayout titleLayout = new HorizontalLayout(title, addButton);
+        titleLayout.setWidthFull();
+        titleLayout.setAlignItems(Alignment.BASELINE);
+        titleLayout.setFlexGrow(1, title);
+
+        wrapper.add(titleLayout);
+        wrapper.add(grid);
+        splitLayout.addToPrimary(wrapper);
+    }
+
+    private void refreshGrid() {
+        grid.select(null);
+        grid.getDataProvider().refreshAll();
+    }
+
+    private void clearForm() {
+        populateForm(null);
+    }
+
+    private void populateForm(JobOrder value) {
+        this.jobOrder = value;
+        binder.readBean(this.jobOrder);
+        if (this.editorLayoutDiv != null) {
+            this.editorLayoutDiv.setVisible(value != null);
+        }
+        if (this.deleteButton != null) {
+            this.deleteButton.setEnabled(value != null && value.getId() != null);
+        }
+    }
+}

--- a/src/main/java/uy/com/bay/utiles/views/providers/ProvidersView.java
+++ b/src/main/java/uy/com/bay/utiles/views/providers/ProvidersView.java
@@ -1,0 +1,258 @@
+package uy.com.bay.utiles.views.providers;
+
+import java.util.Optional;
+
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.confirmdialog.ConfirmDialog;
+import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.GridVariant;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.notification.Notification.Position;
+import com.vaadin.flow.component.notification.NotificationVariant;
+import com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.splitlayout.SplitLayout;
+import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.binder.BeanValidationBinder;
+import com.vaadin.flow.data.binder.ValidationException;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.spring.data.VaadinSpringDataHelpers;
+
+import jakarta.annotation.security.RolesAllowed;
+import uy.com.bay.utiles.data.Provider;
+import uy.com.bay.utiles.data.ProviderType;
+import uy.com.bay.utiles.services.ProviderService;
+
+@PageTitle("Proveedores")
+@Route("providers/:providerID?/:action?(edit)")
+@RolesAllowed("ADMIN")
+public class ProvidersView extends Div implements BeforeEnterObserver {
+
+    private final String PROVIDER_ID = "providerID";
+    private final String PROVIDER_EDIT_ROUTE_TEMPLATE = "providers/%s/edit";
+
+    private final Grid<Provider> grid = new Grid<>(Provider.class, false);
+
+    private TextField name;
+    private IntegerField monthlyCapacity;
+    private ComboBox<ProviderType> type;
+
+    private Button addButton;
+
+    private final Button cancel = new Button("Cerrar");
+    private final Button save = new Button("Guardar");
+    private Button deleteButton;
+
+    private final BeanValidationBinder<Provider> binder;
+
+    private Provider provider;
+    private Div editorLayoutDiv;
+
+    private final ProviderService providerService;
+
+    public ProvidersView(ProviderService providerService) {
+        this.providerService = providerService;
+        this.binder = new BeanValidationBinder<>(Provider.class);
+        addClassNames("providers-view");
+
+        SplitLayout splitLayout = new SplitLayout();
+
+        addButton = new Button("Crear");
+        addButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+
+        deleteButton = new Button("Borrar");
+        deleteButton.addThemeVariants(ButtonVariant.LUMO_ERROR);
+        deleteButton.setEnabled(false);
+
+        setupButtonListeners();
+
+        createGridLayout(splitLayout);
+        createEditorLayout(splitLayout);
+
+        add(splitLayout);
+
+        grid.addColumn("name").setHeader("Nombre").setAutoWidth(true);
+        grid.addColumn("monthlyCapacity").setHeader("Capacidad Mensual").setAutoWidth(true);
+        grid.addColumn("type").setHeader("Tipo").setAutoWidth(true);
+
+        grid.setItems(query -> providerService.list(VaadinSpringDataHelpers.toSpringPageRequest(query)).stream());
+        grid.addThemeVariants(GridVariant.LUMO_NO_BORDER);
+
+        grid.asSingleSelect().addValueChangeListener(event -> {
+            if (event.getValue() != null) {
+                UI.getCurrent().navigate(String.format(PROVIDER_EDIT_ROUTE_TEMPLATE, event.getValue().getId()));
+            } else {
+                clearForm();
+                UI.getCurrent().navigate(ProvidersView.class);
+            }
+        });
+
+        binder.bindInstanceFields(this);
+    }
+
+    private void setupButtonListeners() {
+        addButton.addClickListener(e -> {
+            clearForm();
+            this.provider = new Provider();
+            binder.readBean(this.provider);
+            if (this.editorLayoutDiv != null) {
+                this.editorLayoutDiv.setVisible(true);
+            }
+            if (this.deleteButton != null) {
+                this.deleteButton.setEnabled(false);
+            }
+        });
+
+        deleteButton.addClickListener(e -> {
+            if (this.provider != null && this.provider.getId() != null) {
+                ConfirmDialog dialog = new ConfirmDialog();
+                dialog.setHeader("Confirmar Borrado");
+                dialog.setText(
+                        "¿Estás seguro de que quieres borrar este proveedor? Esta acción no se puede deshacer.");
+                dialog.setCancelable(true);
+                dialog.setConfirmText("Borrar");
+                dialog.setConfirmButtonTheme("error primary");
+
+                dialog.addConfirmListener(event -> {
+                    try {
+                        providerService.delete(this.provider.getId());
+                        clearForm();
+                        refreshGrid();
+                        Notification.show("Proveedor borrado exitosamente.", 3000, Notification.Position.BOTTOM_START);
+                        UI.getCurrent().navigate(ProvidersView.class);
+                    } catch (Exception ex) {
+                        Notification
+                                .show("Error al borrar el proveedor: " + ex.getMessage(), 5000,
+                                        Notification.Position.MIDDLE)
+                                .addThemeVariants(NotificationVariant.LUMO_ERROR);
+                    }
+                });
+                dialog.open();
+            }
+        });
+
+        cancel.addClickListener(e -> {
+            clearForm();
+            refreshGrid();
+            UI.getCurrent().navigate(ProvidersView.class);
+        });
+
+        save.addClickListener(e -> {
+            try {
+                if (this.provider == null) {
+                    this.provider = new Provider();
+                }
+                binder.writeBean(this.provider);
+                providerService.save(this.provider);
+                clearForm();
+                refreshGrid();
+                Notification.show("Proveedor guardado.");
+                UI.getCurrent().navigate(ProvidersView.class);
+            } catch (ObjectOptimisticLockingFailureException exception) {
+                Notification n = Notification.show(
+                        "Error al guardar el proveedor. Alguien más actualizó el registro mientras realizaba cambios.");
+                n.setPosition(Position.MIDDLE);
+                n.addThemeVariants(NotificationVariant.LUMO_ERROR);
+            } catch (ValidationException validationException) {
+                Notification.show("Fallo al guardar. Verifique que todos los valores son válidos.");
+            }
+        });
+    }
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        Optional<Long> providerId = event.getRouteParameters().get(PROVIDER_ID).map(Long::parseLong);
+        if (providerId.isPresent()) {
+            Optional<Provider> providerFromBackend = providerService.get(providerId.get());
+            if (providerFromBackend.isPresent()) {
+                populateForm(providerFromBackend.get());
+            } else {
+                Notification.show(
+                        String.format("El proveedor solicitado no fue encontrado, ID = %s", providerId.get()), 3000,
+                        Notification.Position.BOTTOM_START);
+                refreshGrid();
+                event.forwardTo(ProvidersView.class);
+            }
+        }
+    }
+
+    private void createEditorLayout(SplitLayout splitLayout) {
+        this.editorLayoutDiv = new Div();
+        this.editorLayoutDiv.setClassName("editor-layout");
+
+        Div editorDiv = new Div();
+        editorDiv.setClassName("editor");
+        editorLayoutDiv.add(editorDiv);
+
+        FormLayout formLayout = new FormLayout();
+        name = new TextField("Nombre");
+        monthlyCapacity = new IntegerField("Capacidad Mensual");
+        type = new ComboBox<>("Tipo");
+        type.setItems(ProviderType.values());
+        formLayout.add(name, monthlyCapacity, type);
+
+        editorDiv.add(formLayout);
+        createButtonLayout(this.editorLayoutDiv);
+
+        splitLayout.addToSecondary(this.editorLayoutDiv);
+        this.editorLayoutDiv.setVisible(false);
+    }
+
+    private void createButtonLayout(Div editorLayoutDiv) {
+        HorizontalLayout buttonLayout = new HorizontalLayout();
+        buttonLayout.setClassName("button-layout");
+        cancel.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+        save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+
+        buttonLayout.add(save, deleteButton, cancel);
+        editorLayoutDiv.add(buttonLayout);
+    }
+
+    private void createGridLayout(SplitLayout splitLayout) {
+        Div wrapper = new Div();
+        wrapper.setClassName("grid-wrapper");
+        wrapper.setWidthFull();
+
+        H2 title = new H2("Proveedores");
+        HorizontalLayout titleLayout = new HorizontalLayout(title, addButton);
+        titleLayout.setWidthFull();
+        titleLayout.setAlignItems(Alignment.BASELINE);
+        titleLayout.setFlexGrow(1, title);
+
+        wrapper.add(titleLayout);
+        wrapper.add(grid);
+        splitLayout.addToPrimary(wrapper);
+    }
+
+    private void refreshGrid() {
+        grid.select(null);
+        grid.getDataProvider().refreshAll();
+    }
+
+    private void clearForm() {
+        populateForm(null);
+    }
+
+    private void populateForm(Provider value) {
+        this.provider = value;
+        binder.readBean(this.provider);
+        if (this.editorLayoutDiv != null) {
+            this.editorLayoutDiv.setVisible(value != null);
+        }
+        if (this.deleteButton != null) {
+            this.deleteButton.setEnabled(value != null && value.getId() != null);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR introduces comprehensive management features for Job Orders and Providers, including data models, repositories, services, and Vaadin-based UI views with full CRUD operations.

## Key Changes

### Data Models
- **Provider** entity with name, monthly capacity, and type (HORA/PROYECTO enum)
- **JobOrder** entity with creation date, associated study, hours, and provider reference
- **ProviderType** enum supporting hourly and project-based provider types

### Repositories
- `ProviderRepository` - JPA repository with specification executor support for Provider entities
- `JobOrderRepository` - JPA repository with specification executor support for JobOrder entities

### Services
- `ProviderService` - Service layer for Provider CRUD operations, pagination, and filtering
- `JobOrderService` - Service layer for JobOrder CRUD operations, pagination, and filtering

### UI Views
- **ProvidersView** - Full-featured Vaadin view for managing providers with:
  - Grid display with name, monthly capacity, and type columns
  - Split layout with form editor for create/edit operations
  - Create, save, delete, and cancel operations
  - Confirmation dialog for delete actions
  - Optimistic locking and validation error handling
  - Role-based access control (@RolesAllowed("ADMIN"))

- **JobOrdersView** - Full-featured Vaadin view for managing job orders with:
  - Grid display with date, study, hours, and provider columns
  - Split layout with form editor for create/edit operations
  - ComboBox fields for Study and Provider selection
  - Create, save, delete, and cancel operations
  - Confirmation dialog for delete actions
  - Optimistic locking and validation error handling
  - Role-based access control (@RolesAllowed("ADMIN"))

### Navigation
- Updated MainLayout to include new navigation items for Providers and Job Orders management under a "Ordenes de trabajo" section

## Implementation Details
- Both views follow the same architectural pattern with split layouts, form binding using BeanValidationBinder, and consistent error handling
- Grid pagination is handled through Vaadin Spring Data helpers
- Navigation uses route parameters for edit operations (e.g., `joborders/:jobOrderID?/:action?(edit)`)
- User notifications provide feedback for successful operations and error conditions
- Delete operations require user confirmation to prevent accidental data loss

https://claude.ai/code/session_01AhAJ9fiQ9B4Jhc9R8kt7pM