### PR TITLE
Refactor SupervisionTask: parseo de fileName y descarga de audio

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/SupervisionTask.java
+++ b/src/main/java/uy/com/bay/utiles/data/SupervisionTask.java
@@ -24,6 +24,16 @@ public class SupervisionTask extends AbstractEntity {
 
 	private String fileName;
 
+	private Date audioDate;
+
+	private String surveyor;
+
+	private String mobilePhone;
+
+	private String phoneDisposition;
+
+	private String surveyDisposition;
+
 	@Lob
 	private byte[] audioContent;
 
@@ -303,5 +313,45 @@ public class SupervisionTask extends AbstractEntity {
 
 	public void setScoreByItem(Map<String, Integer> scoreByItem) {
 		this.scoreByItem = scoreByItem;
+	}
+
+	public Date getAudioDate() {
+		return audioDate;
+	}
+
+	public void setAudioDate(Date audioDate) {
+		this.audioDate = audioDate;
+	}
+
+	public String getSurveyor() {
+		return surveyor;
+	}
+
+	public void setSurveyor(String surveyor) {
+		this.surveyor = surveyor;
+	}
+
+	public String getMobilePhone() {
+		return mobilePhone;
+	}
+
+	public void setMobilePhone(String mobilePhone) {
+		this.mobilePhone = mobilePhone;
+	}
+
+	public String getPhoneDisposition() {
+		return phoneDisposition;
+	}
+
+	public void setPhoneDisposition(String phoneDisposition) {
+		this.phoneDisposition = phoneDisposition;
+	}
+
+	public String getSurveyDisposition() {
+		return surveyDisposition;
+	}
+
+	public void setSurveyDisposition(String surveyDisposition) {
+		this.surveyDisposition = surveyDisposition;
 	}
 }

--- a/src/main/java/uy/com/bay/utiles/data/repository/SupervisionTaskRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/SupervisionTaskRepository.java
@@ -52,4 +52,7 @@ public interface SupervisionTaskRepository extends JpaRepository<SupervisionTask
 	@Query("SELECT st.id as id, KEY(s) as itemId, VALUE(s) as score "
 			+ "FROM SupervisionTask st JOIN st.scoreByItem s WHERE st.id IN :ids")
 	List<Tuple> findScoreByItemForIds(@Param("ids") Collection<Long> ids);
+
+	@Query("SELECT st.audioContent FROM SupervisionTask st WHERE st.id = :id")
+	byte[] findAudioContentById(@Param("id") Long id);
 }

--- a/src/main/java/uy/com/bay/utiles/data/service/SupervisionTaskService.java
+++ b/src/main/java/uy/com/bay/utiles/data/service/SupervisionTaskService.java
@@ -112,4 +112,8 @@ public class SupervisionTaskService {
 	public void saveAll(List<SupervisionTask> tasks) {
 		repository.saveAll(tasks);
 	}
+
+	public byte[] getAudioContent(Long id) {
+		return repository.findAudioContentById(id);
+	}
 }

--- a/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionTasksView.java
+++ b/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionTasksView.java
@@ -122,6 +122,21 @@ public class SupervisionTasksView extends VerticalLayout {
 		}).setHeader("Output").setSortable(true)
 				.setComparator(task -> task.getOutput() != null && !task.getOutput().isEmpty());
 
+		grid.addComponentColumn(task -> {
+			StreamResource audioResource = new StreamResource(
+					task.getFileName() != null && !task.getFileName().isEmpty() ? task.getFileName()
+							: "audio_" + task.getId() + ".mp3",
+					() -> {
+						byte[] audioContent = supervisionTaskService.getAudioContent(task.getId());
+						return new ByteArrayInputStream(audioContent != null ? audioContent : new byte[0]);
+					});
+			Anchor downloadLink = new Anchor(audioResource, "");
+			downloadLink.getElement().setAttribute("download", true);
+			downloadLink.removeAll();
+			downloadLink.add(new Button("Descargar"));
+			return downloadLink;
+		}).setHeader("Audio");
+
 		HeaderRow headerRow = grid.appendHeaderRow();
 
 		alchemerStudyNameFilter.setValueChangeMode(ValueChangeMode.LAZY);

--- a/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionView.java
+++ b/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionView.java
@@ -23,6 +23,8 @@ import uy.com.bay.utiles.views.MainLayout;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -82,6 +84,7 @@ public class SupervisionView extends VerticalLayout {
 						task.setCreated(new java.util.Date());
 						task.setStatus(uy.com.bay.utiles.data.Status.PENDING);
 						task.setFileName(fileName);
+						parseFileName(task, fileName);
 						task.setAudioContent(audioContent);
 						task.setQuestionnaire(questionnaireContent);
 						task.setQuestionnaireFileName(questionnaireBuffer.getFileName());
@@ -112,5 +115,39 @@ public class SupervisionView extends VerticalLayout {
 				processButton);
 		setSpacing(true);
 		setAlignItems(Alignment.CENTER);
+	}
+
+	/**
+	 * Parsea el nombre del archivo de audio y completa los atributos de la tarea.
+	 * El nombre tiene el formato:
+	 * {@code audioDate-surveyor-mobilePhone-phoneDisposition-surveyDisposition-...},
+	 * por ejemplo
+	 * {@code 202606081416-kgonzalez-098424586-Contesta_Completa-A_Benchmark_202606_S00541-_.mp3}.
+	 * El primer campo es la fecha del audio en formato {@code yyyyMMddHHmm}.
+	 */
+	private void parseFileName(SupervisionTask task, String fileName) {
+		if (fileName == null) {
+			return;
+		}
+		String[] parts = fileName.split("-");
+		if (parts.length > 0 && !parts[0].isBlank()) {
+			try {
+				task.setAudioDate(new SimpleDateFormat("yyyyMMddHHmm").parse(parts[0].trim()));
+			} catch (ParseException ex) {
+				ex.printStackTrace();
+			}
+		}
+		if (parts.length > 1) {
+			task.setSurveyor(parts[1]);
+		}
+		if (parts.length > 2) {
+			task.setMobilePhone(parts[2]);
+		}
+		if (parts.length > 3) {
+			task.setPhoneDisposition(parts[3]);
+		}
+		if (parts.length > 4) {
+			task.setSurveyDisposition(parts[4]);
+		}
 	}
 }


### PR DESCRIPTION
## Resumen

Refactor de la entidad `SupervisionTask` y sus vistas asociadas.

### Cambios

**1. Entidad `SupervisionTask`** — nuevos campos con getters/setters:
- `audioDate` (`Date`)
- `surveyor` (`String`)
- `mobilePhone` (`String`)
- `phoneDisposition` (`String`)
- `surveyDisposition` (`String`)

**2. `SupervisionView`** — al cargar cada archivo se parsea el `fileName` (separado por `-`) y se completan los nuevos atributos:
- campo 0 → `audioDate` (formato `yyyyMMddHHmm`)
- campo 1 → `surveyor`
- campo 2 → `mobilePhone`
- campo 3 → `phoneDisposition`
- campo 4 → `surveyDisposition`

Ejemplo: `202606081416-kgonzalez-098424586-Contesta_Completa-A_Benchmark_202606_S00541-_.mp3`

El parseo es defensivo: tolera nombres con menos campos y captura `ParseException` si la fecha no respeta el formato.

**3. `SupervisionTasksView`** — nueva columna **"Audio"** con un botón link **"Descargar"**. El `audioContent` no se carga en el grid; se trae de la base de datos **bajo demanda** al presionar el botón, mediante:
- `SupervisionTaskRepository.findAudioContentById(Long id)`
- `SupervisionTaskService.getAudioContent(Long id)`

### Notas

- El esquema lo gestiona Hibernate (no hay Flyway/Liquibase); las nuevas columnas se crean automáticamente. Si la base usa `ddl-auto=validate`/`none`, habría que agregarlas manualmente.
- No fue posible compilar en el entorno remoto porque la política de red bloquea el repositorio de add-ons de Vaadin (`maven.vaadin.com`, 403). Se recomienda correr `./mvnw compile` en un entorno con acceso a ese repositorio para la verificación final.
- Los 5 campos nuevos se persisten pero no se muestran en el grid ni en el export a Excel (no fue parte del pedido).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186Ecv6FFmqiDemqEuke2jw

---
_Generated by [Claude Code](https://claude.ai/code/session_0186Ecv6FFmqiDemqEuke2jw)_