### PR TITLE
Fix ProvidersView and JobOrdersView layout (missing CSS)

### DIFF
--- a/src/main/frontend/themes/Utiles/styles.css
+++ b/src/main/frontend/themes/Utiles/styles.css
@@ -6,6 +6,10 @@
 
 @import url('./views/useradmin-view.css');
 
+@import url('./views/providers-view.css');
+
+@import url('./views/joborders-view.css');
+
 html {
 	--lumo-shade-5pct: rgba(33, 33, 33, 0.05);
 	--lumo-shade-10pct: rgba(33, 33, 33, 0.1);

--- a/src/main/frontend/themes/Utiles/views/joborders-view.css
+++ b/src/main/frontend/themes/Utiles/views/joborders-view.css
@@ -1,0 +1,40 @@
+.joborders-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.joborders-view vaadin-split-layout {
+  width: 100%;
+  height: 100%;
+}
+
+.joborders-view vaadin-grid {
+  height: 100%;
+}
+
+.joborders-view .editor-layout {
+  display: flex;
+  flex-direction: column;
+  width: 400px;
+}
+
+.joborders-view .editor {
+  flex-grow: 1;
+  padding: var(--lumo-space-l);
+}
+
+.joborders-view .button-layout {
+  width: 100%;
+  flex-wrap: wrap;
+  background-color: var(--lumo-contrast-5pct);
+  padding-bottom: var(--lumo-space-s);
+  padding-top: var(--lumo-space-s);
+  padding-left: var(--lumo-space-l);
+  padding-right: var(--lumo-space-l);
+  gap: var(--lumo-space-m);
+}
+
+.joborders-view .grid-wrapper {
+  width: 100%;
+}

--- a/src/main/frontend/themes/Utiles/views/providers-view.css
+++ b/src/main/frontend/themes/Utiles/views/providers-view.css
@@ -1,0 +1,40 @@
+.providers-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.providers-view vaadin-split-layout {
+  width: 100%;
+  height: 100%;
+}
+
+.providers-view vaadin-grid {
+  height: 100%;
+}
+
+.providers-view .editor-layout {
+  display: flex;
+  flex-direction: column;
+  width: 400px;
+}
+
+.providers-view .editor {
+  flex-grow: 1;
+  padding: var(--lumo-space-l);
+}
+
+.providers-view .button-layout {
+  width: 100%;
+  flex-wrap: wrap;
+  background-color: var(--lumo-contrast-5pct);
+  padding-bottom: var(--lumo-space-s);
+  padding-top: var(--lumo-space-s);
+  padding-left: var(--lumo-space-l);
+  padding-right: var(--lumo-space-l);
+  gap: var(--lumo-space-m);
+}
+
+.providers-view .grid-wrapper {
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- Add `providers-view.css` and `joborders-view.css` mirroring `encuestadores-view.css` (split-layout full size + 400px editor panel).
- Register both stylesheets in `styles.css`.

## Why
Without these stylesheets the SplitLayout has no width/height constraints, so the editor panel collapses: the form rendered vertically below the grid in ProvidersView, and in JobOrdersView clicking **Crear** appeared to do nothing because the editor panel had no usable width.

## Test plan
- [ ] Open `/providers`, click **Crear** → editor opens on the right with form fields.
- [ ] Open `/joborders`, click **Crear** → editor opens on the right with form fields.
- [ ] Save / Borrar / Cerrar continue to work in both views.

https://claude.ai/code/session_01AhAJ9fiQ9B4Jhc9R8kt7pM

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhAJ9fiQ9B4Jhc9R8kt7pM)_