### PR TITLE
Add job order generation from budget concepts with provider selection

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/JobOrder.java
+++ b/src/main/java/uy/com/bay/utiles/data/JobOrder.java
@@ -11,6 +11,10 @@ public class JobOrder extends AbstractEntity {
 
     private LocalDate created;
 
+    private LocalDate init;
+
+    private LocalDate end;
+
     @ManyToOne
     @JoinColumn(name = "study_id")
     private Study study;
@@ -27,6 +31,22 @@ public class JobOrder extends AbstractEntity {
 
     public void setCreated(LocalDate created) {
         this.created = created;
+    }
+
+    public LocalDate getInit() {
+        return init;
+    }
+
+    public void setInit(LocalDate init) {
+        this.init = init;
+    }
+
+    public LocalDate getEnd() {
+        return end;
+    }
+
+    public void setEnd(LocalDate end) {
+        this.end = end;
     }
 
     public Study getStudy() {

--- a/src/main/java/uy/com/bay/utiles/entities/BudgetConcept.java
+++ b/src/main/java/uy/com/bay/utiles/entities/BudgetConcept.java
@@ -13,6 +13,7 @@ public class BudgetConcept extends AbstractEntity {
     private String description;
     private String odooProductId;
     private boolean salaryCost;
+    private boolean generatesWorkOrder;
 
     @Enumerated(EnumType.STRING)
     private MatchType matchType;
@@ -55,5 +56,13 @@ public class BudgetConcept extends AbstractEntity {
 
     public void setSalaryCost(boolean salaryCost) {
         this.salaryCost = salaryCost;
+    }
+
+    public boolean isGeneratesWorkOrder() {
+        return generatesWorkOrder;
+    }
+
+    public void setGeneratesWorkOrder(boolean generatesWorkOrder) {
+        this.generatesWorkOrder = generatesWorkOrder;
     }
 }

--- a/src/main/java/uy/com/bay/utiles/entities/BudgetEntry.java
+++ b/src/main/java/uy/com/bay/utiles/entities/BudgetEntry.java
@@ -4,15 +4,18 @@ import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Set;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Transient;
 import uy.com.bay.utiles.data.AbstractEntity;
 import uy.com.bay.utiles.data.ExpenseRequest;
 import uy.com.bay.utiles.data.ExpenseStatus;
 import uy.com.bay.utiles.data.Fieldwork;
+import uy.com.bay.utiles.data.JobOrder;
 
 @Entity
 public class BudgetEntry extends AbstractEntity {
@@ -35,6 +38,10 @@ public class BudgetEntry extends AbstractEntity {
 	@ManyToOne
 	@JoinColumn(name = "budget_id")
 	private Budget budget;
+
+	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+	@JoinColumn(name = "job_order_id")
+	private JobOrder jobOrder;
 
 	@OneToMany(mappedBy = "budgetEntry")
 	private Set<Extra> extras = new HashSet<>();
@@ -127,6 +134,14 @@ public class BudgetEntry extends AbstractEntity {
 
 	public void setBudget(Budget budget) {
 		this.budget = budget;
+	}
+
+	public JobOrder getJobOrder() {
+		return jobOrder;
+	}
+
+	public void setJobOrder(JobOrder jobOrder) {
+		this.jobOrder = jobOrder;
 	}
 
 	public Set<Extra> getExtras() {

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.grid.FooterRow;
 import com.vaadin.flow.component.grid.Grid;
@@ -46,6 +47,8 @@ import com.vaadin.flow.shared.Registration;
 import uy.com.bay.utiles.data.ExpenseRequest;
 import uy.com.bay.utiles.data.ExpenseStatus;
 import uy.com.bay.utiles.data.Fieldwork;
+import uy.com.bay.utiles.data.JobOrder;
+import uy.com.bay.utiles.data.Provider;
 import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.data.service.FieldworkService;
 import uy.com.bay.utiles.entities.Budget;
@@ -59,6 +62,7 @@ import uy.com.bay.utiles.services.BudgetExporter;
 import uy.com.bay.utiles.services.BudgetService;
 import uy.com.bay.utiles.services.OdooCostService;
 import uy.com.bay.utiles.services.OdooService;
+import uy.com.bay.utiles.services.ProviderService;
 import uy.com.bay.utiles.services.StudyService;
 import uy.com.bay.utiles.tasks.DoobloSurveyRetriever;
 import uy.com.bay.utiles.views.gantt.BudgetEntryDetailsDialog;
@@ -88,10 +92,12 @@ public class BudgetForm extends VerticalLayout {
 	private final DoobloSurveyRetriever doobloSurveyRetriever;
 	private final OdooService odooService;
 	private final OdooCostService odooCostService;
+	private final ProviderService providerService;
 
 	public BudgetForm(StudyService studyService, BudgetConceptService budgetConceptService, BudgetService budgetService,
 			AlchemerSurveyResponseHelper alchemerSurveyResponseHelper, FieldworkService fieldworkService,
-			DoobloSurveyRetriever doobloSurveyRetriever, OdooService odooService, OdooCostService odooCostService) {
+			DoobloSurveyRetriever doobloSurveyRetriever, OdooService odooService, OdooCostService odooCostService,
+			ProviderService providerService) {
 		this.budgetConceptService = budgetConceptService;
 		this.budgetService = budgetService;
 		this.fieldworkService = fieldworkService;
@@ -99,6 +105,7 @@ public class BudgetForm extends VerticalLayout {
 		this.doobloSurveyRetriever = doobloSurveyRetriever;
 		this.odooService = odooService;
 		this.odooCostService = odooCostService;
+		this.providerService = providerService;
 		addClassName("budget-form");
 		binder.bindInstanceFields(this);
 		study.setItems(studyService.listAll());
@@ -307,6 +314,16 @@ public class BudgetForm extends VerticalLayout {
 		conceptComboBox.setItems(budgetConceptService.list(Pageable.unpaged()).getContent());
 		conceptComboBox.setItemLabelGenerator(BudgetConcept::getName);
 		entryBinder.forField(conceptComboBox).bind(BudgetEntry::getConcept, BudgetEntry::setConcept);
+		conceptComboBox.addValueChangeListener(e -> {
+			if (!e.isFromClient()) {
+				return;
+			}
+			BudgetConcept selectedConcept = e.getValue();
+			BudgetEntry editedEntry = editor.getItem();
+			if (selectedConcept != null && selectedConcept.isGeneratesWorkOrder() && editedEntry != null) {
+				openProviderSelectionDialog(editedEntry);
+			}
+		});
 		entriesGrid.addColumn(entry -> entry.getConcept() != null ? entry.getConcept().getName() : "")
 				.setHeader("Concepto").setEditorComponent(conceptComboBox).setResizable(true);
 		entriesGrid.addColumn(entry -> currencyFormat.format(entry.getAmmount())).setHeader("Costo unitario")
@@ -336,6 +353,7 @@ public class BudgetForm extends VerticalLayout {
 			editor.save();
 			Budget budget = binder.getBean();
 			if (budget != null) {
+				syncJobOrderDates();
 				Budget savedBudget = budgetService.save(budget);
 				budgetService.findByIdWithEntries(savedBudget.getId()).ifPresentOrElse(refreshed -> {
 					binder.setBean(refreshed);
@@ -458,8 +476,55 @@ public class BudgetForm extends VerticalLayout {
 				if (binder.getBean().getCreated() == null)
 					binder.getBean().setCreated(LocalDate.now());
 			}
+			syncJobOrderDates();
 			fireEvent(new SaveEvent(this, binder.getBean()));
 
+		}
+	}
+
+	private void openProviderSelectionDialog(BudgetEntry budgetEntry) {
+		Dialog dialog = new Dialog();
+		dialog.setHeaderTitle("Seleccionar proveedor");
+
+		ComboBox<Provider> providerComboBox = new ComboBox<>("Proveedor");
+		providerComboBox.setItems(providerService.findAll());
+		providerComboBox.setItemLabelGenerator(Provider::getName);
+		providerComboBox.setWidthFull();
+		dialog.add(providerComboBox);
+
+		Button acceptButton = new Button("Aceptar", e -> {
+			Provider selectedProvider = providerComboBox.getValue();
+			JobOrder jobOrder = budgetEntry.getJobOrder();
+			if (jobOrder == null) {
+				jobOrder = new JobOrder();
+				jobOrder.setCreated(LocalDate.now());
+			}
+			jobOrder.setProvider(selectedProvider);
+			if (binder.getBean() != null) {
+				jobOrder.setStudy(binder.getBean().getStudy());
+			}
+			budgetEntry.setJobOrder(jobOrder);
+			dialog.close();
+		});
+		acceptButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+
+		Button cancelButton = new Button("Cancelar", e -> dialog.close());
+		cancelButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+
+		dialog.getFooter().add(cancelButton, acceptButton);
+		dialog.open();
+	}
+
+	private void syncJobOrderDates() {
+		if (binder.getBean() == null || binder.getBean().getEntries() == null) {
+			return;
+		}
+		for (BudgetEntry entry : binder.getBean().getEntries()) {
+			JobOrder jobOrder = entry.getJobOrder();
+			if (jobOrder != null) {
+				jobOrder.setInit(entry.getInit());
+				jobOrder.setEnd(entry.getEnd());
+			}
 		}
 	}
 

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetView.java
@@ -23,6 +23,7 @@ import uy.com.bay.utiles.services.BudgetConceptService;
 import uy.com.bay.utiles.services.BudgetService;
 import uy.com.bay.utiles.services.OdooCostService;
 import uy.com.bay.utiles.services.OdooService;
+import uy.com.bay.utiles.services.ProviderService;
 import uy.com.bay.utiles.services.StudyService;
 import uy.com.bay.utiles.tasks.DoobloSurveyRetriever;
 import uy.com.bay.utiles.views.MainLayout;
@@ -39,14 +40,15 @@ public class BudgetView extends VerticalLayout implements BeforeEnterObserver {
 
 	public BudgetView(BudgetService budgetService, StudyService studyService, BudgetConceptService budgetConceptService,
 			AlchemerSurveyResponseHelper alchemerSurveyResponseHelper, FieldworkService fieldworkService,
-			DoobloSurveyRetriever doobloSurveyRetriever, OdooService odooService, OdooCostService odooCostService) {
+			DoobloSurveyRetriever doobloSurveyRetriever, OdooService odooService, OdooCostService odooCostService,
+			ProviderService providerService) {
 		this.budgetService = budgetService;
 		addClassName("budget-view");
 		setSizeFull();
 		configureGrid();
 
 		form = new BudgetForm(studyService, budgetConceptService, budgetService, alchemerSurveyResponseHelper,
-				fieldworkService, doobloSurveyRetriever, odooService, odooCostService);
+				fieldworkService, doobloSurveyRetriever, odooService, odooCostService, providerService);
 		form.addSaveListener(this::saveBudget);
 		form.addDeleteListener(this::deleteBudget);
 		form.addCloseListener(e -> closeEditor());

--- a/src/main/java/uy/com/bay/utiles/views/budgetconcept/BudgetConceptView.java
+++ b/src/main/java/uy/com/bay/utiles/views/budgetconcept/BudgetConceptView.java
@@ -49,7 +49,8 @@ public class BudgetConceptView extends Div implements BeforeEnterObserver {
 	private TextField odooProductId;
 	private ComboBox<MatchType> matchType;
 	private Checkbox salaryCost;
-	
+	private Checkbox generatesWorkOrder;
+
 
 	private final Button cancel = new Button("Cerrar");
 	private final Button save = new Button("Guardar");
@@ -179,8 +180,9 @@ public class BudgetConceptView extends Div implements BeforeEnterObserver {
 		matchType = new ComboBox<>("Tipo de Coincidencia");
 		matchType.setItems(MatchType.values());
 		salaryCost = new Checkbox("Costo Salarial");
+		generatesWorkOrder = new Checkbox("Genera orden de trabajo");
 
-		formLayout.add(name, description, odooProductId, matchType, salaryCost);
+		formLayout.add(name, description, odooProductId, matchType, salaryCost, generatesWorkOrder);
 
 		editorDiv.add(formLayout);
 		createButtonLayout(editorLayoutDiv);

--- a/src/main/java/uy/com/bay/utiles/views/joborders/JobOrdersView.java
+++ b/src/main/java/uy/com/bay/utiles/views/joborders/JobOrdersView.java
@@ -50,7 +50,8 @@ public class JobOrdersView extends Div implements BeforeEnterObserver {
 
 	private final Grid<JobOrder> grid = new Grid<>(JobOrder.class, false);
 
-	private DatePicker created;
+	private DatePicker init;
+	private DatePicker end;
 	private ComboBox<Study> study;
 	private IntegerField hours;
 	private ComboBox<Provider> provider;
@@ -96,7 +97,8 @@ public class JobOrdersView extends Div implements BeforeEnterObserver {
 
 		add(splitLayout);
 
-		grid.addColumn("created").setHeader("Fecha").setAutoWidth(true);
+		grid.addColumn("init").setHeader("Inicio").setAutoWidth(true);
+		grid.addColumn("end").setHeader("Fin").setAutoWidth(true);
 		grid.addColumn(jo -> jo.getStudy() != null ? jo.getStudy().getName() : "").setHeader("Estudio")
 				.setAutoWidth(true);
 		grid.addColumn("hours").setHeader("Horas").setAutoWidth(true);
@@ -213,7 +215,8 @@ public class JobOrdersView extends Div implements BeforeEnterObserver {
 		editorLayoutDiv.add(editorDiv);
 
 		FormLayout formLayout = new FormLayout();
-		created = new DatePicker("Fecha");
+		init = new DatePicker("inicio");
+		end = new DatePicker("fin");
 		study = new ComboBox<>("Estudio");
 		study.setItems(studyService.findAll());
 		study.setItemLabelGenerator(Study::getName);
@@ -223,7 +226,7 @@ public class JobOrdersView extends Div implements BeforeEnterObserver {
 		provider.setItemLabelGenerator(Provider::getName);
 		provider.addValueChangeListener(e -> applyProviderHoursRule(e.getValue()));
 
-		formLayout.add(created, study, provider, hours);
+		formLayout.add(init, end, study, provider, hours);
 
 		editorDiv.add(formLayout);
 		createButtonLayout(this.editorLayoutDiv);


### PR DESCRIPTION
## Summary
This PR implements functionality to automatically generate job orders from budget entries when a budget concept marked as "generates work order" is selected. It includes provider selection via dialog and synchronization of job order dates with budget entry dates.

## Key Changes

- **BudgetForm**: 
  - Added `ProviderService` dependency injection
  - Implemented `openProviderSelectionDialog()` to allow provider selection when a work-order-generating concept is selected
  - Added `syncJobOrderDates()` to synchronize job order init/end dates with budget entry dates during save operations
  - Added value change listener to concept ComboBox that triggers provider selection dialog

- **JobOrder entity**:
  - Added `init` and `end` date fields to track job order duration
  - Added corresponding getters and setters

- **BudgetEntry entity**:
  - Added one-to-one relationship with `JobOrder` with cascade delete and orphan removal
  - Added `jobOrder` field with getters and setters

- **BudgetConcept entity**:
  - Added `generatesWorkOrder` boolean flag to indicate if a concept should trigger job order creation
  - Added corresponding getters and setters

- **JobOrdersView**:
  - Replaced single "created" date field with separate "init" and "end" date fields
  - Updated grid columns to display init and end dates instead of creation date
  - Updated form layout to include both date fields

- **BudgetView**:
  - Updated constructor to inject and pass `ProviderService` to `BudgetForm`

- **BudgetConceptView**:
  - Added checkbox UI component for the `generatesWorkOrder` flag in the editor layout

## Implementation Details

- Provider selection is triggered only when a concept with `generatesWorkOrder=true` is selected from the client (not programmatically)
- Job orders are created with the selected provider and study context
- Job order dates are automatically synchronized with their corresponding budget entry dates on save
- The dialog-based provider selection provides a clean UX for the user to choose a provider when needed

https://claude.ai/code/session_01KuwbJqfQ8FPWVUdotVNtH7