### PR TITLE
Fix: permitir eliminar Fieldwork desde FieldworksView

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/AlchemerSurveyResponseRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/AlchemerSurveyResponseRepository.java
@@ -3,6 +3,9 @@ package uy.com.bay.utiles.data.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import uy.com.bay.utiles.data.AlchemerSurveyResponse;
 
@@ -11,5 +14,8 @@ public interface AlchemerSurveyResponseRepository extends JpaRepository<Alchemer
 
     List<AlchemerSurveyResponse> findByDataResponseIdAndDataSurveyId(Long responseId, Integer surveyId);
 
+    @Modifying
+    @Query("UPDATE AlchemerSurveyResponse a SET a.fieldwork = null WHERE a.fieldwork.id = :fieldworkId")
+    void clearFieldwork(@Param("fieldworkId") Long fieldworkId);
 
 }

--- a/src/main/java/uy/com/bay/utiles/data/repository/DoobloResponseRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/DoobloResponseRepository.java
@@ -1,8 +1,15 @@
 package uy.com.bay.utiles.data.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import uy.com.bay.utiles.data.DoobloResponse;
 
 public interface DoobloResponseRepository extends JpaRepository<DoobloResponse, Long> {
     boolean existsByInterviewId(String interviewId);
+
+    @Modifying
+    @Query("UPDATE DoobloResponse d SET d.fieldwork = null WHERE d.fieldwork.id = :fieldworkId")
+    void clearFieldwork(@Param("fieldworkId") Long fieldworkId);
 }

--- a/src/main/java/uy/com/bay/utiles/data/service/FieldworkService.java
+++ b/src/main/java/uy/com/bay/utiles/data/service/FieldworkService.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import uy.com.bay.utiles.data.Fieldwork;
 import uy.com.bay.utiles.data.Study;
+import uy.com.bay.utiles.data.repository.AlchemerSurveyResponseRepository;
+import uy.com.bay.utiles.data.repository.DoobloResponseRepository;
 import uy.com.bay.utiles.data.repository.FieldworkRepository;
 import uy.com.bay.utiles.entities.Budget;
 import uy.com.bay.utiles.entities.BudgetEntry;
@@ -19,9 +21,14 @@ import java.util.Optional;
 public class FieldworkService {
 
     private final FieldworkRepository repository;
+    private final DoobloResponseRepository doobloResponseRepository;
+    private final AlchemerSurveyResponseRepository alchemerSurveyResponseRepository;
 
-    public FieldworkService(FieldworkRepository repository) {
+    public FieldworkService(FieldworkRepository repository, DoobloResponseRepository doobloResponseRepository,
+            AlchemerSurveyResponseRepository alchemerSurveyResponseRepository) {
         this.repository = repository;
+        this.doobloResponseRepository = doobloResponseRepository;
+        this.alchemerSurveyResponseRepository = alchemerSurveyResponseRepository;
     }
 
     public Optional<Fieldwork> get(Long id) {
@@ -32,8 +39,29 @@ public class FieldworkService {
         return repository.save(entity);
     }
 
+    @Transactional
     public void delete(Long id) {
-        repository.deleteById(id);
+        repository.findById(id).ifPresent(fieldwork -> {
+            // Las respuestas de encuestas referencian al fieldwork mediante una FK; se
+            // desvinculan (sin borrar los datos de encuesta) para no violar la restriccion.
+            doobloResponseRepository.clearFieldwork(id);
+            alchemerSurveyResponseRepository.clearFieldwork(id);
+
+            // El Study expone la coleccion con cascade = ALL. Si el fieldwork sigue en ella
+            // al hacer flush, Hibernate intenta re-guardarlo ("deleted object would be
+            // re-saved by cascade"), por lo que hay que quitarlo antes de eliminarlo.
+            Study study = fieldwork.getStudy();
+            if (study != null && study.getFieldworks() != null) {
+                study.getFieldworks().remove(fieldwork);
+            }
+
+            BudgetEntry budgetEntry = fieldwork.getBudgetEntry();
+            if (budgetEntry != null && budgetEntry.getFieldworks() != null) {
+                budgetEntry.getFieldworks().remove(fieldwork);
+            }
+
+            repository.delete(fieldwork);
+        });
     }
 
     public Page<Fieldwork> list(Pageable pageable) {

--- a/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
+++ b/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
@@ -228,11 +228,16 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 
 		delete.addClickListener(e -> {
 			if (this.fieldwork != null) {
-				fieldworkService.delete(this.fieldwork.getId());
-				clearForm();
-				refreshGrid();
-				Notification.show("Solicitud de campo eliminada.");
-				UI.getCurrent().navigate(FieldworksView.class);
+				try {
+					fieldworkService.delete(this.fieldwork.getId());
+					clearForm();
+					refreshGrid();
+					Notification.show("Solicitud de campo eliminada.");
+					UI.getCurrent().navigate(FieldworksView.class);
+				} catch (Exception ex) {
+					Notification.show("No se pudo eliminar la solicitud de campo: " + ex.getMessage(), 5000,
+							Notification.Position.MIDDLE);
+				}
 			}
 		});
 	}


### PR DESCRIPTION
## Contexto

Seguimiento del PR #320 (ya mergeado). Al presionar **"Eliminar"** en el formulario de `FieldworksView` la entidad `Fieldwork` no se borraba. Este PR contiene únicamente ese arreglo (el refactor de #320 ya está en `main`).

## Causa

El borrado fallaba por dos motivos preexistentes:

1. **`Study.fieldworks` está mapeado con `cascade = CascadeType.ALL` (y `EAGER`).** Al eliminar un `Fieldwork` que seguía presente en esa colección, Hibernate intentaba re-guardarlo al hacer flush y lanzaba `ObjectDeletedException: deleted object would be re-saved by cascade`. Ocurría siempre, hubiera o no respuestas asociadas.
2. **Las FKs `dooblo_response.fieldwork_id` y `alchemer_survey_response.fieldwork_id`** apuntan al `Fieldwork`; si existían respuestas asociadas, el `DELETE` violaba la restricción de integridad.

Como el handler de "Eliminar" no capturaba excepciones, el error se propagaba, nunca se mostraba "eliminada" y la fila permanecía.

## Cambios

- **`FieldworkService.delete`** ahora es `@Transactional` y antes de eliminar:
  - desvincula las respuestas que referencian al fieldwork (`clearFieldwork`), poniendo su FK en `null` **sin borrar los datos de encuesta**;
  - quita el fieldwork de las colecciones de `Study` y `BudgetEntry` para evitar el re-guardado por cascada;
  - luego elimina la entidad.
- Nuevos métodos `@Modifying clearFieldwork(...)` en `DoobloResponseRepository` y `AlchemerSurveyResponseRepository`.
- El handler de "Eliminar" en `FieldworksView` envuelve la operación en `try/catch` y muestra un mensaje claro ante cualquier error en vez de un error de servidor.

## Notas

- Decisión por defecto: al borrar un `Fieldwork`, **se conservan** las respuestas de Dooblo/Alchemer (solo se les quita el vínculo). Si se prefiere eliminarlas en cascada, se puede ajustar.
- No pude compilar en el entorno de desarrollo porque la política de egress bloquea `maven.vaadin.com` (aloja `gantt-flow-addon`); conviene validar la compilación en CI y probar el borrado contra la BD real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0137tCrFUZyuvGini1HhDY1h

---
_Generated by [Claude Code](https://claude.ai/code/session_0137tCrFUZyuvGini1HhDY1h)_