### PR TITLE
Agregar dashboard "Resultados por encuestador" de supervisión

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/SupervisionTaskRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/SupervisionTaskRepository.java
@@ -118,4 +118,15 @@ public interface SupervisionTaskRepository extends JpaRepository<SupervisionTask
 			+ "WHERE st.surveyor IS NOT NULL AND (:studyName IS NULL OR st.alchemerStudyName = :studyName) "
 			+ "GROUP BY st.surveyor ORDER BY st.surveyor")
 	List<Tuple> findAverageAiScoreBySurveyor(@Param("studyName") String studyName);
+
+	/**
+	 * Estadísticas por encuestador: promedio del puntaje global y promedio de cada
+	 * dimensión, agrupados por surveyor. Alimenta el ranking y el radar mejor/peor.
+	 */
+	@Query("SELECT st.surveyor as surveyor, AVG(st.aiScore) as avgScore, "
+			+ "AVG(st.scoreCobertura) as cobertura, AVG(st.scoreFidelidad) as fidelidad, "
+			+ "AVG(st.scoreNeutralidad) as neutralidad, AVG(st.scoreFluidez) as fluidez "
+			+ "FROM SupervisionTask st WHERE st.surveyor IS NOT NULL "
+			+ "GROUP BY st.surveyor ORDER BY st.surveyor")
+	List<Tuple> findSurveyorStats();
 }

--- a/src/main/java/uy/com/bay/utiles/data/service/SupervisionSummaryService.java
+++ b/src/main/java/uy/com/bay/utiles/data/service/SupervisionSummaryService.java
@@ -18,6 +18,8 @@ import uy.com.bay.utiles.data.repository.FieldworkRepository;
 import uy.com.bay.utiles.data.repository.SupervisionTaskRepository;
 import uy.com.bay.utiles.dto.SupervisionStudyReportDTO;
 import uy.com.bay.utiles.dto.SupervisionStudyReportDTO.SurveyorScore;
+import uy.com.bay.utiles.dto.SupervisionSurveyorReportDTO;
+import uy.com.bay.utiles.dto.SupervisionSurveyorReportDTO.SurveyorProfile;
 import uy.com.bay.utiles.dto.SupervisionSummaryDTO;
 import uy.com.bay.utiles.dto.SupervisionSummaryDTO.DimensionScores;
 import uy.com.bay.utiles.dto.SupervisionSummaryDTO.MonthScore;
@@ -118,6 +120,48 @@ public class SupervisionSummaryService {
 
 		// Puntaje global por encuestador.
 		dto.setScoreBySurveyor(computeScoreBySurveyor(studyName));
+
+		return dto;
+	}
+
+	/**
+	 * Indicadores del reporte por encuestador: ranking por puntaje global promedio y
+	 * el perfil por dimensión del mejor encuestador frente al que requiere apoyo.
+	 */
+	@Transactional(readOnly = true)
+	public SupervisionSurveyorReportDTO computeSurveyorReport() {
+		SupervisionSurveyorReportDTO dto = new SupervisionSurveyorReportDTO();
+
+		List<SurveyorScore> ranking = new ArrayList<>();
+		Tuple bestTuple = null;
+		Tuple worstTuple = null;
+		double bestScore = Double.NEGATIVE_INFINITY;
+		double worstScore = Double.POSITIVE_INFINITY;
+
+		for (Tuple tuple : supervisionTaskRepository.findSurveyorStats()) {
+			String surveyor = tuple.get("surveyor", String.class);
+			double average = value(tuple, "avgScore");
+			ranking.add(new SurveyorScore(surveyor, round1(average)));
+			if (average > bestScore) {
+				bestScore = average;
+				bestTuple = tuple;
+			}
+			if (average < worstScore) {
+				worstScore = average;
+				worstTuple = tuple;
+			}
+		}
+
+		// Ranking de mayor a menor puntaje global promedio.
+		ranking.sort((a, b) -> Double.compare(b.score(), a.score()));
+		dto.setRanking(ranking);
+
+		if (bestTuple != null) {
+			dto.setBest(new SurveyorProfile(bestTuple.get("surveyor", String.class), toDimensionScores(bestTuple)));
+		}
+		if (worstTuple != null) {
+			dto.setWorst(new SurveyorProfile(worstTuple.get("surveyor", String.class), toDimensionScores(worstTuple)));
+		}
 
 		return dto;
 	}

--- a/src/main/java/uy/com/bay/utiles/dto/SupervisionSurveyorReportDTO.java
+++ b/src/main/java/uy/com/bay/utiles/dto/SupervisionSurveyorReportDTO.java
@@ -1,0 +1,53 @@
+package uy.com.bay.utiles.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import uy.com.bay.utiles.dto.SupervisionStudyReportDTO.SurveyorScore;
+import uy.com.bay.utiles.dto.SupervisionSummaryDTO.DimensionScores;
+
+/**
+ * Indicadores del dashboard "Resultados por encuestador" de la supervisión: el
+ * ranking de encuestadores por puntaje global promedio y el perfil por dimensión
+ * del mejor encuestador frente al que requiere apoyo. Se calcula en
+ * {@code SupervisionSummaryService}.
+ */
+public class SupervisionSurveyorReportDTO {
+
+	/** Puntaje global promedio por encuestador (ranking). */
+	private List<SurveyorScore> ranking = new ArrayList<>();
+
+	/** Encuestador con mayor puntaje global promedio. */
+	private SurveyorProfile best;
+
+	/** Encuestador con menor puntaje global promedio. */
+	private SurveyorProfile worst;
+
+	/** Perfil de un encuestador: nombre y promedios por dimensión. */
+	public record SurveyorProfile(String surveyor, DimensionScores dimensions) {
+	}
+
+	public List<SurveyorScore> getRanking() {
+		return ranking;
+	}
+
+	public void setRanking(List<SurveyorScore> ranking) {
+		this.ranking = ranking;
+	}
+
+	public SurveyorProfile getBest() {
+		return best;
+	}
+
+	public void setBest(SurveyorProfile best) {
+		this.best = best;
+	}
+
+	public SurveyorProfile getWorst() {
+		return worst;
+	}
+
+	public void setWorst(SurveyorProfile worst) {
+		this.worst = worst;
+	}
+}

--- a/src/main/java/uy/com/bay/utiles/views/MainLayout.java
+++ b/src/main/java/uy/com/bay/utiles/views/MainLayout.java
@@ -287,6 +287,10 @@ public class MainLayout extends AppLayout {
 		SideNavItem reportePorProyectoItem = new SideNavItem("Reporte por proyecto", "supervision-study-report");
 		reportePorProyectoItem.setPrefixComponent(new Icon("vaadin", "chart-grid"));
 		supervisionMenuItem.addItem(reportePorProyectoItem);
+		SideNavItem resultadosPorEncuestadorItem = new SideNavItem("Resultados por encuestador",
+				"supervision-surveyor-report");
+		resultadosPorEncuestadorItem.setPrefixComponent(new Icon("vaadin", "user-check"));
+		supervisionMenuItem.addItem(resultadosPorEncuestadorItem);
 		SideNavItem metodologiaItem = new SideNavItem("Metodología", "supervision-methodology");
 		metodologiaItem.setPrefixComponent(new Icon("vaadin", "book"));
 		supervisionMenuItem.addItem(metodologiaItem);

--- a/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionSurveyorReportView.java
+++ b/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionSurveyorReportView.java
@@ -1,0 +1,187 @@
+package uy.com.bay.utiles.views.supervision;
+
+import java.util.List;
+
+import com.github.appreciated.apexcharts.ApexCharts;
+import com.github.appreciated.apexcharts.ApexChartsBuilder;
+import com.github.appreciated.apexcharts.config.builder.ChartBuilder;
+import com.github.appreciated.apexcharts.config.builder.DataLabelsBuilder;
+import com.github.appreciated.apexcharts.config.builder.LegendBuilder;
+import com.github.appreciated.apexcharts.config.builder.PlotOptionsBuilder;
+import com.github.appreciated.apexcharts.config.chart.Type;
+import com.github.appreciated.apexcharts.config.legend.Position;
+import com.github.appreciated.apexcharts.config.plotoptions.Bar;
+import com.github.appreciated.apexcharts.helper.Series;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+import jakarta.annotation.security.RolesAllowed;
+import uy.com.bay.utiles.data.service.SupervisionSummaryService;
+import uy.com.bay.utiles.dto.SupervisionStudyReportDTO.SurveyorScore;
+import uy.com.bay.utiles.dto.SupervisionSurveyorReportDTO;
+import uy.com.bay.utiles.dto.SupervisionSurveyorReportDTO.SurveyorProfile;
+import uy.com.bay.utiles.views.MainLayout;
+
+/**
+ * Dashboard "Resultados por encuestador" de la supervisión. Muestra dos gráficos
+ * ApexCharts: el ranking de encuestadores por puntaje global promedio (barras) y
+ * un radar de múltiples series que compara al mejor encuestador con el que
+ * requiere apoyo, según el promedio de cada dimensión de la rúbrica.
+ */
+@PageTitle("Resultados por encuestador")
+@Route(value = "supervision-surveyor-report", layout = MainLayout.class)
+@RolesAllowed("ADMIN")
+public class SupervisionSurveyorReportView extends VerticalLayout {
+
+	private static final String ACCENT = "#2E6DB4";
+	private static final String BEST_COLOR = "#2F8F6B";
+	private static final String WORST_COLOR = "#C5503F";
+
+	public SupervisionSurveyorReportView(SupervisionSummaryService summaryService) {
+		setSizeFull();
+		setPadding(true);
+		setSpacing(false);
+		addClassName("supervision-surveyor-report-view");
+
+		SupervisionSurveyorReportDTO report = summaryService.computeSurveyorReport();
+
+		add(buildHeader());
+		add(buildChartsRow(report));
+	}
+
+	private Div buildHeader() {
+		Div header = new Div();
+		header.getStyle().set("margin-bottom", "16px");
+
+		Span subtitle = new Span("Desempeño de los encuestadores");
+		subtitle.getStyle().set("color", "#8A93A3").set("font-size", "13px");
+
+		header.add(subtitle);
+		return header;
+	}
+
+	private Div buildChartsRow(SupervisionSurveyorReportDTO report) {
+		Div row = new Div();
+		row.setWidthFull();
+		row.getStyle().set("display", "grid").set("grid-template-columns", "1.3fr 1fr").set("gap", "16px")
+				.set("align-items", "start");
+
+		row.add(buildRankingCard(report.getRanking()));
+		row.add(buildBestVsWorstCard(report.getBest(), report.getWorst()));
+		return row;
+	}
+
+	/** RANKING DE ENCUESTADORES: barras con el promedio de aiScore por encuestador. */
+	private Div buildRankingCard(List<SurveyorScore> ranking) {
+		Div card = card();
+		card.add(cardTitle("Ranking de encuestadores"));
+		card.add(cardCaption("Puntaje global promedio por encuestador"));
+
+		if (ranking.isEmpty()) {
+			card.add(noData());
+			return card;
+		}
+
+		ChartPoint[] points = ranking.stream().map(s -> new ChartPoint(s.surveyor(), s.score()))
+				.toArray(ChartPoint[]::new);
+
+		Bar bar = new Bar();
+		bar.setHorizontal(true);
+
+		ApexCharts chart = ApexChartsBuilder.get().withChart(ChartBuilder.get().withType(Type.BAR).build())
+				.withPlotOptions(PlotOptionsBuilder.get().withBar(bar).build()).withColors(ACCENT)
+				.withDataLabels(DataLabelsBuilder.get().withEnabled(true).build())
+				.withSeries(new Series<>("Puntaje Global", points)).build();
+		int height = Math.max(320, ranking.size() * 42 + 80);
+		chart.setWidth("100%");
+		chart.setHeight(height + "px");
+		card.add(chart);
+		return card;
+	}
+
+	/** MEJOR VS. REQUIERE APOYO: radar de dos series (mejor y peor encuestador). */
+	private Div buildBestVsWorstCard(SurveyorProfile best, SurveyorProfile worst) {
+		Div card = card();
+		card.add(cardTitle("Mejor vs. requiere apoyo"));
+		card.add(cardCaption("Perfil por dimensión del mejor encuestador y del que requiere apoyo"));
+
+		if (best == null || worst == null) {
+			card.add(noData());
+			return card;
+		}
+
+		ApexCharts chart = ApexChartsBuilder.get().withChart(ChartBuilder.get().withType(Type.RADAR).build())
+				.withColors(BEST_COLOR, WORST_COLOR).withLabels("Cobertura", "Fidelidad", "Neutralidad", "Fluidez")
+				.withDataLabels(DataLabelsBuilder.get().withEnabled(true).build())
+				.withLegend(LegendBuilder.get().withPosition(Position.BOTTOM).build())
+				.withSeries(new Series<>("Mejor — " + best.surveyor(), dimensionValues(best)),
+						new Series<>("Requiere apoyo — " + worst.surveyor(), dimensionValues(worst)))
+				.build();
+		chart.setWidth("100%");
+		chart.setHeight("360px");
+		card.add(chart);
+		return card;
+	}
+
+	private Double[] dimensionValues(SurveyorProfile profile) {
+		return new Double[] { profile.dimensions().cobertura(), profile.dimensions().fidelidad(),
+				profile.dimensions().neutralidad(), profile.dimensions().fluidez() };
+	}
+
+	// --------------------------------------------------------------- Helpers
+
+	/**
+	 * Punto de datos {@code {x, y}} consumido por ApexCharts. El eje X toma el
+	 * encuestador y el eje Y el puntaje promedio. Jackson serializa ambos campos en
+	 * el objeto de datos de la serie.
+	 */
+	public static class ChartPoint {
+		private final String x;
+		private final Double y;
+
+		public ChartPoint(String x, Double y) {
+			this.x = x;
+			this.y = y;
+		}
+
+		public String getX() {
+			return x;
+		}
+
+		public Double getY() {
+			return y;
+		}
+	}
+
+	/** Una tarjeta blanca con el estilo del dashboard. */
+	private Div card() {
+		Div card = new Div();
+		card.getStyle().set("background", "#fff").set("border", "1px solid #E1E6EE").set("border-radius", "11px")
+				.set("padding", "20px 22px").set("box-shadow", "0 1px 2px rgba(16,42,78,0.04)");
+		return card;
+	}
+
+	private Span cardTitle(String text) {
+		Span span = new Span(text);
+		span.getStyle().set("display", "block").set("font-size", "13px").set("font-weight", "700")
+				.set("color", "#102A4E").set("text-transform", "uppercase").set("letter-spacing", "0.04em");
+		return span;
+	}
+
+	private Span cardCaption(String text) {
+		Span span = new Span(text);
+		span.getStyle().set("display", "block").set("font-size", "12px").set("color", "#8A93A3").set("margin",
+				"2px 0 10px");
+		return span;
+	}
+
+	private Component noData() {
+		Span span = new Span("Sin datos disponibles");
+		span.getStyle().set("color", "#8A93A3").set("font-size", "13px").set("font-style", "italic");
+		return span;
+	}
+}


### PR DESCRIPTION
## Resumen

Agrega una nueva vista **"Resultados por encuestador"** (`SupervisionSurveyorReportView`, ruta `supervision-surveyor-report`) con un dashboard ApexCharts, y su sublink en el menú **Supervisión**.

## Cambios principales

- **Nueva vista** `SupervisionSurveyorReportView` con dos gráficos:
  - **Ranking de encuestadores** (barras horizontales): promedio de `aiScore` agrupado por `surveyor`; cada barra es un encuestador distinto, ordenadas de mayor a menor.
  - **Mejor vs. requiere apoyo** (radar de múltiples series): compara al encuestador con mayor promedio de `aiScore` contra el de menor promedio, usando como ejes los promedios de `scoreCobertura`, `scoreFidelidad`, `scoreNeutralidad` y `scoreFluidez`.

- **Nuevo DTO** `SupervisionSurveyorReportDTO` (ranking + perfiles del mejor/peor encuestador; reutiliza `DimensionScores` y `SurveyorScore`).

- **Servicio** `SupervisionSummaryService`: nuevo método `computeSurveyorReport()`, reutilizando el helper `toDimensionScores`.

- **Repositorio** `SupervisionTaskRepository`: nueva consulta `findSurveyorStats()` que devuelve, por encuestador, el promedio de `aiScore` y el promedio de cada dimensión en una sola query.

- **Navegación**: `MainLayout` incorpora el sublink "Resultados por encuestador" bajo el menú Supervisión.

## Cómo se construye cada indicador

- **Ranking de encuestadores** (barras): promedia `aiScore` de las `SupervisionTask` agrupadas por `surveyor`; cada barra es un `surveyor` distinto y el valor es el promedio de `aiScore`.
- **Mejor vs. requiere apoyo** (radar multi-serie): agrupa las `SupervisionTask` por `surveyor` y calcula el promedio de `aiScore` de cada grupo. Inserta una serie para la agrupación con **mayor** promedio y otra para la de **menor** promedio; las opciones del radar son los promedios de `scoreCobertura` (cobertura), `scoreFidelidad` (fidelidad), `scoreNeutralidad` (neutralidad) y `scoreFluidez` (fluidez) de cada serie.

## Notas

- Usa el plugin ApexCharts ya presente en el `pom.xml`, replicando los patrones de las vistas de supervisión existentes.
- Vista protegida con `@RolesAllowed("ADMIN")` y servicio transaccional de solo lectura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012x1NyENKB7nVfrRJuettsy

---
_Generated by [Claude Code](https://claude.ai/code/session_012x1NyENKB7nVfrRJuettsy)_