### PR TITLE
Fix transient entity persistence issues in budget cost sync

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/BudgetService.java
+++ b/src/main/java/uy/com/bay/utiles/services/BudgetService.java
@@ -51,7 +51,10 @@ public class BudgetService {
 				entry.setBudget(entity);
 			}
 		}
-		return repository.save(entity);
+		// saveAndFlush forces the cascade-persist of new BudgetEntry instances to
+		// happen within this transaction, so the returned graph always has managed,
+		// persisted entries and any constraint/ordering problem surfaces here.
+		return repository.saveAndFlush(entity);
 	}
 
 	@Transactional

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
@@ -210,8 +210,24 @@ public class BudgetForm extends VerticalLayout {
 		if (budgetStudy == null || budgetStudy.getOdooId() == null || budgetStudy.getOdooId().isEmpty()) {
 			return;
 		}
+		// OdooCost owns the budget_entry_id FK and is not cascaded, so it can only
+		// reference a persisted BudgetEntry. Persist the budget first if it (or any
+		// of its entries) is still transient, otherwise saving the costs would fail
+		// with "references an unsaved transient instance of BudgetEntry".
+		boolean hasTransientEntries = binder.getBean().getId() == null
+				|| binder.getBean().getEntries().stream().anyMatch(e -> e.getId() == null);
+		if (hasTransientEntries) {
+			binder.getBean().getEntries().forEach(e -> e.setBudget(binder.getBean()));
+			Budget saved = budgetService.save(binder.getBean());
+			Budget reloaded = budgetService.findByIdWithEntries(saved.getId()).orElse(saved);
+			binder.setBean(reloaded);
+			entriesGrid.setItems(reloaded.getEntries());
+		}
 		Long budgetId = binder.getBean().getId();
 		for (BudgetEntry budgetEntry : binder.getBean().getEntries()) {
+			if (budgetEntry.getId() == null) {
+				continue;
+			}
 			BudgetConcept concept = budgetEntry.getConcept();
 			if (concept == null || concept.getOdooProductId() == null || concept.getOdooProductId().isEmpty()) {
 				continue;

--- a/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
+++ b/src/main/java/uy/com/bay/utiles/views/budget/BudgetForm.java
@@ -474,6 +474,12 @@ public class BudgetForm extends VerticalLayout {
 	}
 
 	private void validateAndSave() {
+		// Commit any in-progress row edit in the entries grid so its changes are
+		// written back to the BudgetEntry bean even if the inline "Guardar" of the
+		// grid editor was not pressed.
+		if (editor.isOpen()) {
+			editor.save();
+		}
 		if (binder.isValid()) {
 			Budget budget = binder.getBean();
 			if (budget.getStudy() != null) {


### PR DESCRIPTION
## Summary
This PR fixes issues with persisting budget entries and their associated costs when syncing from Odoo. The changes ensure that budget entries are properly persisted before attempting to save related costs, and that in-progress grid edits are committed before validation.

## Key Changes
- **BudgetForm.refreshCostsFromOdoo()**: Added logic to detect and persist transient budget entries before syncing costs from Odoo. This prevents "references an unsaved transient instance" errors since OdooCost foreign keys are not cascade-persisted.
- **BudgetForm.refreshCostsFromOdoo()**: Added null check to skip processing budget entries that remain transient after the initial save attempt.
- **BudgetForm.validateAndSave()**: Added explicit editor save call to commit any in-progress inline grid edits before validation, ensuring all changes are written to the bean.
- **BudgetService.save()**: Changed from `repository.save()` to `repository.saveAndFlush()` to force immediate cascade-persist of new BudgetEntry instances within the transaction, surfacing any constraint or ordering issues immediately.

## Implementation Details
The root cause was that OdooCost entities own the foreign key relationship to BudgetEntry but don't use cascade persistence, requiring entries to be persisted first. The fix detects transient entries, persists them with their parent budget, and reloads the managed entity graph before proceeding with cost synchronization. Additionally, the grid editor save ensures all user edits are captured before the validation and persistence flow.

https://claude.ai/code/session_016RPUdTCPAggxSDApUGKxuC