### PR TITLE
Cargar el módulo de ApexCharts al inicio (@Uses en MainLayout)

### DIFF
--- a/src/main/java/uy/com/bay/utiles/views/MainLayout.java
+++ b/src/main/java/uy/com/bay/utiles/views/MainLayout.java
@@ -5,9 +5,11 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
+import com.github.appreciated.apexcharts.ApexCharts;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.applayout.AppLayout;
 import com.vaadin.flow.component.applayout.DrawerToggle;
+import com.vaadin.flow.component.dependency.Uses;
 import com.vaadin.flow.component.avatar.Avatar;
 import com.vaadin.flow.component.contextmenu.MenuItem;
 import com.vaadin.flow.component.html.Anchor;
@@ -49,6 +51,11 @@ import uy.com.bay.utiles.views.extras.ExtrasReportDialog;
 
 @Layout
 @AnonymousAllowed
+// Force the ApexCharts addon's frontend module to load eagerly at app startup.
+// Without this it loads lazily, so on a direct page load the <apex-charts-wrapper>
+// custom element is inserted before its module is registered and never upgrades
+// (firstUpdated() never runs), leaving the chart blank until a later navigation.
+@Uses(ApexCharts.class)
 public class MainLayout extends AppLayout {
 
 	private H1 viewTitle;


### PR DESCRIPTION
## Causa raíz (confirmada con el DOM)

El `<apex-charts-wrapper>` queda **vacío** incluso creando el gráfico después del layout (el `deferred` del #330/#331 no alcanzó). El motivo real:

- El addon expone el web component con `@Tag("apex-charts-wrapper")` + `@JsModule(".../apexcharts-wrapper.ts")`, y ese módulo se carga **lazy**.
- En una carga directa, Flow inserta el `<apex-charts-wrapper>` **antes** de que ese módulo esté registrado → el custom element no se "upgradea" → `firstUpdated()` (donde el addon crea el chart) **nunca corre** → wrapper vacío.
- Al **navegar y volver**, el módulo ya está cargado → el elemento nuevo se upgradea → renderiza. (Por eso el `resize` y el `deferred` no servían: el problema no es tamaño ni timing de layout, es que el módulo no está disponible.)

## Fix

`@Uses(ApexCharts.class)` en `MainLayout` (que siempre está presente) fuerza a Flow a **cargar el `@JsModule` del addon en el arranque**. Así `apex-charts-wrapper` queda definido antes de renderizar cualquier vista y los gráficos se dibujan a la primera — en Metodología, en los 4 dashboards y en el heatmap.

Cambio mínimo: 1 archivo, +7 líneas (imports + anotación).

## Nota

El `deferred` que quedó de los PRs anteriores es inofensivo y sigue cubriendo el caso de tamaño; se puede simplificar más adelante si querés. No fue posible compilar en el entorno (`maven.vaadin.com` bloqueado); hay que desplegar y entrar **directo** a una vista con gráficos para confirmar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wd3qEChuykJSpFdDNSGKX8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wd3qEChuykJSpFdDNSGKX8)_