### PR TITLE
Add Excel export functionality for surveyors list

### DIFF
--- a/src/main/java/uy/com/bay/utiles/services/ExcelReportGenerator.java
+++ b/src/main/java/uy/com/bay/utiles/services/ExcelReportGenerator.java
@@ -69,6 +69,36 @@ public class ExcelReportGenerator {
         }
     }
 
+    public static ByteArrayOutputStream generateSurveyorExcel(List<Surveyor> surveyors) throws IOException {
+        try (XSSFWorkbook workbook = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            XSSFSheet sheet = workbook.createSheet("Encuestadores");
+
+            List<Field> surveyorFields = getFields(Surveyor.class);
+
+            Row headerRow = sheet.createRow(0);
+            for (int i = 0; i < surveyorFields.size(); i++) {
+                Cell cell = headerRow.createCell(i);
+                cell.setCellValue(surveyorFields.get(i).getName());
+            }
+
+            CellStyle dateCellStyle = workbook.createCellStyle();
+            CreationHelper createHelper = workbook.getCreationHelper();
+            dateCellStyle.setDataFormat(createHelper.createDataFormat().getFormat("dd/MM/yyyy"));
+
+            int rowNum = 1;
+            for (Surveyor surveyor : surveyors) {
+                Row row = sheet.createRow(rowNum++);
+                int cellNum = 0;
+                for (Field field : surveyorFields) {
+                    cellNum = writeFieldToCell(surveyor, field, row, cellNum, dateCellStyle);
+                }
+            }
+
+            workbook.write(out);
+            return out;
+        }
+    }
+
     private static List<Field> getFields(Class<?> clazz) {
         List<Field> fields = new ArrayList<>();
         while (clazz != null) {

--- a/src/main/java/uy/com/bay/utiles/views/surveyors/EncuestadoresView.java
+++ b/src/main/java/uy/com/bay/utiles/views/surveyors/EncuestadoresView.java
@@ -333,7 +333,14 @@ public class EncuestadoresView extends Div implements BeforeEnterObserver {
 
 		// Title Layout
 		H2 title = new H2("Encuestadores");
-		HorizontalLayout titleLayout = new HorizontalLayout(title, addButton);
+
+		Button exportButton = new Button("Exportar");
+		exportButton.addThemeVariants(ButtonVariant.LUMO_CONTRAST);
+		Anchor exportLink = new Anchor(createSurveyorExcelStreamResource(), "");
+		exportLink.getElement().setAttribute("download", true);
+		exportLink.add(exportButton);
+
+		HorizontalLayout titleLayout = new HorizontalLayout(title, addButton, exportLink);
 		titleLayout.setWidthFull();
 		titleLayout.setAlignItems(Alignment.BASELINE); // Align items nicely
 		titleLayout.setFlexGrow(1, title); // Title takes available space
@@ -398,6 +405,20 @@ public class EncuestadoresView extends Div implements BeforeEnterObserver {
 
 			dialog.open();
 		}
+	}
+
+	private StreamResource createSurveyorExcelStreamResource() {
+		return new StreamResource("encuestadores.xlsx", () -> {
+			try {
+				List<Surveyor> surveyors = encuestadorService.findAll();
+				ByteArrayOutputStream excelOutput = ExcelReportGenerator.generateSurveyorExcel(surveyors);
+				return new ByteArrayInputStream(excelOutput.toByteArray());
+			} catch (IOException e) {
+				Notification.show("Error al generar el archivo Excel", 3000, Notification.Position.MIDDLE)
+						.addThemeVariants(NotificationVariant.LUMO_ERROR);
+				return new ByteArrayInputStream(new byte[0]);
+			}
+		});
 	}
 
 	private StreamResource createExcelStreamResource(List<JournalEntry> journalEntries) {


### PR DESCRIPTION
## Summary
Added the ability to export the surveyors (encuestadores) list to an Excel file, following the same pattern already established for journal entries export.

## Key Changes
- **ExcelReportGenerator.java**: Added new `generateSurveyorExcel()` method that creates an Excel workbook with surveyor data, including proper date formatting for date fields
- **EncuestadoresView.java**: 
  - Added an "Exportar" (Export) button to the surveyors view header
  - Implemented `createSurveyorExcelStreamResource()` method to handle Excel file generation and download
  - Integrated the export button with the existing UI layout using an Anchor element for file download

## Implementation Details
- The export functionality reuses the existing `getFields()` and `writeFieldToCell()` utility methods from ExcelReportGenerator for consistency
- Date fields are formatted as "dd/MM/yyyy" in the Excel output
- Error handling includes user notification if Excel generation fails
- The exported file is named "encuestadores.xlsx" and uses the same StreamResource pattern as the existing journal entries export

https://claude.ai/code/session_01Wp6rGa9GMTNApgEbSZRL6M