### PR TITLE
Support multiple survey IDs per fieldwork with multi-select UI

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/Fieldwork.java
+++ b/src/main/java/uy/com/bay/utiles/data/Fieldwork.java
@@ -2,8 +2,10 @@ package uy.com.bay.utiles.data;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import jakarta.persistence.CollectionTable;
@@ -17,6 +19,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MapKeyColumn;
 import jakarta.persistence.MapKeyTemporal;
+import jakarta.persistence.OrderColumn;
 import jakarta.persistence.TemporalType;
 import uy.com.bay.utiles.entities.BudgetEntry;
 
@@ -46,8 +49,17 @@ public class Fieldwork extends AbstractEntity {
 	@JoinColumn(name = "budget_entry_id")
 	private BudgetEntry budgetEntry;
 
-	private String doobloId;
-	private String alchemerId;
+	@ElementCollection(fetch = FetchType.EAGER)
+	@CollectionTable(name = "fieldwork_dooblo_id", joinColumns = @JoinColumn(name = "fieldwork_id"))
+	@OrderColumn(name = "id_order")
+	@Column(name = "dooblo_id")
+	private List<String> doobloId = new ArrayList<>();
+
+	@ElementCollection(fetch = FetchType.EAGER)
+	@CollectionTable(name = "fieldwork_alchemer_id", joinColumns = @JoinColumn(name = "fieldwork_id"))
+	@OrderColumn(name = "id_order")
+	@Column(name = "alchemer_id")
+	private List<String> alchemerId = new ArrayList<>();
 
 	@ElementCollection(fetch = FetchType.EAGER)
 	@CollectionTable(name = "fieldwork_completed_by_month", joinColumns = @JoinColumn(name = "fieldwork_id"))
@@ -56,20 +68,20 @@ public class Fieldwork extends AbstractEntity {
 	@Column(name = "completed")
 	private Map<Date, Integer> completedByMonth = new HashMap<>();
 
-	public String getDoobloId() {
+	public List<String> getDoobloId() {
 		return doobloId;
 	}
 
-	public void setDoobloId(String doobloId) {
-		this.doobloId = doobloId;
+	public void setDoobloId(List<String> doobloId) {
+		this.doobloId = doobloId != null ? doobloId : new ArrayList<>();
 	}
 
-	public String getAlchemerId() {
+	public List<String> getAlchemerId() {
 		return alchemerId;
 	}
 
-	public void setAlchemerId(String alchemerId) {
-		this.alchemerId = alchemerId;
+	public void setAlchemerId(List<String> alchemerId) {
+		this.alchemerId = alchemerId != null ? alchemerId : new ArrayList<>();
 	}
 
 	

--- a/src/main/java/uy/com/bay/utiles/data/repository/FieldworkRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/FieldworkRepository.java
@@ -12,9 +12,11 @@ import uy.com.bay.utiles.data.Fieldwork;
 import uy.com.bay.utiles.data.Study;
 
 public interface FieldworkRepository extends JpaRepository<Fieldwork, Long>, JpaSpecificationExecutor<Fieldwork> {
-	Optional<Fieldwork> findByAlchemerId(String alchemerId);
+	@Query("SELECT f FROM Fieldwork f JOIN f.alchemerId a WHERE a = :alchemerId")
+	Optional<Fieldwork> findByAlchemerId(@Param("alchemerId") String alchemerId);
 
-	Optional<Fieldwork> findByDoobloId(String doobloId);
+	@Query("SELECT f FROM Fieldwork f JOIN f.doobloId d WHERE d = :doobloId")
+	Optional<Fieldwork> findByDoobloId(@Param("doobloId") String doobloId);
 
 	List<Fieldwork> findAllByStudy(Study study);
 
@@ -31,5 +33,6 @@ public interface FieldworkRepository extends JpaRepository<Fieldwork, Long>, Jpa
 			@Param("endDate") LocalDate endDate,
 			@Param("startDate") LocalDate startDate);
 
-	List<Fieldwork> findAllByInitPlannedDateAfterAndAlchemerIdIsNotNull(LocalDate date);
+	@Query("SELECT DISTINCT f FROM Fieldwork f WHERE f.initPlannedDate > :date AND SIZE(f.alchemerId) > 0")
+	List<Fieldwork> findAllByInitPlannedDateAfterAndAlchemerIdIsNotNull(@Param("date") LocalDate date);
 }

--- a/src/main/java/uy/com/bay/utiles/services/AlchemerSurveyResponseHelper.java
+++ b/src/main/java/uy/com/bay/utiles/services/AlchemerSurveyResponseHelper.java
@@ -52,6 +52,23 @@ public class AlchemerSurveyResponseHelper {
         this.objectMapper = objectMapper;
     }
 
+    public Map<Date, Integer> getCompletedSurveys(List<String> surveyIds, Date startDate, Date endDate) {
+        Map<Date, Integer> merged = new LinkedHashMap<>();
+        if (surveyIds == null) {
+            return merged;
+        }
+        for (String surveyId : surveyIds) {
+            if (surveyId == null || surveyId.isBlank()) {
+                continue;
+            }
+            Map<Date, Integer> partial = getCompletedSurveys(surveyId, startDate, endDate);
+            for (Map.Entry<Date, Integer> entry : partial.entrySet()) {
+                merged.merge(entry.getKey(), entry.getValue() == null ? 0 : entry.getValue(), Integer::sum);
+            }
+        }
+        return merged;
+    }
+
     public Map<Date, Integer> getCompletedSurveys(String surveyId, Date startDate, Date endDate) {
         Map<Date, Integer> result = new LinkedHashMap<>();
         if (startDate == null || endDate == null || startDate.after(endDate)) {

--- a/src/main/java/uy/com/bay/utiles/tasks/DoobloSurveyRetriever.java
+++ b/src/main/java/uy/com/bay/utiles/tasks/DoobloSurveyRetriever.java
@@ -7,6 +7,7 @@ import java.util.Base64;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -106,6 +107,23 @@ public class DoobloSurveyRetriever {
 		} catch (Exception e) {
 			LOGGER.error("Failed to process XML and save DoobloResponse for interview ID {}", interviewId, e);
 		}
+	}
+
+	public Map<Date, Integer> getCompletedSurveys(List<String> surveyIds, Date fromDate, Date toDate) {
+		Map<Date, Integer> merged = new LinkedHashMap<>();
+		if (surveyIds == null) {
+			return merged;
+		}
+		for (String surveyId : surveyIds) {
+			if (surveyId == null || surveyId.isBlank()) {
+				continue;
+			}
+			Map<Date, Integer> partial = getCompletedSurveys(surveyId, fromDate, toDate);
+			for (Map.Entry<Date, Integer> entry : partial.entrySet()) {
+				merged.merge(entry.getKey(), entry.getValue() == null ? 0 : entry.getValue(), Integer::sum);
+			}
+		}
+		return merged;
 	}
 
 	public Map<Date, Integer> getCompletedSurveys(String surveyId, Date fromDate, Date toDate) {

--- a/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
+++ b/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
@@ -6,9 +6,12 @@ import java.io.IOException;
 import java.text.NumberFormat;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
@@ -24,6 +27,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
 import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.grid.Grid;
@@ -36,7 +40,6 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.splitlayout.SplitLayout;
 import com.vaadin.flow.component.textfield.IntegerField;
 import com.vaadin.flow.component.textfield.TextArea;
-import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.binder.BeanValidationBinder;
 import com.vaadin.flow.data.binder.ValidationException;
 import com.vaadin.flow.router.BeforeEnterEvent;
@@ -67,8 +70,8 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 
 	private final Grid<Fieldwork> grid = new Grid<>(Fieldwork.class, false);
 
-	private TextField doobloId;
-	private TextField alchemerId;
+	private MultiSelectComboBox<String> doobloId;
+	private MultiSelectComboBox<String> alchemerId;
 	private ComboBox<Study> study;
 	private ComboBox<uy.com.bay.utiles.entities.BudgetEntry> budgetEntry;
 	private DatePicker initPlannedDate;
@@ -154,8 +157,14 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 
 		// Configure Form
 		binder = new BeanValidationBinder<>(Fieldwork.class);
-		binder.forField(doobloId).bind(Fieldwork::getDoobloId, Fieldwork::setDoobloId);
-		binder.forField(alchemerId).bind(Fieldwork::getAlchemerId, Fieldwork::setAlchemerId);
+		binder.forField(doobloId)
+				.<List<String>>withConverter(set -> set == null ? new ArrayList<>() : new ArrayList<>(set),
+						list -> list == null ? new LinkedHashSet<>() : new LinkedHashSet<>(list))
+				.bind(Fieldwork::getDoobloId, Fieldwork::setDoobloId);
+		binder.forField(alchemerId)
+				.<List<String>>withConverter(set -> set == null ? new ArrayList<>() : new ArrayList<>(set),
+						list -> list == null ? new LinkedHashSet<>() : new LinkedHashSet<>(list))
+				.bind(Fieldwork::getAlchemerId, Fieldwork::setAlchemerId);
 		binder.forField(budgetEntry).bind(Fieldwork::getBudgetEntry, Fieldwork::setBudgetEntry);
 		binder.bindInstanceFields(this);
 
@@ -274,8 +283,8 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 		this.editorLayoutDiv.add(editorDiv);
 
 		FormLayout formLayout = new FormLayout();
-		doobloId = new TextField("Dooblo Id");
-		alchemerId = new TextField("Alchemer Id");
+		doobloId = createCustomValueMultiSelect("Dooblo Id");
+		alchemerId = createCustomValueMultiSelect("Alchemer Id");
 		study = new ComboBox<>("Estudio");
 		study.setItems(studyService.listAll());
 		study.setItemLabelGenerator(Study::getName);
@@ -308,6 +317,25 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 
 		splitLayout.addToSecondary(this.editorLayoutDiv);
 		this.editorLayoutDiv.setVisible(false);
+	}
+
+	private MultiSelectComboBox<String> createCustomValueMultiSelect(String label) {
+		MultiSelectComboBox<String> combo = new MultiSelectComboBox<>(label);
+		combo.setAllowCustomValue(true);
+		combo.setItems(new ArrayList<>());
+		combo.addCustomValueSetListener(event -> {
+			String customValue = event.getDetail();
+			if (customValue == null || customValue.isBlank()) {
+				return;
+			}
+			Set<String> selected = new LinkedHashSet<>(combo.getValue());
+			selected.add(customValue);
+			// The selected items must be present in the data provider, otherwise the
+			// newly typed value would be discarded when the selection is applied.
+			combo.setItems(new ArrayList<>(selected));
+			combo.setValue(selected);
+		});
+		return combo;
 	}
 
 	private void createButtonLayout(Div editorLayoutDiv) {
@@ -553,6 +581,14 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 			if (value.getStudy() != null && value.getStudy().getBudget() != null) {
 				this.budgetEntry.setItems(value.getStudy().getBudget().getEntries());
 			}
+			// Seed the data providers with the existing values so they render as
+			// selected chips and remain selectable.
+			this.doobloId.setItems(value.getDoobloId() != null ? new ArrayList<>(value.getDoobloId()) : new ArrayList<>());
+			this.alchemerId.setItems(
+					value.getAlchemerId() != null ? new ArrayList<>(value.getAlchemerId()) : new ArrayList<>());
+		} else {
+			this.doobloId.setItems(new ArrayList<>());
+			this.alchemerId.setItems(new ArrayList<>());
 		}
 		binder.readBean(this.fieldwork);
 		this.editorLayoutDiv.setVisible(value != null);

--- a/src/main/java/uy/com/bay/utiles/views/gantt/FieldworkDetailsDialog.java
+++ b/src/main/java/uy/com/bay/utiles/views/gantt/FieldworkDetailsDialog.java
@@ -30,11 +30,11 @@ public class FieldworkDetailsDialog extends Dialog {
 		type.setReadOnly(true);
 
 		TextField doobloId = new TextField("Dooblo Id");
-		doobloId.setValue(fieldwork.getDoobloId() != null ? fieldwork.getDoobloId() : "");
+		doobloId.setValue(fieldwork.getDoobloId() != null ? String.join(", ", fieldwork.getDoobloId()) : "");
 		doobloId.setReadOnly(true);
 
 		TextField alchemerId = new TextField("Alchemer Id");
-		alchemerId.setValue(fieldwork.getAlchemerId() != null ? fieldwork.getAlchemerId() : "");
+		alchemerId.setValue(fieldwork.getAlchemerId() != null ? String.join(", ", fieldwork.getAlchemerId()) : "");
 		alchemerId.setReadOnly(true);
 
 		TextField initPlannedDate = new TextField("Fecha Planificada Inicio");


### PR DESCRIPTION
## Summary
This PR refactors the fieldwork survey ID management to support multiple survey IDs per fieldwork instead of single values. The UI has been updated to use multi-select combo boxes, the data model now stores lists of IDs, and the survey retrieval logic has been enhanced to aggregate results across multiple IDs.

## Key Changes

- **Data Model Updates (Fieldwork.java)**
  - Changed `doobloId` and `alchemerId` from `String` to `List<String>`
  - Added JPA `@ElementCollection` annotations with proper collection tables and ordering
  - Updated getters/setters to handle list initialization

- **UI Component Changes (FieldworksView.java)**
  - Replaced `TextField` components with `MultiSelectComboBox<String>` for survey ID fields
  - Implemented `createCustomValueMultiSelect()` helper method to support custom value entry with automatic data provider updates
  - Added custom value listener to allow users to add new survey IDs on-the-fly
  - Added converters in binder to handle `Set<String>` ↔ `List<String>` conversion between UI and model
  - Updated `populateForm()` to seed data providers with existing values for proper rendering

- **Survey Retrieval Logic**
  - Added overloaded `getCompletedSurveys(List<String> surveyIds, ...)` methods in both `DoobloSurveyRetriever.java` and `AlchemerSurveyResponseHelper.java`
  - New methods iterate through multiple survey IDs and merge completion counts by date

- **Repository Query Updates (FieldworkRepository.java)**
  - Updated `findByAlchemerId()` and `findByDoobloId()` with explicit `@Query` annotations to join on collection elements
  - Updated `findAllByInitPlannedDateAfterAndAlchemerIdIsNotNull()` to check collection size instead of null

- **Display Updates (FieldworkDetailsDialog.java)**
  - Updated read-only display fields to join multiple IDs with comma separator for readability

## Implementation Details
- The multi-select combo box allows custom values while maintaining a data provider of all previously entered values
- Converters handle the impedance mismatch between the UI's `Set<String>` and the model's `List<String>`
- Survey completion aggregation uses `Map.merge()` to sum counts across multiple survey sources
- JPA queries properly handle the new collection-based fields with explicit join conditions

https://claude.ai/code/session_0137tCrFUZyuvGini1HhDY1h