### PR TITLE
Add date filter dialog for surveyor export with transfer amounts

### DIFF
--- a/src/main/java/uy/com/bay/utiles/data/repository/JournalEntryRepository.java
+++ b/src/main/java/uy/com/bay/utiles/data/repository/JournalEntryRepository.java
@@ -1,9 +1,12 @@
 package uy.com.bay.utiles.data.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import uy.com.bay.utiles.data.ExpenseReport;
 import uy.com.bay.utiles.data.JournalEntry;
@@ -18,4 +21,16 @@ public interface JournalEntryRepository
 	List<JournalEntry> findAllByStudyOrderByDateAsc(Study study);
 
 	List<JournalEntry> findAllByExpenseReport(ExpenseReport expenseReport);
+
+	/**
+	 * Sums the amount of the {@link uy.com.bay.utiles.data.ExpenseTransfer}
+	 * referenced by the journal entries of each surveyor whose transfer date is on
+	 * or after the given date, grouped by surveyor id.
+	 *
+	 * @return a list of {@code [surveyorId, sumOfTransferAmounts]} rows
+	 */
+	@Query("SELECT je.surveyor.id, SUM(je.transfer.amount) FROM JournalEntry je "
+			+ "WHERE je.transfer IS NOT NULL AND je.transfer.transferDate >= :fromDate "
+			+ "GROUP BY je.surveyor.id")
+	List<Object[]> sumTransferAmountsBySurveyor(@Param("fromDate") LocalDate fromDate);
 }

--- a/src/main/java/uy/com/bay/utiles/services/ExcelReportGenerator.java
+++ b/src/main/java/uy/com/bay/utiles/services/ExcelReportGenerator.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 public class ExcelReportGenerator {
 
@@ -69,7 +70,8 @@ public class ExcelReportGenerator {
         }
     }
 
-    public static ByteArrayOutputStream generateSurveyorExcel(List<Surveyor> surveyors) throws IOException {
+    public static ByteArrayOutputStream generateSurveyorExcel(List<Surveyor> surveyors,
+            Map<Long, Double> transferSumsBySurveyorId) throws IOException {
         try (XSSFWorkbook workbook = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             XSSFSheet sheet = workbook.createSheet("Encuestadores");
 
@@ -90,7 +92,16 @@ public class ExcelReportGenerator {
                 Row row = sheet.createRow(rowNum++);
                 int cellNum = 0;
                 for (Field field : surveyorFields) {
-                    cellNum = writeFieldToCell(surveyor, field, row, cellNum, dateCellStyle);
+                    if ("balance".equals(field.getName())) {
+                        double transferSum = 0.0;
+                        if (transferSumsBySurveyorId != null && surveyor.getId() != null) {
+                            transferSum = transferSumsBySurveyorId.getOrDefault(surveyor.getId(), 0.0);
+                        }
+                        Cell cell = row.createCell(cellNum++);
+                        cell.setCellValue(surveyor.getBalance() + transferSum);
+                    } else {
+                        cellNum = writeFieldToCell(surveyor, field, row, cellNum, dateCellStyle);
+                    }
                 }
             }
 

--- a/src/main/java/uy/com/bay/utiles/services/JournalEntryService.java
+++ b/src/main/java/uy/com/bay/utiles/services/JournalEntryService.java
@@ -3,8 +3,11 @@ package uy.com.bay.utiles.services;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.springframework.data.jpa.domain.Specification;
@@ -34,6 +37,31 @@ public class JournalEntryService {
 
 	public List<JournalEntry> findAllByStudy(Study study) {
 		return repository.findAllByStudyOrderByDateAsc(study);
+	}
+
+	/**
+	 * Returns, for each surveyor, the sum of the amounts of the
+	 * {@link uy.com.bay.utiles.data.ExpenseTransfer} entities referenced by their
+	 * journal entries whose transfer date is on or after {@code fromDate}. If
+	 * {@code fromDate} is {@code null} no transfers are considered and an empty map
+	 * is returned.
+	 *
+	 * @param fromDate the earliest transfer date to consider (inclusive)
+	 * @return a map of surveyor id to the sum of transfer amounts
+	 */
+	public Map<Long, Double> sumTransferAmountsBySurveyor(LocalDate fromDate) {
+		if (fromDate == null) {
+			return Collections.emptyMap();
+		}
+		Map<Long, Double> result = new HashMap<>();
+		for (Object[] row : repository.sumTransferAmountsBySurveyor(fromDate)) {
+			Long surveyorId = (Long) row[0];
+			Double sum = (Double) row[1];
+			if (surveyorId != null) {
+				result.put(surveyorId, sum != null ? sum : 0.0);
+			}
+		}
+		return result;
 	}
 
 	public List<JournalEntry> list(Specification<JournalEntry> filter) {

--- a/src/main/java/uy/com/bay/utiles/views/surveyors/EncuestadoresView.java
+++ b/src/main/java/uy/com/bay/utiles/views/surveyors/EncuestadoresView.java
@@ -3,7 +3,9 @@ package uy.com.bay.utiles.views.surveyors;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
@@ -13,6 +15,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.confirmdialog.ConfirmDialog;
+import com.vaadin.flow.component.datetimepicker.DateTimePicker;
 import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.grid.Grid;
@@ -20,11 +23,13 @@ import com.vaadin.flow.component.grid.GridVariant;
 import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.notification.Notification.Position;
 import com.vaadin.flow.component.notification.NotificationVariant;
 import com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.splitlayout.SplitLayout;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.binder.BeanValidationBinder;
@@ -336,11 +341,9 @@ public class EncuestadoresView extends Div implements BeforeEnterObserver {
 
 		Button exportButton = new Button("Exportar");
 		exportButton.addThemeVariants(ButtonVariant.LUMO_CONTRAST);
-		Anchor exportLink = new Anchor(createSurveyorExcelStreamResource(), "");
-		exportLink.getElement().setAttribute("download", true);
-		exportLink.add(exportButton);
+		exportButton.addClickListener(e -> showExportDialog());
 
-		HorizontalLayout titleLayout = new HorizontalLayout(title, addButton, exportLink);
+		HorizontalLayout titleLayout = new HorizontalLayout(title, addButton, exportButton);
 		titleLayout.setWidthFull();
 		titleLayout.setAlignItems(Alignment.BASELINE); // Align items nicely
 		titleLayout.setFlexGrow(1, title); // Title takes available space
@@ -407,11 +410,42 @@ public class EncuestadoresView extends Div implements BeforeEnterObserver {
 		}
 	}
 
-	private StreamResource createSurveyorExcelStreamResource() {
+	private void showExportDialog() {
+		Dialog dialog = new Dialog();
+		dialog.setHeaderTitle("Exportar Encuestadores");
+		dialog.setCloseOnEsc(true);
+		dialog.setCloseOnOutsideClick(true);
+
+		Paragraph message = new Paragraph("Indicar la fecha hasta cuando se debe considerar las transferencias");
+		DateTimePicker transferDatePicker = new DateTimePicker();
+		transferDatePicker.setWidthFull();
+
+		VerticalLayout content = new VerticalLayout(message, transferDatePicker);
+		content.setPadding(false);
+		content.setSpacing(false);
+		dialog.add(content);
+
+		Button downloadButton = new Button("Descargar");
+		downloadButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+		Anchor downloadLink = new Anchor(createSurveyorExcelStreamResource(transferDatePicker), "");
+		downloadLink.getElement().setAttribute("download", true);
+		downloadLink.add(downloadButton);
+
+		Button closeButton = new Button("Cerrar", e -> dialog.close());
+		closeButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+
+		dialog.getFooter().add(downloadLink, closeButton);
+		dialog.open();
+	}
+
+	private StreamResource createSurveyorExcelStreamResource(DateTimePicker transferDatePicker) {
 		return new StreamResource("encuestadores.xlsx", () -> {
 			try {
 				List<Surveyor> surveyors = encuestadorService.findAll();
-				ByteArrayOutputStream excelOutput = ExcelReportGenerator.generateSurveyorExcel(surveyors);
+				LocalDate fromDate = transferDatePicker.getValue() != null ? transferDatePicker.getValue().toLocalDate()
+						: null;
+				Map<Long, Double> transferSums = journalEntryService.sumTransferAmountsBySurveyor(fromDate);
+				ByteArrayOutputStream excelOutput = ExcelReportGenerator.generateSurveyorExcel(surveyors, transferSums);
 				return new ByteArrayInputStream(excelOutput.toByteArray());
 			} catch (IOException e) {
 				Notification.show("Error al generar el archivo Excel", 3000, Notification.Position.MIDDLE)


### PR DESCRIPTION
## Summary
This PR adds a date-based filtering feature to the surveyor export functionality, allowing users to specify a cutoff date for including transfer amounts in the Excel report.

## Key Changes

- **Export Dialog**: Replaced direct export link with a dialog that prompts users to select a transfer date cutoff
  - New `showExportDialog()` method displays a dialog with a DateTimePicker component
  - Users can specify the date from which transfer amounts should be included in the export

- **Transfer Amount Calculation**: Added new query and service method to calculate transfer sums by surveyor
  - New `sumTransferAmountsBySurveyor()` method in `JournalEntryService` that aggregates transfer amounts per surveyor
  - New `@Query` method in `JournalEntryRepository` that sums transfer amounts grouped by surveyor ID, filtered by transfer date

- **Excel Report Enhancement**: Updated `generateSurveyorExcel()` to include calculated transfer amounts
  - Modified method signature to accept a map of transfer sums by surveyor ID
  - Special handling for the "balance" field to add transfer sum to the surveyor's base balance
  - Gracefully handles null values and missing surveyor IDs

- **UI Improvements**: Enhanced the export button interaction
  - Export button now triggers the dialog instead of direct download
  - Dialog includes "Descargar" (Download) and "Cerrar" (Close) buttons with appropriate styling

## Implementation Details

- The date filter is inclusive (transfers on or after the selected date are included)
- If no date is selected, an empty map is returned and no transfers are added to the balance
- The transfer sum calculation is performed at query time for efficiency
- The balance field in the Excel export now reflects both the surveyor's base balance and applicable transfer amounts

https://claude.ai/code/session_019zcYpuKdM5gcQsGBQtfHK5