### PR TITLE
Render de gráficos: rollout de deferred a dashboards y heatmap + limpieza

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/ApexChartRenderHelper.java
+++ b/src/main/java/uy/com/bay/utiles/views/ApexChartRenderHelper.java
@@ -2,6 +2,7 @@ package uy.com.bay.utiles.views;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableSupplier;
 
@@ -19,8 +20,8 @@ import com.vaadin.flow.function.SerializableSupplier;
  * created fresh while everything is already loaded and laid out.
  *
  * <p>
- * {@link #renderDeferred} reproduces that working scenario on purpose: it waits
- * for the browser to lay out the container and then builds/adds the chart, so the
+ * Both entry points here reproduce that working scenario on purpose: the chart is
+ * attached to the DOM only after the browser has laid out its container, so the
  * wrapper is created when the module is loaded and the container has a real width.
  * The chart keeps its percentage width, so responsiveness is preserved.
  */
@@ -34,14 +35,29 @@ public final class ApexChartRenderHelper {
 	}
 
 	/**
-	 * Builds and adds an ApexCharts component into {@code chartContainer} only after
-	 * the browser has laid out that container. Must be called while the container is
-	 * attached (typically from {@code onAttach}); the container should be dedicated
-	 * to the chart, since it is cleared before the chart is added.
+	 * Wraps a chart in a full-width holder that adds it to the DOM only once its
+	 * container has been laid out. Drop-in replacement for adding the chart
+	 * directly: {@code parent.add(deferred(chart))}.
 	 *
-	 * @param chartContainer the (attached) element that will hold the chart
-	 * @param chartFactory   builds a fresh chart component; invoked once the layout
-	 *                       is ready
+	 * @param chart the chart component to render once the layout is ready
+	 * @return a holder to add to the layout in place of the chart
+	 */
+	public static Component deferred(Component chart) {
+		Div holder = new Div();
+		holder.setWidthFull();
+		renderDeferred(holder, () -> chart);
+		return holder;
+	}
+
+	/**
+	 * Builds and adds an ApexCharts component into {@code chartContainer} only after
+	 * the browser has laid out that container. The container should be dedicated to
+	 * the chart, since it is cleared before the chart is added. Safe to call while
+	 * the container is still detached: the client script runs once it is attached.
+	 *
+	 * @param chartContainer the element that will hold the chart
+	 * @param chartFactory   supplies the chart component; invoked once the layout is
+	 *                       ready
 	 */
 	public static void renderDeferred(HasComponents chartContainer, SerializableSupplier<Component> chartFactory) {
 		Element container = ((Component) chartContainer).getElement();
@@ -49,19 +65,5 @@ public final class ApexChartRenderHelper {
 			chartContainer.removeAll();
 			chartContainer.add(chartFactory.get());
 		});
-	}
-
-	/**
-	 * Schedules a window {@code resize} event after the next paints so any already
-	 * created ApexCharts recompute their dimensions. Kept for charts that are known
-	 * to be created but drawn at the wrong size.
-	 *
-	 * @param element the element used to run the client-side script (typically the
-	 *                view's own element)
-	 */
-	public static void scheduleResize(Element element) {
-		element.executeJs("const fire = () => window.dispatchEvent(new Event('resize'));"
-				+ "requestAnimationFrame(() => requestAnimationFrame(fire));"
-				+ "setTimeout(fire, 200);");
 	}
 }

--- a/src/main/java/uy/com/bay/utiles/views/MainLayout.java
+++ b/src/main/java/uy/com/bay/utiles/views/MainLayout.java
@@ -363,12 +363,6 @@ public class MainLayout extends AppLayout {
 	protected void afterNavigation() {
 		super.afterNavigation();
 		viewTitle.setText(getCurrentPageTitle());
-		// Some client-side components (notably ApexCharts) measure their container at
-		// render time and can be drawn blank when a view is opened before the layout
-		// has settled, only appearing after navigating elsewhere. Nudging a resize
-		// after each navigation forces every chart in the loaded view (including the
-		// supervision dashboards) to recompute its size and draw.
-		ApexChartRenderHelper.scheduleResize(getElement());
 	}
 
 	@Override

--- a/src/main/java/uy/com/bay/utiles/views/joborders/JobOrderAvailabilityView.java
+++ b/src/main/java/uy/com/bay/utiles/views/joborders/JobOrderAvailabilityView.java
@@ -45,6 +45,7 @@ import jakarta.annotation.security.RolesAllowed;
 import uy.com.bay.utiles.data.JobOrder;
 import uy.com.bay.utiles.data.Provider;
 import uy.com.bay.utiles.services.JobOrderService;
+import uy.com.bay.utiles.views.ApexChartRenderHelper;
 
 @PageTitle("Disponibilidad de proveedores")
 @Route("joborder-availability")
@@ -142,7 +143,7 @@ public class JobOrderAvailabilityView extends VerticalLayout {
 		}
 
 		ApexCharts chart = buildChart(from, to, series);
-		chartContainer.add(chart);
+		chartContainer.add(ApexChartRenderHelper.deferred(chart));
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })

--- a/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionStudyReportView.java
+++ b/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionStudyReportView.java
@@ -25,6 +25,7 @@ import uy.com.bay.utiles.data.service.SupervisionSummaryService;
 import uy.com.bay.utiles.dto.SupervisionStudyReportDTO;
 import uy.com.bay.utiles.dto.SupervisionStudyReportDTO.SurveyorScore;
 import uy.com.bay.utiles.dto.SupervisionSummaryDTO.DimensionScores;
+import uy.com.bay.utiles.views.ApexChartRenderHelper;
 import uy.com.bay.utiles.views.MainLayout;
 
 /**
@@ -160,7 +161,7 @@ public class SupervisionStudyReportView extends VerticalLayout {
 				.withSeries(new Series<>("Promedio", values)).build();
 		chart.setWidth("100%");
 		chart.setHeight("320px");
-		card.add(chart);
+		card.add(ApexChartRenderHelper.deferred(chart));
 		return card;
 	}
 
@@ -188,7 +189,7 @@ public class SupervisionStudyReportView extends VerticalLayout {
 		int height = Math.max(320, scoreBySurveyor.size() * 42 + 80);
 		chart.setWidth("100%");
 		chart.setHeight(height + "px");
-		card.add(chart);
+		card.add(ApexChartRenderHelper.deferred(chart));
 		return card;
 	}
 

--- a/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionSummaryView.java
+++ b/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionSummaryView.java
@@ -27,6 +27,7 @@ import uy.com.bay.utiles.dto.SupervisionSummaryDTO;
 import uy.com.bay.utiles.dto.SupervisionSummaryDTO.DimensionScores;
 import uy.com.bay.utiles.dto.SupervisionSummaryDTO.MonthScore;
 import uy.com.bay.utiles.dto.SupervisionSummaryDTO.StudyScore;
+import uy.com.bay.utiles.views.ApexChartRenderHelper;
 import uy.com.bay.utiles.views.MainLayout;
 
 /**
@@ -146,7 +147,7 @@ public class SupervisionSummaryView extends VerticalLayout {
 				.withSeries(new Series<>("Puntaje Global", points)).build();
 		chart.setWidth("100%");
 		chart.setHeight("300px");
-		card.add(chart);
+		card.add(ApexChartRenderHelper.deferred(chart));
 		return card;
 	}
 
@@ -171,7 +172,7 @@ public class SupervisionSummaryView extends VerticalLayout {
 				.withLegend(LegendBuilder.get().withPosition(Position.BOTTOM).build()).build();
 		chart.setWidth("100%");
 		chart.setHeight("300px");
-		chartContainer.add(chart);
+		chartContainer.add(ApexChartRenderHelper.deferred(chart));
 		card.add(chartContainer);
 		return card;
 	}
@@ -192,7 +193,7 @@ public class SupervisionSummaryView extends VerticalLayout {
 				.withSeries(new Series<>("Promedio", values)).build();
 		chart.setWidth("100%");
 		chart.setHeight("320px");
-		card.add(chart);
+		card.add(ApexChartRenderHelper.deferred(chart));
 		return card;
 	}
 
@@ -222,7 +223,7 @@ public class SupervisionSummaryView extends VerticalLayout {
 		int height = Math.max(320, scoreByStudy.size() * 42 + 80);
 		chart.setWidth("100%");
 		chart.setHeight(height + "px");
-		card.add(chart);
+		card.add(ApexChartRenderHelper.deferred(chart));
 		return card;
 	}
 

--- a/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionSurveyorReportView.java
+++ b/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionSurveyorReportView.java
@@ -24,6 +24,7 @@ import uy.com.bay.utiles.data.service.SupervisionSummaryService;
 import uy.com.bay.utiles.dto.SupervisionStudyReportDTO.SurveyorScore;
 import uy.com.bay.utiles.dto.SupervisionSurveyorReportDTO;
 import uy.com.bay.utiles.dto.SupervisionSurveyorReportDTO.SurveyorProfile;
+import uy.com.bay.utiles.views.ApexChartRenderHelper;
 import uy.com.bay.utiles.views.MainLayout;
 
 /**
@@ -99,7 +100,7 @@ public class SupervisionSurveyorReportView extends VerticalLayout {
 		int height = Math.max(320, ranking.size() * 42 + 80);
 		chart.setWidth("100%");
 		chart.setHeight(height + "px");
-		card.add(chart);
+		card.add(ApexChartRenderHelper.deferred(chart));
 		return card;
 	}
 
@@ -123,7 +124,7 @@ public class SupervisionSurveyorReportView extends VerticalLayout {
 				.build();
 		chart.setWidth("100%");
 		chart.setHeight("360px");
-		card.add(chart);
+		card.add(ApexChartRenderHelper.deferred(chart));
 		return card;
 	}
 

--- a/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionTimelineReportView.java
+++ b/src/main/java/uy/com/bay/utiles/views/supervision/SupervisionTimelineReportView.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.router.Route;
 import jakarta.annotation.security.RolesAllowed;
 import uy.com.bay.utiles.data.service.SupervisionSummaryService;
 import uy.com.bay.utiles.dto.SupervisionTimelineReportDTO;
+import uy.com.bay.utiles.views.ApexChartRenderHelper;
 import uy.com.bay.utiles.views.MainLayout;
 
 /**
@@ -116,7 +117,7 @@ public class SupervisionTimelineReportView extends VerticalLayout {
 				.build();
 		chart.setWidth("100%");
 		chart.setHeight("320px");
-		card.add(chart);
+		card.add(ApexChartRenderHelper.deferred(chart));
 		return card;
 	}
 
@@ -146,7 +147,7 @@ public class SupervisionTimelineReportView extends VerticalLayout {
 				.withLegend(LegendBuilder.get().withPosition(Position.BOTTOM).build()).withSeries(series).build();
 		chart.setWidth("100%");
 		chart.setHeight("340px");
-		card.add(chart);
+		card.add(ApexChartRenderHelper.deferred(chart));
 		return card;
 	}
 


### PR DESCRIPTION
## Contexto

El #330 validó en la vista **Metodología** el fix real: crear el gráfico ApexCharts **después** de que el contenedor tiene layout (el addon crea el chart una sola vez en `firstUpdated()`, así que si el elemento se inserta antes de que su módulo/tamaño estén listos, queda vacío). Este PR **replica ese fix al resto de las vistas con gráficos** y **limpia** los intentos previos con `resize`.

## Cambios

- **`ApexChartRenderHelper.deferred(chart)`**: envuelve un gráfico en un contenedor que lo adjunta al DOM recién cuando ya está pintado. Reemplazo directo: `card.add(deferred(chart))`.
- **Rollout** (cada `card.add(chart)` → `card.add(ApexChartRenderHelper.deferred(chart))`):
  - `SupervisionSummaryView` — 4 gráficos (evolución, nivel, dimensiones, por proyecto)
  - `SupervisionStudyReportView` — 2 (radar + barras)
  - `SupervisionSurveyorReportView` — 2 (barras + radar)
  - `SupervisionTimelineReportView` — 2 (líneas)
  - `JobOrderAvailabilityView` — heatmap
- **Limpieza** del intento fallido con `resize` (que había quedado en `main`):
  - Se elimina `scheduleResize` del helper.
  - Se revierte el `resize` global de `MainLayout.afterNavigation()` (queda como estaba originalmente).

La vista Metodología ya usa `renderDeferred` (del #330) y no se toca. Los gráficos mantienen `width: 100%` → responsividad intacta.

## Verificación

No fue posible compilar en el entorno (la red bloquea `maven.vaadin.com`). Tras desplegar, entrar **directo** (sin pasar por otra vista) a `supervision-summary`, `supervision-study-report`, `supervision-surveyor-report`, `supervision-timeline-report` y `joborder-availability`, y confirmar que los gráficos aparecen a la primera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wd3qEChuykJSpFdDNSGKX8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wd3qEChuykJSpFdDNSGKX8)_