### PR TITLE
Agregar dashboard "Evolución temporal" de supervisión

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/SupervisionTaskRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/SupervisionTaskRepository.java
@@ -129,4 +129,21 @@ public interface SupervisionTaskRepository extends JpaRepository<SupervisionTask
 			+ "FROM SupervisionTask st WHERE st.surveyor IS NOT NULL "
 			+ "GROUP BY st.surveyor ORDER BY st.surveyor")
 	List<Tuple> findSurveyorStats();
+
+	// ---- Evolución temporal (filtrado por surveyor; null = todos) ----
+
+	/** Encuestadores (surveyor) distintos, para el combobox de la evolución temporal. */
+	@Query("SELECT DISTINCT st.surveyor FROM SupervisionTask st WHERE st.surveyor IS NOT NULL ORDER BY st.surveyor")
+	List<String> findDistinctSurveyors();
+
+	/**
+	 * Proyección de fecha de audio, puntaje global y dimensiones del encuestador
+	 * seleccionado (null = todos), para agrupar la evolución por mes en memoria.
+	 */
+	@Query("SELECT st.audioDate as audioDate, st.aiScore as aiScore, "
+			+ "st.scoreCobertura as cobertura, st.scoreFidelidad as fidelidad, "
+			+ "st.scoreNeutralidad as neutralidad, st.scoreFluidez as fluidez "
+			+ "FROM SupervisionTask st WHERE st.audioDate IS NOT NULL "
+			+ "AND (:surveyor IS NULL OR st.surveyor = :surveyor)")
+	List<Tuple> findMonthlyStatsBySurveyor(@Param("surveyor") String surveyor);
 }

--- a/src/main/java/uy/com/bay/utiles/data/service/SupervisionSummaryService.java
+++ b/src/main/java/uy/com/bay/utiles/data/service/SupervisionSummaryService.java
@@ -20,6 +20,7 @@ import uy.com.bay.utiles.dto.SupervisionStudyReportDTO;
 import uy.com.bay.utiles.dto.SupervisionStudyReportDTO.SurveyorScore;
 import uy.com.bay.utiles.dto.SupervisionSurveyorReportDTO;
 import uy.com.bay.utiles.dto.SupervisionSurveyorReportDTO.SurveyorProfile;
+import uy.com.bay.utiles.dto.SupervisionTimelineReportDTO;
 import uy.com.bay.utiles.dto.SupervisionSummaryDTO;
 import uy.com.bay.utiles.dto.SupervisionSummaryDTO.DimensionScores;
 import uy.com.bay.utiles.dto.SupervisionSummaryDTO.MonthScore;
@@ -166,6 +167,49 @@ public class SupervisionSummaryService {
 		return dto;
 	}
 
+	/** Nombres de encuestador distintos para el combobox de la evolución temporal. */
+	@Transactional(readOnly = true)
+	public List<String> findSurveyorNames() {
+		return supervisionTaskRepository.findDistinctSurveyors();
+	}
+
+	/**
+	 * Evolución temporal del encuestador seleccionado (null = todos): promedio del
+	 * puntaje global y de cada dimensión, agrupados por mes del audioDate.
+	 */
+	@Transactional(readOnly = true)
+	public SupervisionTimelineReportDTO computeTimelineReport(String surveyor) {
+		// Acumuladores por año-mes: [sumScore, sumCob, sumFid, sumNeu, sumFlu, count].
+		Map<YearMonth, double[]> byMonth = new TreeMap<>();
+		for (Tuple tuple : supervisionTaskRepository.findMonthlyStatsBySurveyor(surveyor)) {
+			Date audioDate = tuple.get("audioDate", Date.class);
+			if (audioDate == null) {
+				continue;
+			}
+			YearMonth month = YearMonth.from(audioDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+			double[] acc = byMonth.computeIfAbsent(month, k -> new double[6]);
+			acc[0] += value(tuple, "aiScore");
+			acc[1] += intValue(tuple, "cobertura");
+			acc[2] += intValue(tuple, "fidelidad");
+			acc[3] += intValue(tuple, "neutralidad");
+			acc[4] += intValue(tuple, "fluidez");
+			acc[5] += 1;
+		}
+
+		SupervisionTimelineReportDTO dto = new SupervisionTimelineReportDTO();
+		for (Map.Entry<YearMonth, double[]> entry : byMonth.entrySet()) {
+			double[] acc = entry.getValue();
+			double n = acc[5];
+			dto.getMonths().add(monthLabel(entry.getKey()));
+			dto.getGlobalScore().add(round1(n > 0 ? acc[0] / n : 0d));
+			dto.getCobertura().add(round1(n > 0 ? acc[1] / n : 0d));
+			dto.getFidelidad().add(round1(n > 0 ? acc[2] / n : 0d));
+			dto.getNeutralidad().add(round1(n > 0 ? acc[3] / n : 0d));
+			dto.getFluidez().add(round1(n > 0 ? acc[4] / n : 0d));
+		}
+		return dto;
+	}
+
 	private List<SurveyorScore> computeScoreBySurveyor(String studyName) {
 		List<SurveyorScore> scores = new ArrayList<>();
 		for (Tuple tuple : supervisionTaskRepository.findAverageAiScoreBySurveyor(studyName)) {
@@ -245,6 +289,11 @@ public class SupervisionSummaryService {
 
 	private double value(Tuple tuple, String alias) {
 		Double v = tuple.get(alias, Double.class);
+		return v != null ? v : 0d;
+	}
+
+	private double intValue(Tuple tuple, String alias) {
+		Integer v = tuple.get(alias, Integer.class);
 		return v != null ? v : 0d;
 	}
 

--- a/src/main/java/uy/com/bay/utiles/dto/SupervisionTimelineReportDTO.java
+++ b/src/main/java/uy/com/bay/utiles/dto/SupervisionTimelineReportDTO.java
@@ -1,0 +1,80 @@
+package uy.com.bay.utiles.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Indicadores del dashboard "Evolución temporal" de la supervisión, calculados
+ * para un encuestador concreto (surveyor) o para todos cuando el filtro es
+ * {@code null}. Todas las listas comparten el mismo eje X ({@link #months}); cada
+ * lista de valores está alineada por índice con {@code months}. Se calcula en
+ * {@code SupervisionSummaryService}.
+ */
+public class SupervisionTimelineReportDTO {
+
+	/** Etiquetas de mes (eje X), en orden cronológico. */
+	private List<String> months = new ArrayList<>();
+
+	/** Promedio del puntaje global (aiScore) por mes. */
+	private List<Double> globalScore = new ArrayList<>();
+
+	/** Promedio de cobertura por mes. */
+	private List<Double> cobertura = new ArrayList<>();
+
+	/** Promedio de fidelidad por mes. */
+	private List<Double> fidelidad = new ArrayList<>();
+
+	/** Promedio de neutralidad por mes. */
+	private List<Double> neutralidad = new ArrayList<>();
+
+	/** Promedio de fluidez por mes. */
+	private List<Double> fluidez = new ArrayList<>();
+
+	public List<String> getMonths() {
+		return months;
+	}
+
+	public void setMonths(List<String> months) {
+		this.months = months;
+	}
+
+	public List<Double> getGlobalScore() {
+		return globalScore;
+	}
+
+	public void setGlobalScore(List<Double> globalScore) {
+		this.globalScore = globalScore;
+	}
+
+	public List<Double> getCobertura() {
+		return cobertura;
+	}
+
+	public void setCobertura(List<Double> cobertura) {
+		this.cobertura = cobertura;
+	}
+
+	public List<Double> getFidelidad() {
+		return fidelidad;
+	}
+
+	public void setFidelidad(List<Double> fidelidad) {
+		this.fidelidad = fidelidad;
+	}
+
+	public List<Double> getNeutralidad() {
+		return neutralidad;
+	}
+
+	public void setNeutralidad(List<Double> neutralidad) {
+		this.neutralidad = neutralidad;
+	}
+
+	public List<Double> getFluidez() {
+		return fluidez;
+	}
+
+	public void setFluidez(List<Double> fluidez) {
+		this.fluidez = fluidez;
+	}
+}

--- a/src/main/java/uy/com/bay/utiles/views/MainLayout.java
+++ b/src/main/java/uy/com/bay/utiles/views/MainLayout.java
@@ -291,6 +291,9 @@ public class MainLayout extends AppLayout {
 				"supervision-surveyor-report");
 		resultadosPorEncuestadorItem.setPrefixComponent(new Icon("vaadin", "user-check"));
 		supervisionMenuItem.addItem(resultadosPorEncuestadorItem);
+		SideNavItem evolucionTemporalItem = new SideNavItem("Evolución temporal", "supervision-timeline-report");
+		evolucionTemporalItem.setPrefixComponent(new Icon("vaadin", "line-chart"));
+		supervisionMenuItem.addItem(evolucionTemporalItem);
 		SideNavItem metodologiaItem = new SideNavItem("Metodología", "supervision-methodology");
 		metodologiaItem.setPrefixComponent(new Icon("vaadin", "book"));
 		supervisionMenuItem.addItem(metodologiaItem);

--- a/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionTimelineReportView.java
+++ b/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionTimelineReportView.java
@@ -1,0 +1,213 @@
+package uy.com.bay.utiles.views.supervision;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.github.appreciated.apexcharts.ApexCharts;
+import com.github.appreciated.apexcharts.ApexChartsBuilder;
+import com.github.appreciated.apexcharts.config.builder.ChartBuilder;
+import com.github.appreciated.apexcharts.config.builder.DataLabelsBuilder;
+import com.github.appreciated.apexcharts.config.builder.LegendBuilder;
+import com.github.appreciated.apexcharts.config.builder.StrokeBuilder;
+import com.github.appreciated.apexcharts.config.chart.Type;
+import com.github.appreciated.apexcharts.config.legend.Position;
+import com.github.appreciated.apexcharts.helper.Series;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+import jakarta.annotation.security.RolesAllowed;
+import uy.com.bay.utiles.data.service.SupervisionSummaryService;
+import uy.com.bay.utiles.dto.SupervisionTimelineReportDTO;
+import uy.com.bay.utiles.views.MainLayout;
+
+/**
+ * Dashboard "Evolución temporal" de la supervisión. Un combobox permite elegir un
+ * encuestador (surveyor) o "Todos los encuestadores"; al cambiar la selección se
+ * recalculan dos gráficos de líneas: el puntaje global en el tiempo y la evolución
+ * por dimensión de la rúbrica, ambos agrupados por mes del audioDate.
+ */
+@PageTitle("Evolución temporal")
+@Route(value = "supervision-timeline-report", layout = MainLayout.class)
+@RolesAllowed("ADMIN")
+public class SupervisionTimelineReportView extends VerticalLayout {
+
+	private static final String ACCENT = "#2E6DB4";
+	private static final String ALL_SURVEYORS = "Todos los encuestadores";
+	private static final String[] DIMENSION_COLORS = { "#2E6DB4", "#2F8F6B", "#E4A11B", "#8A6FB0" };
+
+	private final SupervisionSummaryService summaryService;
+	private final Div content = new Div();
+
+	public SupervisionTimelineReportView(SupervisionSummaryService summaryService) {
+		this.summaryService = summaryService;
+
+		setSizeFull();
+		setPadding(true);
+		setSpacing(false);
+		addClassName("supervision-timeline-report-view");
+
+		add(buildHeader());
+		add(buildSurveyorSelector());
+
+		content.setWidthFull();
+		add(content);
+
+		refresh(null);
+	}
+
+	private Div buildHeader() {
+		Div header = new Div();
+		header.getStyle().set("margin-bottom", "16px");
+
+		Span subtitle = new Span("Evolución de la supervisión a lo largo del tiempo");
+		subtitle.getStyle().set("color", "#8A93A3").set("font-size", "13px");
+
+		header.add(subtitle);
+		return header;
+	}
+
+	private Component buildSurveyorSelector() {
+		List<String> items = new ArrayList<>();
+		items.add(ALL_SURVEYORS);
+		items.addAll(summaryService.findSurveyorNames());
+
+		ComboBox<String> surveyorComboBox = new ComboBox<>("Encuestador");
+		surveyorComboBox.setItems(items);
+		surveyorComboBox.setValue(ALL_SURVEYORS);
+		surveyorComboBox.setWidth("320px");
+		surveyorComboBox.getStyle().set("margin-bottom", "16px");
+		surveyorComboBox.addValueChangeListener(event -> {
+			String value = event.getValue();
+			refresh(value == null || ALL_SURVEYORS.equals(value) ? null : value);
+		});
+		return surveyorComboBox;
+	}
+
+	/** Recalcula y vuelve a dibujar los gráficos para el encuestador seleccionado. */
+	private void refresh(String surveyor) {
+		SupervisionTimelineReportDTO report = summaryService.computeTimelineReport(surveyor);
+
+		content.removeAll();
+		content.add(buildGlobalScoreCard(report));
+		content.add(buildDimensionsCard(report));
+	}
+
+	/** PUNTAJE GLOBAL EN EL TIEMPO: línea con el promedio de aiScore por mes. */
+	private Div buildGlobalScoreCard(SupervisionTimelineReportDTO report) {
+		Div card = card();
+		card.getStyle().set("margin-bottom", "16px");
+		card.add(cardTitle("Puntaje global en el tiempo"));
+		card.add(cardCaption("Promedio del puntaje global por mes"));
+
+		if (report.getMonths().isEmpty()) {
+			card.add(noData());
+			return card;
+		}
+
+		ApexCharts chart = ApexChartsBuilder.get().withChart(ChartBuilder.get().withType(Type.LINE).build())
+				.withColors(ACCENT).withStroke(StrokeBuilder.get().withWidth(3.0).build())
+				.withDataLabels(DataLabelsBuilder.get().withEnabled(false).build())
+				.withSeries(new Series<>("Puntaje Global", toPoints(report.getMonths(), report.getGlobalScore())))
+				.build();
+		chart.setWidth("100%");
+		chart.setHeight("320px");
+		card.add(chart);
+		return card;
+	}
+
+	/** EVOLUCIÓN POR DIMENSIÓN DE LA RÚBRICA: una línea por dimensión. */
+	private Div buildDimensionsCard(SupervisionTimelineReportDTO report) {
+		Div card = card();
+		card.add(cardTitle("Evolución por dimensión de la rúbrica"));
+		card.add(cardCaption("Promedio de cada dimensión por mes"));
+
+		if (report.getMonths().isEmpty()) {
+			card.add(noData());
+			return card;
+		}
+
+		List<String> months = report.getMonths();
+
+		@SuppressWarnings("unchecked")
+		Series<ChartPoint>[] series = new Series[] {
+				new Series<>("Cobertura", toPoints(months, report.getCobertura())),
+				new Series<>("Fidelidad", toPoints(months, report.getFidelidad())),
+				new Series<>("Neutralidad", toPoints(months, report.getNeutralidad())),
+				new Series<>("Fluidez", toPoints(months, report.getFluidez())) };
+
+		ApexCharts chart = ApexChartsBuilder.get().withChart(ChartBuilder.get().withType(Type.LINE).build())
+				.withColors(DIMENSION_COLORS).withStroke(StrokeBuilder.get().withWidth(2.0).build())
+				.withDataLabels(DataLabelsBuilder.get().withEnabled(false).build())
+				.withLegend(LegendBuilder.get().withPosition(Position.BOTTOM).build()).withSeries(series).build();
+		chart.setWidth("100%");
+		chart.setHeight("340px");
+		card.add(chart);
+		return card;
+	}
+
+	private ChartPoint[] toPoints(List<String> months, List<Double> values) {
+		ChartPoint[] points = new ChartPoint[months.size()];
+		for (int i = 0; i < months.size(); i++) {
+			points[i] = new ChartPoint(months.get(i), values.get(i));
+		}
+		return points;
+	}
+
+	// --------------------------------------------------------------- Helpers
+
+	/**
+	 * Punto de datos {@code {x, y}} consumido por ApexCharts. El eje X toma el mes y
+	 * el eje Y el valor promedio. Jackson serializa ambos campos en el objeto de
+	 * datos de la serie.
+	 */
+	public static class ChartPoint {
+		private final String x;
+		private final Double y;
+
+		public ChartPoint(String x, Double y) {
+			this.x = x;
+			this.y = y;
+		}
+
+		public String getX() {
+			return x;
+		}
+
+		public Double getY() {
+			return y;
+		}
+	}
+
+	/** Una tarjeta blanca con el estilo del dashboard. */
+	private Div card() {
+		Div card = new Div();
+		card.getStyle().set("background", "#fff").set("border", "1px solid #E1E6EE").set("border-radius", "11px")
+				.set("padding", "20px 22px").set("box-shadow", "0 1px 2px rgba(16,42,78,0.04)");
+		return card;
+	}
+
+	private Span cardTitle(String text) {
+		Span span = new Span(text);
+		span.getStyle().set("display", "block").set("font-size", "13px").set("font-weight", "700")
+				.set("color", "#102A4E").set("text-transform", "uppercase").set("letter-spacing", "0.04em");
+		return span;
+	}
+
+	private Span cardCaption(String text) {
+		Span span = new Span(text);
+		span.getStyle().set("display", "block").set("font-size", "12px").set("color", "#8A93A3").set("margin",
+				"2px 0 10px");
+		return span;
+	}
+
+	private Component noData() {
+		Span span = new Span("Sin datos disponibles");
+		span.getStyle().set("color", "#8A93A3").set("font-size", "13px").set("font-style", "italic");
+		return span;
+	}
+}


### PR DESCRIPTION
## Resumen

Agrega una nueva vista **"Evolución temporal"** (`SupervisionTimelineReportView`, ruta `supervision-timeline-report`) con un dashboard ApexCharts filtrable por encuestador, y su sublink en el menú **Supervisión**.

La vista comienza con un **combobox de Encuestador** cuyos items son los valores distintos de `surveyor` de las `SupervisionTask`, más la opción por defecto **"Todos los encuestadores"** (seleccionada al inicio). Al cambiar la selección, ambos gráficos se recalculan filtrando las `SupervisionTask` por `surveyor` (o sin filtro si es "Todos los encuestadores").

## Cambios principales

- **Nueva vista** `SupervisionTimelineReportView` con dos gráficos de líneas:
  - **Puntaje global en el tiempo**: promedio de `aiScore` agrupado por mes del `audioDate`.
  - **Evolución por dimensión de la rúbrica**: una serie por dimensión (`scoreCobertura`, `scoreFidelidad`, `scoreNeutralidad`, `scoreFluidez`), cada una promediada y agrupada por mes del `audioDate`.

- **Nuevo DTO** `SupervisionTimelineReportDTO`: listas de meses (eje X compartido) y de promedios por mes, alineadas por índice.

- **Servicio** `SupervisionSummaryService`: nuevos métodos `findSurveyorNames()` y `computeTimelineReport(surveyor)` (agrupa por mes en memoria).

- **Repositorio** `SupervisionTaskRepository`: `findDistinctSurveyors()` y `findMonthlyStatsBySurveyor(surveyor)` (proyección de fecha + puntaje + 4 dimensiones, filtrada por encuestador).

- **Navegación**: `MainLayout` incorpora el sublink "Evolución temporal" bajo el menú Supervisión.

## Cómo se construye cada indicador (filtrando por `surveyor`)

- **Puntaje global en el tiempo** (línea): promedia `aiScore` de las `SupervisionTask` del encuestador, agrupadas por mes del `audioDate`.
- **Evolución por dimensión** (líneas): agrupa por mes del `audioDate` y crea una línea por cada promedio de `scoreCobertura` (cobertura), `scoreFidelidad` (fidelidad), `scoreNeutralidad` (neutralidad) y `scoreFluidez` (fluidez).

## Notas

- Usa el plugin ApexCharts ya presente en el `pom.xml`, replicando los patrones de las vistas de supervisión existentes.
- Vista protegida con `@RolesAllowed("ADMIN")` y servicio transaccional de solo lectura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012x1NyENKB7nVfrRJuettsy

---
_Generated by [Claude Code](https://claude.ai/code/session_012x1NyENKB7nVfrRJuettsy)_