### PR TITLE
Render de gráficos ApexCharts: fix global en MainLayout (cubre los dashboards)

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/ApexChartRenderHelper.java
+++ b/src/main/java/uy/com/bay/utiles/views/ApexChartRenderHelper.java
@@ -28,8 +28,11 @@ public final class ApexChartRenderHelper {
 	 *                view's own element)
 	 */
 	public static void scheduleResize(Element element) {
+		// Fire several times: after the next two animation frames (fast path) and at a
+		// few delays, to also cover slow first paints / data-driven charts that finish
+		// laying out a bit later.
 		element.executeJs("const fire = () => window.dispatchEvent(new Event('resize'));"
 				+ "requestAnimationFrame(() => requestAnimationFrame(fire));"
-				+ "setTimeout(fire, 200);");
+				+ "[150, 500, 1000].forEach(d => setTimeout(fire, d));");
 	}
 }

--- a/src/main/java/uy/com/bay/utiles/views/MainLayout.java
+++ b/src/main/java/uy/com/bay/utiles/views/MainLayout.java
@@ -363,6 +363,12 @@ public class MainLayout extends AppLayout {
 	protected void afterNavigation() {
 		super.afterNavigation();
 		viewTitle.setText(getCurrentPageTitle());
+		// Some client-side components (notably ApexCharts) measure their container at
+		// render time and can be drawn blank when a view is opened before the layout
+		// has settled, only appearing after navigating elsewhere. Nudging a resize
+		// after each navigation forces every chart in the loaded view (including the
+		// supervision dashboards) to recompute its size and draw.
+		ApexChartRenderHelper.scheduleResize(getElement());
 	}
 
 	@Override

--- a/src/main/java/uy/com/bay/utiles/views/joborders/JobOrderAvailabilityView.java
+++ b/src/main/java/uy/com/bay/utiles/views/joborders/JobOrderAvailabilityView.java
@@ -28,7 +28,6 @@ import com.github.appreciated.apexcharts.config.plotoptions.xmap.ColorScale;
 import com.github.appreciated.apexcharts.config.plotoptions.xmap.Ranges;
 import com.github.appreciated.apexcharts.config.xaxis.XAxisType;
 import com.github.appreciated.apexcharts.helper.Series;
-import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.datepicker.DatePicker;
@@ -46,7 +45,6 @@ import jakarta.annotation.security.RolesAllowed;
 import uy.com.bay.utiles.data.JobOrder;
 import uy.com.bay.utiles.data.Provider;
 import uy.com.bay.utiles.services.JobOrderService;
-import uy.com.bay.utiles.views.ApexChartRenderHelper;
 
 @PageTitle("Disponibilidad de proveedores")
 @Route("joborder-availability")
@@ -120,14 +118,6 @@ public class JobOrderAvailabilityView extends VerticalLayout {
 		add(chartContainer);
 
 		rebuildChart();
-	}
-
-	@Override
-	protected void onAttach(AttachEvent attachEvent) {
-		super.onAttach(attachEvent);
-		// ApexCharts can be drawn at 0px width when the view is opened directly;
-		// force a resize once attached so the heatmap renders reliably.
-		ApexChartRenderHelper.scheduleResize(getElement());
 	}
 
 	private void rebuildChart() {

--- a/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionMethodologyView.java
+++ b/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionMethodologyView.java
@@ -10,7 +10,6 @@ import com.github.appreciated.apexcharts.config.builder.LegendBuilder;
 import com.github.appreciated.apexcharts.config.builder.StrokeBuilder;
 import com.github.appreciated.apexcharts.config.chart.Type;
 import com.github.appreciated.apexcharts.config.legend.Position;
-import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Html;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
@@ -21,7 +20,6 @@ import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 
 import jakarta.annotation.security.RolesAllowed;
-import uy.com.bay.utiles.views.ApexChartRenderHelper;
 import uy.com.bay.utiles.views.MainLayout;
 
 /**
@@ -67,19 +65,6 @@ public class SupervisionMethodologyView extends VerticalLayout {
 		add(buildHeader());
 		add(buildTopRow());
 		add(buildRubricCards());
-	}
-
-	/**
-	 * ApexCharts measures its container size at render time. When the user navigates
-	 * straight to this view, the donut can be drawn before the layout has settled
-	 * (drawer animation / container still 0px wide), producing an empty SVG that only
-	 * appears after visiting other views. Once attached and painted we ask ApexCharts
-	 * to recompute its size; the chart keeps width:100% so it stays responsive.
-	 */
-	@Override
-	protected void onAttach(AttachEvent attachEvent) {
-		super.onAttach(attachEvent);
-		ApexChartRenderHelper.scheduleResize(getElement());
 	}
 
 	private Div buildHeader() {


### PR DESCRIPTION
## Contexto

El PR #328 corrigió el render intermitente de ApexCharts con un `onAttach` **por vista**, pero solo cubría `SupervisionMethodologyView` (dona) y `JobOrderAvailabilityView` (heatmap). Los **4 dashboards de supervisión** (`supervision-summary`, `supervision-study-report`, `supervision-surveyor-report`, `supervision-timeline-report`) **no tenían el fix** y seguían dibujándose en blanco al entrar directo a la vista.

Diagnóstico confirmado con DevTools en producción: todo el contenido renderiza menos los gráficos; el push funciona (XHR 200) y los chunks JS cargan (200), sin errores. La dona de Metodología tiene datos fijos y aun así quedaba en blanco → es ApexCharts midiendo el contenedor con ancho 0 al renderizar. Lo confirma el propio comportamiento: al navegar a otra vista y volver, el gráfico aparece.

## Cambios

- **`MainLayout.afterNavigation()`**: dispara el `resize` después de **cada** navegación, de modo que **todas las vistas con gráficos** (presentes y futuras, incluidos los 4 dashboards) recalculen su tamaño al cargarse. Un único mecanismo, en un solo lugar.
- **`ApexChartRenderHelper`**: reforzado para disparar el `resize` varias veces (doble `requestAnimationFrame` + 150/500/1000 ms), cubriendo también gráficos con primer *paint* lento o con datos.
- **`SupervisionMethodologyView` / `JobOrderAvailabilityView`**: se elimina el `onAttach` por vista (ahora redundante con el global) y sus imports.

Los gráficos mantienen `width: 100%` → la responsividad se conserva; solo se fuerza el recálculo de tamaño.

## Verificación

No fue posible compilar en el entorno de desarrollo (la red bloquea `maven.vaadin.com`, donde vive el addon `apexcharts`). Tras desplegar, entrar **directo** (sin pasar por otra vista) a `supervision-summary` y `supervision-methodology` y confirmar que los gráficos aparecen a la primera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wd3qEChuykJSpFdDNSGKX8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wd3qEChuykJSpFdDNSGKX8)_