### PR TITLE
Agregar dashboard "Reporte por proyecto" de supervisión

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/SupervisionTaskRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/SupervisionTaskRepository.java
@@ -81,4 +81,41 @@ public interface SupervisionTaskRepository extends JpaRepository<SupervisionTask
 	@Query("SELECT st.alchemerStudyName as studyName, AVG(st.aiScore) as avgScore FROM SupervisionTask st "
 			+ "WHERE st.alchemerStudyName IS NOT NULL GROUP BY st.alchemerStudyName ORDER BY st.alchemerStudyName")
 	List<Tuple> findAverageAiScoreByStudy();
+
+	// ---- Reporte por proyecto (filtrado por alchemerStudyName; null = todos) ----
+
+	/** Nombres de proyecto (alchemerStudyName) distintos, para el combobox. */
+	@Query("SELECT DISTINCT st.alchemerStudyName FROM SupervisionTask st WHERE st.alchemerStudyName IS NOT NULL "
+			+ "ORDER BY st.alchemerStudyName")
+	List<String> findDistinctAlchemerStudyNames();
+
+	/** Identificadores de encuesta distintos del proyecto seleccionado (null = todos). */
+	@Query("SELECT DISTINCT st.alchemerSuerveyId FROM SupervisionTask st WHERE st.alchemerSuerveyId IS NOT NULL "
+			+ "AND (:studyName IS NULL OR st.alchemerStudyName = :studyName)")
+	List<Integer> findDistinctAlchemerSuerveyIdsByStudy(@Param("studyName") String studyName);
+
+	/** Cantidad de tareas de supervisión del proyecto seleccionado (null = todos). */
+	@Query("SELECT COUNT(st) FROM SupervisionTask st WHERE (:studyName IS NULL OR st.alchemerStudyName = :studyName)")
+	long countByStudy(@Param("studyName") String studyName);
+
+	/** Promedio del puntaje global del proyecto seleccionado (null = todos). */
+	@Query("SELECT AVG(st.aiScore) FROM SupervisionTask st WHERE (:studyName IS NULL OR st.alchemerStudyName = :studyName)")
+	Double averageAiScoreByStudy(@Param("studyName") String studyName);
+
+	/** Cantidad de encuestadores distintos del proyecto seleccionado (null = todos). */
+	@Query("SELECT COUNT(DISTINCT st.surveyor) FROM SupervisionTask st WHERE st.surveyor IS NOT NULL "
+			+ "AND (:studyName IS NULL OR st.alchemerStudyName = :studyName)")
+	long countDistinctSurveyorByStudy(@Param("studyName") String studyName);
+
+	/** Promedio de cada dimensión de calidad del proyecto seleccionado (null = todos). */
+	@Query("SELECT AVG(st.scoreCobertura) as cobertura, AVG(st.scoreFidelidad) as fidelidad, "
+			+ "AVG(st.scoreNeutralidad) as neutralidad, AVG(st.scoreFluidez) as fluidez FROM SupervisionTask st "
+			+ "WHERE (:studyName IS NULL OR st.alchemerStudyName = :studyName)")
+	Tuple findAverageDimensionScoresByStudy(@Param("studyName") String studyName);
+
+	/** Promedio del puntaje global agrupado por encuestador del proyecto seleccionado (null = todos). */
+	@Query("SELECT st.surveyor as surveyor, AVG(st.aiScore) as avgScore FROM SupervisionTask st "
+			+ "WHERE st.surveyor IS NOT NULL AND (:studyName IS NULL OR st.alchemerStudyName = :studyName) "
+			+ "GROUP BY st.surveyor ORDER BY st.surveyor")
+	List<Tuple> findAverageAiScoreBySurveyor(@Param("studyName") String studyName);
 }

--- a/src/main/java/uy/com/bay/utiles/data/service/SupervisionSummaryService.java
+++ b/src/main/java/uy/com/bay/utiles/data/service/SupervisionSummaryService.java
@@ -16,6 +16,8 @@ import jakarta.persistence.Tuple;
 import uy.com.bay.utiles.data.Fieldwork;
 import uy.com.bay.utiles.data.repository.FieldworkRepository;
 import uy.com.bay.utiles.data.repository.SupervisionTaskRepository;
+import uy.com.bay.utiles.dto.SupervisionStudyReportDTO;
+import uy.com.bay.utiles.dto.SupervisionStudyReportDTO.SurveyorScore;
 import uy.com.bay.utiles.dto.SupervisionSummaryDTO;
 import uy.com.bay.utiles.dto.SupervisionSummaryDTO.DimensionScores;
 import uy.com.bay.utiles.dto.SupervisionSummaryDTO.MonthScore;
@@ -54,7 +56,7 @@ public class SupervisionSummaryService {
 
 		// Encuestas completas: a partir de los alchemerSuerveyId distintos de las
 		// tareas se recuperan los fieldworks que los referencian y se suma getCompleted.
-		long completed = computeCompletedSurveys();
+		long completed = computeCompletedSurveys(supervisionTaskRepository.findDistinctAlchemerSuerveyIds());
 		dto.setCompletedSurveys(completed);
 
 		// Nivel de supervisión: cociente entre supervisadas y completas.
@@ -76,8 +78,61 @@ public class SupervisionSummaryService {
 		return dto;
 	}
 
-	private long computeCompletedSurveys() {
-		List<Integer> surveyIds = supervisionTaskRepository.findDistinctAlchemerSuerveyIds();
+	/** Nombres de proyecto distintos para alimentar el combobox del reporte. */
+	@Transactional(readOnly = true)
+	public List<String> findStudyNames() {
+		return supervisionTaskRepository.findDistinctAlchemerStudyNames();
+	}
+
+	/**
+	 * Indicadores del reporte por proyecto. Cuando {@code studyName} es {@code null}
+	 * se consideran todas las tareas de supervisión ("Todos los estudios").
+	 */
+	@Transactional(readOnly = true)
+	public SupervisionStudyReportDTO computeStudyReport(String studyName) {
+		SupervisionStudyReportDTO dto = new SupervisionStudyReportDTO();
+
+		// Encuestas supervisadas: cantidad de tareas del proyecto.
+		long supervised = supervisionTaskRepository.countByStudy(studyName);
+		dto.setSupervisedSurveys(supervised);
+
+		// Encuestas completas: suma de getCompleted de los fieldworks asociados a los
+		// alchemerSuerveyId distintos del proyecto.
+		long completed = computeCompletedSurveys(
+				supervisionTaskRepository.findDistinctAlchemerSuerveyIdsByStudy(studyName));
+		dto.setCompletedSurveys(completed);
+
+		// Nivel de supervisión: cociente entre supervisadas y completas.
+		dto.setSupervisionLevel(completed > 0 ? (double) supervised / completed : 0d);
+
+		// Puntaje global promedio del proyecto.
+		Double avg = supervisionTaskRepository.averageAiScoreByStudy(studyName);
+		dto.setGlobalScoreAverage(avg != null ? avg : 0d);
+
+		// Promedio por encuestador: supervisadas / encuestadores distintos.
+		long surveyors = supervisionTaskRepository.countDistinctSurveyorByStudy(studyName);
+		dto.setAveragePerSurveyor(surveyors > 0 ? (double) supervised / surveyors : 0d);
+
+		// Dimensiones del proyecto (promedios).
+		dto.setDimensionScores(toDimensionScores(supervisionTaskRepository.findAverageDimensionScoresByStudy(studyName)));
+
+		// Puntaje global por encuestador.
+		dto.setScoreBySurveyor(computeScoreBySurveyor(studyName));
+
+		return dto;
+	}
+
+	private List<SurveyorScore> computeScoreBySurveyor(String studyName) {
+		List<SurveyorScore> scores = new ArrayList<>();
+		for (Tuple tuple : supervisionTaskRepository.findAverageAiScoreBySurveyor(studyName)) {
+			String surveyor = tuple.get("surveyor", String.class);
+			Double average = tuple.get("avgScore", Double.class);
+			scores.add(new SurveyorScore(surveyor, round1(average != null ? average : 0d)));
+		}
+		return scores;
+	}
+
+	private long computeCompletedSurveys(List<Integer> surveyIds) {
 		if (surveyIds.isEmpty()) {
 			return 0;
 		}
@@ -123,7 +178,10 @@ public class SupervisionSummaryService {
 	}
 
 	private DimensionScores computeDimensionScores() {
-		Tuple tuple = supervisionTaskRepository.findAverageDimensionScores();
+		return toDimensionScores(supervisionTaskRepository.findAverageDimensionScores());
+	}
+
+	private DimensionScores toDimensionScores(Tuple tuple) {
 		if (tuple == null) {
 			return new DimensionScores(0, 0, 0, 0);
 		}

--- a/src/main/java/uy/com/bay/utiles/dto/SupervisionStudyReportDTO.java
+++ b/src/main/java/uy/com/bay/utiles/dto/SupervisionStudyReportDTO.java
@@ -1,0 +1,95 @@
+package uy.com.bay.utiles.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import uy.com.bay.utiles.dto.SupervisionSummaryDTO.DimensionScores;
+
+/**
+ * Indicadores del dashboard "Reporte por proyecto" de la supervisión, calculados
+ * para un proyecto concreto (alchemerStudyName) o para todos los proyectos cuando
+ * el filtro es {@code null}. Se calcula en {@code SupervisionSummaryService}.
+ */
+public class SupervisionStudyReportDTO {
+
+	/** Suma de encuestas completas (getCompleted de los fieldworks asociados). */
+	private long completedSurveys;
+
+	/** Cantidad de tareas de supervisión del proyecto. */
+	private long supervisedSurveys;
+
+	/** Cociente entre encuestas supervisadas y encuestas completas. */
+	private double supervisionLevel;
+
+	/** Promedio del puntaje global (aiScore). */
+	private double globalScoreAverage;
+
+	/** Promedio de encuestas supervisadas por encuestador. */
+	private double averagePerSurveyor;
+
+	/** Promedio de cada dimensión de calidad. */
+	private DimensionScores dimensionScores = new DimensionScores(0, 0, 0, 0);
+
+	/** Promedio del puntaje global por encuestador. */
+	private List<SurveyorScore> scoreBySurveyor = new ArrayList<>();
+
+	/** Puntaje global promedio de un encuestador. */
+	public record SurveyorScore(String surveyor, double score) {
+	}
+
+	public long getCompletedSurveys() {
+		return completedSurveys;
+	}
+
+	public void setCompletedSurveys(long completedSurveys) {
+		this.completedSurveys = completedSurveys;
+	}
+
+	public long getSupervisedSurveys() {
+		return supervisedSurveys;
+	}
+
+	public void setSupervisedSurveys(long supervisedSurveys) {
+		this.supervisedSurveys = supervisedSurveys;
+	}
+
+	public double getSupervisionLevel() {
+		return supervisionLevel;
+	}
+
+	public void setSupervisionLevel(double supervisionLevel) {
+		this.supervisionLevel = supervisionLevel;
+	}
+
+	public double getGlobalScoreAverage() {
+		return globalScoreAverage;
+	}
+
+	public void setGlobalScoreAverage(double globalScoreAverage) {
+		this.globalScoreAverage = globalScoreAverage;
+	}
+
+	public double getAveragePerSurveyor() {
+		return averagePerSurveyor;
+	}
+
+	public void setAveragePerSurveyor(double averagePerSurveyor) {
+		this.averagePerSurveyor = averagePerSurveyor;
+	}
+
+	public DimensionScores getDimensionScores() {
+		return dimensionScores;
+	}
+
+	public void setDimensionScores(DimensionScores dimensionScores) {
+		this.dimensionScores = dimensionScores;
+	}
+
+	public List<SurveyorScore> getScoreBySurveyor() {
+		return scoreBySurveyor;
+	}
+
+	public void setScoreBySurveyor(List<SurveyorScore> scoreBySurveyor) {
+		this.scoreBySurveyor = scoreBySurveyor;
+	}
+}

--- a/src/main/java/uy/com/bay/utiles/views/MainLayout.java
+++ b/src/main/java/uy/com/bay/utiles/views/MainLayout.java
@@ -284,6 +284,9 @@ public class MainLayout extends AppLayout {
 		SideNavItem resumenEjecutivoItem = new SideNavItem("Resumen ejecutivo", "supervision-summary");
 		resumenEjecutivoItem.setPrefixComponent(new Icon("vaadin", "dashboard"));
 		supervisionMenuItem.addItem(resumenEjecutivoItem);
+		SideNavItem reportePorProyectoItem = new SideNavItem("Reporte por proyecto", "supervision-study-report");
+		reportePorProyectoItem.setPrefixComponent(new Icon("vaadin", "chart-grid"));
+		supervisionMenuItem.addItem(reportePorProyectoItem);
 		SideNavItem metodologiaItem = new SideNavItem("Metodología", "supervision-methodology");
 		metodologiaItem.setPrefixComponent(new Icon("vaadin", "book"));
 		supervisionMenuItem.addItem(metodologiaItem);

--- a/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionStudyReportView.java
+++ b/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionStudyReportView.java
@@ -1,0 +1,259 @@
+package uy.com.bay.utiles.views.supervision;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import com.github.appreciated.apexcharts.ApexCharts;
+import com.github.appreciated.apexcharts.ApexChartsBuilder;
+import com.github.appreciated.apexcharts.config.builder.ChartBuilder;
+import com.github.appreciated.apexcharts.config.builder.DataLabelsBuilder;
+import com.github.appreciated.apexcharts.config.builder.PlotOptionsBuilder;
+import com.github.appreciated.apexcharts.config.chart.Type;
+import com.github.appreciated.apexcharts.config.plotoptions.Bar;
+import com.github.appreciated.apexcharts.helper.Series;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+import jakarta.annotation.security.RolesAllowed;
+import uy.com.bay.utiles.data.service.SupervisionSummaryService;
+import uy.com.bay.utiles.dto.SupervisionStudyReportDTO;
+import uy.com.bay.utiles.dto.SupervisionStudyReportDTO.SurveyorScore;
+import uy.com.bay.utiles.dto.SupervisionSummaryDTO.DimensionScores;
+import uy.com.bay.utiles.views.MainLayout;
+
+/**
+ * Dashboard "Reporte por proyecto" de la supervisión. Un combobox permite elegir
+ * un proyecto (alchemerStudyName) o "Todos los estudios"; al cambiar la selección
+ * se recalculan los indicadores (encuestas completas, supervisadas, nivel de
+ * supervisión, puntaje global promedio y promedio por encuestador) y los gráficos
+ * ApexCharts: dimensiones del proyecto (radar) y puntaje global por encuestador
+ * (barras).
+ */
+@PageTitle("Reporte por proyecto")
+@Route(value = "supervision-study-report", layout = MainLayout.class)
+@RolesAllowed("ADMIN")
+public class SupervisionStudyReportView extends VerticalLayout {
+
+	private static final String ACCENT = "#2E6DB4";
+	private static final String ALL_STUDIES = "Todos los estudios";
+
+	private final SupervisionSummaryService summaryService;
+	private final Div content = new Div();
+
+	public SupervisionStudyReportView(SupervisionSummaryService summaryService) {
+		this.summaryService = summaryService;
+
+		setSizeFull();
+		setPadding(true);
+		setSpacing(false);
+		addClassName("supervision-study-report-view");
+
+		add(buildHeader());
+		add(buildStudySelector());
+
+		content.setWidthFull();
+		add(content);
+
+		refresh(null);
+	}
+
+	private Div buildHeader() {
+		Div header = new Div();
+		header.getStyle().set("margin-bottom", "16px");
+
+		Span subtitle = new Span("Indicadores de supervisión por proyecto");
+		subtitle.getStyle().set("color", "#8A93A3").set("font-size", "13px");
+
+		header.add(subtitle);
+		return header;
+	}
+
+	private Component buildStudySelector() {
+		List<String> items = new ArrayList<>();
+		items.add(ALL_STUDIES);
+		items.addAll(summaryService.findStudyNames());
+
+		ComboBox<String> studyComboBox = new ComboBox<>("Estudio");
+		studyComboBox.setItems(items);
+		studyComboBox.setValue(ALL_STUDIES);
+		studyComboBox.setWidth("320px");
+		studyComboBox.getStyle().set("margin-bottom", "16px");
+		studyComboBox.addValueChangeListener(event -> {
+			String value = event.getValue();
+			refresh(value == null || ALL_STUDIES.equals(value) ? null : value);
+		});
+		return studyComboBox;
+	}
+
+	/** Recalcula y vuelve a dibujar los indicadores para el proyecto seleccionado. */
+	private void refresh(String studyName) {
+		SupervisionStudyReportDTO report = summaryService.computeStudyReport(studyName);
+
+		content.removeAll();
+		content.add(buildKpiRow(report));
+		content.add(buildChartsRow(report));
+	}
+
+	// ---------------------------------------------------------------- KPI row
+
+	private Div buildKpiRow(SupervisionStudyReportDTO report) {
+		Div row = new Div();
+		row.setWidthFull();
+		row.getStyle().set("display", "grid").set("grid-template-columns", "repeat(5, 1fr)").set("gap", "16px")
+				.set("margin-bottom", "16px");
+
+		row.add(kpiCard("Encuestas completas", formatInteger(report.getCompletedSurveys()), "#2F8F6B"));
+		row.add(kpiCard("Encuestas supervisadas", formatInteger(report.getSupervisedSurveys()), "#8A6FB0"));
+		row.add(kpiCard("Nivel de supervisión", formatPercentage(report.getSupervisionLevel()), "#E4A11B"));
+		row.add(kpiCard("Puntaje global prom.", formatDecimal(report.getGlobalScoreAverage()), "#C5503F"));
+		row.add(kpiCard("Prom. x encuestador", formatDecimal(report.getAveragePerSurveyor()), ACCENT));
+		return row;
+	}
+
+	private Div kpiCard(String title, String value, String color) {
+		Div card = card();
+		card.getStyle().set("border-top", "4px solid " + color).set("display", "flex").set("flex-direction", "column")
+				.set("gap", "6px");
+
+		Span label = new Span(title);
+		label.getStyle().set("font-size", "12px").set("color", "#8A93A3").set("text-transform", "uppercase")
+				.set("letter-spacing", "0.04em").set("font-weight", "600");
+
+		Span number = new Span(value);
+		number.getStyle().set("font-family", "'IBM Plex Mono',monospace").set("font-size", "30px")
+				.set("font-weight", "600").set("color", "#102A4E");
+
+		card.add(label, number);
+		return card;
+	}
+
+	// -------------------------------------------------------------- Chart row
+
+	private Div buildChartsRow(SupervisionStudyReportDTO report) {
+		Div row = new Div();
+		row.setWidthFull();
+		row.getStyle().set("display", "grid").set("grid-template-columns", "1fr 1fr").set("gap", "16px");
+
+		row.add(buildDimensionCard(report.getDimensionScores()));
+		row.add(buildScoreBySurveyorCard(report.getScoreBySurveyor()));
+		return row;
+	}
+
+	/** DIMENSIONES DEL PROYECTO: gráfico de radar con los promedios. */
+	private Div buildDimensionCard(DimensionScores dimensions) {
+		Div card = card();
+		card.add(cardTitle("Dimensiones del proyecto"));
+		card.add(cardCaption("Promedio por dimensión de la rúbrica"));
+
+		Double[] values = { dimensions.cobertura(), dimensions.fidelidad(), dimensions.neutralidad(),
+				dimensions.fluidez() };
+
+		ApexCharts chart = ApexChartsBuilder.get().withChart(ChartBuilder.get().withType(Type.RADAR).build())
+				.withColors(ACCENT).withLabels("Cobertura", "Fidelidad", "Neutralidad", "Fluidez")
+				.withDataLabels(DataLabelsBuilder.get().withEnabled(true).build())
+				.withSeries(new Series<>("Promedio", values)).build();
+		chart.setWidth("100%");
+		chart.setHeight("320px");
+		card.add(chart);
+		return card;
+	}
+
+	/** PUNTAJE GLOBAL POR ENCUESTADOR: gráfico de barras (promedio por encuestador). */
+	private Div buildScoreBySurveyorCard(List<SurveyorScore> scoreBySurveyor) {
+		Div card = card();
+		card.add(cardTitle("Puntaje global por encuestador"));
+		card.add(cardCaption("Promedio del puntaje global por encuestador"));
+
+		if (scoreBySurveyor.isEmpty()) {
+			card.add(noData());
+			return card;
+		}
+
+		ChartPoint[] points = scoreBySurveyor.stream().map(s -> new ChartPoint(s.surveyor(), s.score()))
+				.toArray(ChartPoint[]::new);
+
+		Bar bar = new Bar();
+		bar.setHorizontal(true);
+
+		ApexCharts chart = ApexChartsBuilder.get().withChart(ChartBuilder.get().withType(Type.BAR).build())
+				.withPlotOptions(PlotOptionsBuilder.get().withBar(bar).build()).withColors(ACCENT)
+				.withDataLabels(DataLabelsBuilder.get().withEnabled(true).build())
+				.withSeries(new Series<>("Puntaje Global", points)).build();
+		int height = Math.max(320, scoreBySurveyor.size() * 42 + 80);
+		chart.setWidth("100%");
+		chart.setHeight(height + "px");
+		card.add(chart);
+		return card;
+	}
+
+	// --------------------------------------------------------------- Helpers
+
+	/**
+	 * Punto de datos {@code {x, y}} consumido por ApexCharts. El eje X toma la
+	 * etiqueta (encuestador) y el eje Y el valor numérico. Jackson serializa ambos
+	 * campos en el objeto de datos de la serie.
+	 */
+	public static class ChartPoint {
+		private final String x;
+		private final Double y;
+
+		public ChartPoint(String x, Double y) {
+			this.x = x;
+			this.y = y;
+		}
+
+		public String getX() {
+			return x;
+		}
+
+		public Double getY() {
+			return y;
+		}
+	}
+
+	/** Una tarjeta blanca con el estilo del dashboard. */
+	private Div card() {
+		Div card = new Div();
+		card.getStyle().set("background", "#fff").set("border", "1px solid #E1E6EE").set("border-radius", "11px")
+				.set("padding", "20px 22px").set("box-shadow", "0 1px 2px rgba(16,42,78,0.04)");
+		return card;
+	}
+
+	private Span cardTitle(String text) {
+		Span span = new Span(text);
+		span.getStyle().set("display", "block").set("font-size", "13px").set("font-weight", "700")
+				.set("color", "#102A4E").set("text-transform", "uppercase").set("letter-spacing", "0.04em");
+		return span;
+	}
+
+	private Span cardCaption(String text) {
+		Span span = new Span(text);
+		span.getStyle().set("display", "block").set("font-size", "12px").set("color", "#8A93A3").set("margin",
+				"2px 0 10px");
+		return span;
+	}
+
+	private Component noData() {
+		Span span = new Span("Sin datos disponibles");
+		span.getStyle().set("color", "#8A93A3").set("font-size", "13px").set("font-style", "italic");
+		return span;
+	}
+
+	private String formatInteger(long value) {
+		return String.format(Locale.US, "%,d", value);
+	}
+
+	private String formatDecimal(double value) {
+		return String.format(Locale.US, "%.1f", value);
+	}
+
+	private String formatPercentage(double ratio) {
+		return String.format(Locale.US, "%.1f%%", ratio * 100d);
+	}
+}


### PR DESCRIPTION
## Resumen

Agrega una nueva vista **"Reporte por proyecto"** (`SupervisionStudyReportView`, ruta `supervision-study-report`) con un dashboard ApexCharts filtrable por proyecto, y su sublink en el menú **Supervisión**.

La vista comienza con un **combobox de Estudio** cuyos items son los valores distintos de `alchemerStudyName` de las `SupervisionTask`, más la opción por defecto **"Todos los estudios"** (seleccionada al inicio). Al cambiar la selección, todos los indicadores se recalculan filtrando las `SupervisionTask` por `alchemerStudyName` (o sin filtro si es "Todos los estudios").

## Cambios principales

- **Nueva vista** `SupervisionStudyReportView`:
  - Combobox de proyecto que refresca los componentes al cambiar.
  - 5 tarjetas KPI: encuestas completas, encuestas supervisadas, nivel de supervisión, puntaje global promedio y promedio por encuestador.
  - Gráfico de **radar** "Dimensiones del proyecto".
  - Gráfico de **barras** horizontal "Puntaje global por encuestador".

- **Nuevo DTO** `SupervisionStudyReportDTO` con los indicadores del reporte (reutiliza el record `DimensionScores`).

- **Servicio** `SupervisionSummaryService`: nuevos métodos `findStudyNames()` y `computeStudyReport(studyName)`; se refactorizaron helpers (`computeCompletedSurveys`, `toDimensionScores`) para compartirlos entre el resumen ejecutivo y el reporte por proyecto.

- **Repositorio** `SupervisionTaskRepository`: nuevas consultas filtradas por proyecto (nombres distintos, ids de encuesta distintos, conteo, promedio de aiScore, conteo de encuestadores distintos, promedio de dimensiones y promedio de aiScore por encuestador). Se reutiliza `FieldworkRepository.findDistinctByAlchemerIdIn`.

- **Navegación**: `MainLayout` incorpora el sublink "Reporte por proyecto" bajo el menú Supervisión.

## Cómo se calcula cada indicador (filtrando por `alchemerStudyName`)

- **Encuestas completas**: a partir de los `alchemerSuerveyId` distintos de las tareas del proyecto, se recuperan los `Fieldwork` cuyo `fieldwork_alchemer_id` contiene alguno de esos valores y se suma `getCompleted()`.
- **Encuestas supervisadas**: cantidad de `SupervisionTask` del proyecto.
- **Nivel de supervisión**: supervisadas / completas.
- **Puntaje global prom.**: promedio de `aiScore`.
- **Prom. x encuestador**: supervisadas / cantidad de `surveyor` distintos.
- **Dimensiones del proyecto** (radar): promedios de `scoreCobertura`, `scoreFidelidad`, `scoreNeutralidad`, `scoreFluidez`.
- **Puntaje global por encuestador** (barras): promedio de `aiScore` agrupado por `surveyor`.

## Notas

- Usa el plugin ApexCharts ya presente en el `pom.xml`, replicando los patrones de las vistas de supervisión existentes.
- Vista protegida con `@RolesAllowed("ADMIN")` y servicio transaccional de solo lectura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012x1NyENKB7nVfrRJuettsy

---
_Generated by [Claude Code](https://claude.ai/code/session_012x1NyENKB7nVfrRJuettsy)_