### PR TITLE
Borrado de Fieldwork: reforzar lógica + diagnóstico en UI y logging

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/service/FieldworkService.java
+++ b/src/main/java/uy/com/bay/utiles/data/service/FieldworkService.java
@@ -1,6 +1,8 @@
 package uy.com.bay.utiles.data.service;
 
 import org.hibernate.Hibernate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -19,6 +21,8 @@ import java.util.Optional;
 
 @Service
 public class FieldworkService {
+
+    private static final Logger logger = LoggerFactory.getLogger(FieldworkService.class);
 
     private final FieldworkRepository repository;
     private final DoobloResponseRepository doobloResponseRepository;
@@ -41,27 +45,47 @@ public class FieldworkService {
 
     @Transactional
     public void delete(Long id) {
-        repository.findById(id).ifPresent(fieldwork -> {
+        if (id == null) {
+            return;
+        }
+        Fieldwork fieldwork = repository.findById(id).orElse(null);
+        if (fieldwork == null) {
+            logger.warn("delete: no se encontro Fieldwork con id={}", id);
+            return;
+        }
+        try {
             // Las respuestas de encuestas referencian al fieldwork mediante una FK; se
             // desvinculan (sin borrar los datos de encuesta) para no violar la restriccion.
             doobloResponseRepository.clearFieldwork(id);
             alchemerSurveyResponseRepository.clearFieldwork(id);
 
-            // El Study expone la coleccion con cascade = ALL. Si el fieldwork sigue en ella
-            // al hacer flush, Hibernate intenta re-guardarlo ("deleted object would be
-            // re-saved by cascade"), por lo que hay que quitarlo antes de eliminarlo.
+            // Romper la asociacion por ambos lados. El Study expone la coleccion con
+            // cascade = ALL: si el fieldwork sigue referenciado al hacer flush, Hibernate
+            // intenta re-guardarlo ("deleted object would be re-saved by cascade"). Se
+            // quita de las colecciones inversas y se anulan los lados propietarios (FK).
             Study study = fieldwork.getStudy();
             if (study != null && study.getFieldworks() != null) {
-                study.getFieldworks().remove(fieldwork);
+                study.getFieldworks().removeIf(f -> id.equals(f.getId()));
             }
+            fieldwork.setStudy(null);
 
             BudgetEntry budgetEntry = fieldwork.getBudgetEntry();
             if (budgetEntry != null && budgetEntry.getFieldworks() != null) {
-                budgetEntry.getFieldworks().remove(fieldwork);
+                budgetEntry.getFieldworks().removeIf(f -> id.equals(f.getId()));
             }
+            fieldwork.setBudgetEntry(null);
+
+            // Persistir la desvinculacion (FK study_id / budget_entry_id en null) antes
+            // de eliminar, para que el DELETE no choque con el grafo de cascada.
+            repository.saveAndFlush(fieldwork);
 
             repository.delete(fieldwork);
-        });
+            repository.flush();
+            logger.info("delete: Fieldwork id={} eliminado correctamente", id);
+        } catch (RuntimeException e) {
+            logger.error("delete: error al eliminar Fieldwork id={}", id, e);
+            throw e;
+        }
     }
 
     public Page<Fieldwork> list(Pageable pageable) {

--- a/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
+++ b/src/main/java/uy/com/bay/utiles/views/fieldworks/FieldworksView.java
@@ -227,17 +227,27 @@ public class FieldworksView extends Div implements BeforeEnterObserver {
 		});
 
 		delete.addClickListener(e -> {
-			if (this.fieldwork != null) {
-				try {
-					fieldworkService.delete(this.fieldwork.getId());
-					clearForm();
-					refreshGrid();
-					Notification.show("Solicitud de campo eliminada.");
-					UI.getCurrent().navigate(FieldworksView.class);
-				} catch (Exception ex) {
-					Notification.show("No se pudo eliminar la solicitud de campo: " + ex.getMessage(), 5000,
+			if (this.fieldwork == null || this.fieldwork.getId() == null) {
+				Notification.show("No hay ninguna solicitud de campo seleccionada para eliminar.", 4000,
+						Notification.Position.MIDDLE);
+				return;
+			}
+			Long idToDelete = this.fieldwork.getId();
+			try {
+				fieldworkService.delete(idToDelete);
+				if (fieldworkService.get(idToDelete).isPresent()) {
+					Notification.show(
+							"La solicitud de campo no pudo eliminarse (sigue existiendo en la base de datos).", 6000,
 							Notification.Position.MIDDLE);
+					return;
 				}
+				clearForm();
+				refreshGrid();
+				Notification.show("Solicitud de campo eliminada.");
+				UI.getCurrent().navigate(FieldworksView.class);
+			} catch (Exception ex) {
+				Notification.show("No se pudo eliminar la solicitud de campo: " + ex.getMessage(), 6000,
+						Notification.Position.MIDDLE);
 			}
 		});
 	}


### PR DESCRIPTION
## Contexto

Seguimiento de #321 (ya mergeado). El borrado de `Fieldwork` desde `FieldworksView` seguía sin funcionar y, según lo observado, **no aparecía ningún mensaje** al presionar "Eliminar" y la fila quedaba. Esto indica que el flujo no entra al borrado o que el `DELETE` no surte efecto, más que un error de cascada/FK. Este PR refuerza la lógica y, sobre todo, agrega diagnóstico para identificar la causa con certeza.

## Cambios

- **`FieldworkService.delete` reforzado**: rompe la asociación por ambos lados (quita el fieldwork de las colecciones inversas de `Study`/`BudgetEntry` con `removeIf` y anula los lados propietarios `study`/`budgetEntry`), hace `saveAndFlush` antes de eliminar y luego `flush`, para evitar de forma robusta el error "deleted object would be re-saved by cascade".
- **Logging en servidor**: registra si el borrado fue exitoso, si no se encontró la entidad, o el stack trace del error real.
- **Handler "Eliminar" auto-diagnóstico en la UI**: ahora muestra un mensaje claro en **todos** los casos:
  - sin selección (`this.fieldwork`/id en `null`),
  - excepción (muestra el texto real del error),
  - borrado sin efecto (re-consulta la BD y avisa si la entidad sigue existiendo),
  - éxito.

## Cómo usarlo para diagnosticar

Tras desplegar, presionar "Eliminar" y observar el mensaje en pantalla (y el log del servidor) indica exactamente la causa: selección nula, excepción concreta, o borrado sin efecto.

## Notas

- No pude compilar en el entorno de desarrollo porque la política de egress bloquea `maven.vaadin.com` (aloja `gantt-flow-addon`); conviene validar la compilación en CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0137tCrFUZyuvGini1HhDY1h

---
_Generated by [Claude Code](https://claude.ai/code/session_0137tCrFUZyuvGini1HhDY1h)_