### PR TITLE
Add transactional expense report deletion with journal entry reversal

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/JournalEntryRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/JournalEntryRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
+import uy.com.bay.utiles.data.ExpenseReport;
 import uy.com.bay.utiles.data.JournalEntry;
 import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.data.Surveyor;
@@ -15,4 +16,6 @@ public interface JournalEntryRepository
 	List<JournalEntry> findAllBySurveyorOrderByDateAsc(Surveyor surveyor);
 
 	List<JournalEntry> findAllByStudyOrderByDateAsc(Study study);
+
+	List<JournalEntry> findAllByExpenseReport(ExpenseReport expenseReport);
 }

--- a/src/main/java/uy/com/bay/utiles/services/ExpenseReportService.java
+++ b/src/main/java/uy/com/bay/utiles/services/ExpenseReportService.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import uy.com.bay.utiles.data.ExpenseReport;
 import uy.com.bay.utiles.data.ExpenseReportDTO;
@@ -51,8 +52,34 @@ public class ExpenseReportService {
 		return repository.save(entity);
 	}
 
+	@Transactional
 	public void delete(Long id) {
+		Optional<ExpenseReport> reportOpt = repository.findById(id);
+		if (reportOpt.isPresent()) {
+			ExpenseReport report = reportOpt.get();
+			List<JournalEntry> entries = journalEntryRepository.findAllByExpenseReport(report);
+			for (JournalEntry entry : entries) {
+				reverseJournalEntry(entry);
+				journalEntryRepository.delete(entry);
+			}
+		}
 		repository.deleteById(id);
+	}
+
+	private void reverseJournalEntry(JournalEntry entry) {
+		Surveyor surveyor = entry.getSurveyor();
+		if (surveyor != null) {
+			surveyor.setBalance(surveyor.getBalance() + entry.getAmount());
+			surveyorRepository.save(surveyor);
+		}
+		ExpenseReport report = entry.getExpenseReport();
+		if (report != null && report.getConcept() != null && !report.getConcept().isRefund()) {
+			Study study = entry.getStudy();
+			if (study != null) {
+				study.setTotalReportedCost(study.getTotalReportedCost() - entry.getAmount());
+				studyRepository.save(study);
+			}
+		}
 	}
 
 	public Page<ExpenseReport> list(Pageable pageable) {


### PR DESCRIPTION
## Summary
Enhanced the expense report deletion functionality to properly handle related journal entries and reverse their financial impacts on surveyors and studies.

## Key Changes
- Added `@Transactional` annotation to the `delete()` method in `ExpenseReportService` to ensure data consistency
- Implemented comprehensive deletion logic that:
  - Retrieves all journal entries associated with the expense report being deleted
  - Reverses the financial impact of each journal entry before deletion
  - Deletes the journal entries from the database
  - Finally deletes the expense report itself
- Added new `reverseJournalEntry()` private method that:
  - Restores surveyor balance by adding back the journal entry amount
  - Decreases study's total reported cost (only for non-refund expense reports)
  - Persists the updated surveyor and study entities
- Added `findAllByExpenseReport()` query method to `JournalEntryRepository` to retrieve journal entries by expense report

## Notable Implementation Details
- The reversal logic includes null checks for surveyor, report concept, and study entities to handle edge cases safely
- Only non-refund expense reports trigger the study cost adjustment during reversal
- The transactional boundary ensures all operations (reversals and deletions) complete atomically

https://claude.ai/code/session_01M7veHEJTRBQ8DMpHBApXD6