### PR TITLE
Use lightweight DTO projection for expenses report to prevent OutOfMemoryError

### DIFF
--- a/src/main/java/uy/com/bay/utiles/controllers/FileDownloadController.java
+++ b/src/main/java/uy/com/bay/utiles/controllers/FileDownloadController.java
@@ -7,7 +7,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import uy.com.bay.utiles.data.ExpenseTransferFile;
-import uy.com.bay.utiles.data.JournalEntry;
+import uy.com.bay.utiles.data.JournalEntryReportDTO;
 import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.data.Surveyor;
 import uy.com.bay.utiles.services.ExcelReportGenerator;
@@ -73,9 +73,10 @@ public class FileDownloadController {
             studyIds.forEach(id -> studyService.get(id).ifPresent(studies::add));
         }
 
-        List<JournalEntry> journalEntries = journalEntryService.list(journalEntryService.createFilterSpecification(desde, hasta, surveyors, studies));
+        List<JournalEntryReportDTO> journalEntries = journalEntryService.listReport(
+                journalEntryService.createFilterSpecification(desde, hasta, surveyors, studies));
 
-        ByteArrayOutputStream baos = ExcelReportGenerator.generateExcel(journalEntries);
+        ByteArrayOutputStream baos = ExcelReportGenerator.generateReport(journalEntries);
         ByteArrayResource resource = new ByteArrayResource(baos.toByteArray());
 
         return ResponseEntity.ok()

--- a/src/main/java/uy/com/bay/utiles/data/JournalEntryReportDTO.java
+++ b/src/main/java/uy/com/bay/utiles/data/JournalEntryReportDTO.java
@@ -1,0 +1,148 @@
+package uy.com.bay.utiles.data;
+
+import java.util.Date;
+
+/**
+ * Lightweight projection used to build the expenses Excel report.
+ *
+ * <p>
+ * It carries only the scalar fields of {@link JournalEntry}, {@link Study} and
+ * {@link Surveyor} that the report actually renders. Loading the report through
+ * this projection avoids materializing the full {@code JournalEntry} entity
+ * graph, whose eagerly-fetched attachment collections
+ * ({@link ExpenseTransferFile} / {@link ExpenseReportFile}) hold {@code @Lob}
+ * binary content and previously caused {@link OutOfMemoryError} when many
+ * entries were exported at once.
+ */
+public class JournalEntryReportDTO {
+
+	private final String detail;
+	private final String obs;
+	private final Date date;
+	private final Operation operation;
+	private final Double amount;
+	private final Source source;
+
+	private final String studyName;
+	private final String studyOdooId;
+	private final String studyObs;
+	private final String studyClientName;
+	private final String studyArea;
+	private final Double studyTotalReportedCost;
+	private final Double studyTotalTransfered;
+	private final Double studyExpectedRevenue;
+
+	private final String surveyorFirstName;
+	private final String surveyorLastName;
+	private final String surveyorLogin;
+	private final String surveyorCi;
+	private final String surveyorSurveyToGoId;
+	private final Double surveyorBalance;
+
+	public JournalEntryReportDTO(String detail, String obs, Date date, Operation operation, Double amount,
+			Source source, String studyName, String studyOdooId, String studyObs, String studyClientName,
+			String studyArea, Double studyTotalReportedCost, Double studyTotalTransfered, Double studyExpectedRevenue,
+			String surveyorFirstName, String surveyorLastName, String surveyorLogin, String surveyorCi,
+			String surveyorSurveyToGoId, Double surveyorBalance) {
+		this.detail = detail;
+		this.obs = obs;
+		this.date = date;
+		this.operation = operation;
+		this.amount = amount;
+		this.source = source;
+		this.studyName = studyName;
+		this.studyOdooId = studyOdooId;
+		this.studyObs = studyObs;
+		this.studyClientName = studyClientName;
+		this.studyArea = studyArea;
+		this.studyTotalReportedCost = studyTotalReportedCost;
+		this.studyTotalTransfered = studyTotalTransfered;
+		this.studyExpectedRevenue = studyExpectedRevenue;
+		this.surveyorFirstName = surveyorFirstName;
+		this.surveyorLastName = surveyorLastName;
+		this.surveyorLogin = surveyorLogin;
+		this.surveyorCi = surveyorCi;
+		this.surveyorSurveyToGoId = surveyorSurveyToGoId;
+		this.surveyorBalance = surveyorBalance;
+	}
+
+	public String getDetail() {
+		return detail;
+	}
+
+	public String getObs() {
+		return obs;
+	}
+
+	public Date getDate() {
+		return date;
+	}
+
+	public Operation getOperation() {
+		return operation;
+	}
+
+	public Double getAmount() {
+		return amount;
+	}
+
+	public Source getSource() {
+		return source;
+	}
+
+	public String getStudyName() {
+		return studyName;
+	}
+
+	public String getStudyOdooId() {
+		return studyOdooId;
+	}
+
+	public String getStudyObs() {
+		return studyObs;
+	}
+
+	public String getStudyClientName() {
+		return studyClientName;
+	}
+
+	public String getStudyArea() {
+		return studyArea;
+	}
+
+	public Double getStudyTotalReportedCost() {
+		return studyTotalReportedCost;
+	}
+
+	public Double getStudyTotalTransfered() {
+		return studyTotalTransfered;
+	}
+
+	public Double getStudyExpectedRevenue() {
+		return studyExpectedRevenue;
+	}
+
+	public String getSurveyorFirstName() {
+		return surveyorFirstName;
+	}
+
+	public String getSurveyorLastName() {
+		return surveyorLastName;
+	}
+
+	public String getSurveyorLogin() {
+		return surveyorLogin;
+	}
+
+	public String getSurveyorCi() {
+		return surveyorCi;
+	}
+
+	public String getSurveyorSurveyToGoId() {
+		return surveyorSurveyToGoId;
+	}
+
+	public Double getSurveyorBalance() {
+		return surveyorBalance;
+	}
+}

--- a/src/main/java/uy/com/bay/utiles/services/ExcelReportGenerator.java
+++ b/src/main/java/uy/com/bay/utiles/services/ExcelReportGenerator.java
@@ -8,6 +8,7 @@ import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import uy.com.bay.utiles.data.JournalEntry;
+import uy.com.bay.utiles.data.JournalEntryReportDTO;
 import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.data.Surveyor;
 
@@ -20,6 +21,91 @@ import java.util.List;
 import java.util.Map;
 
 public class ExcelReportGenerator {
+
+    /**
+     * Builds the expenses report from lightweight {@link JournalEntryReportDTO}
+     * projections instead of full {@link JournalEntry} entities.
+     *
+     * <p>
+     * Using the projection avoids eagerly loading the attachment collections
+     * (which carry {@code @Lob} binary content) of every entry, which previously
+     * caused {@link OutOfMemoryError} when a large number of entries was exported.
+     */
+    public static ByteArrayOutputStream generateReport(List<JournalEntryReportDTO> rows) throws IOException {
+        try (XSSFWorkbook workbook = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            XSSFSheet sheet = workbook.createSheet("Reporte de Gastos");
+
+            String[] headers = { "JournalEntry.detail", "JournalEntry.obs", "JournalEntry.date",
+                    "JournalEntry.operation", "JournalEntry.amount", "JournalEntry.source", "Study.name",
+                    "Study.odooId", "Study.obs", "Study.clientName", "Study.area", "Study.totalReportedCost",
+                    "Study.totalTransfered", "Study.expectedRevenue", "Surveyor.firstName", "Surveyor.lastName",
+                    "Surveyor.login", "Surveyor.ci", "Surveyor.surveyToGoId", "Surveyor.balance" };
+
+            Row headerRow = sheet.createRow(0);
+            for (int i = 0; i < headers.length; i++) {
+                headerRow.createCell(i).setCellValue(headers[i]);
+            }
+
+            CellStyle dateCellStyle = workbook.createCellStyle();
+            CreationHelper createHelper = workbook.getCreationHelper();
+            dateCellStyle.setDataFormat(createHelper.createDataFormat().getFormat("dd/MM/yyyy"));
+
+            int rowNum = 1;
+            for (JournalEntryReportDTO dto : rows) {
+                Row row = sheet.createRow(rowNum++);
+                int cellNum = 0;
+                cellNum = writeString(row, cellNum, dto.getDetail());
+                cellNum = writeString(row, cellNum, dto.getObs());
+                cellNum = writeDate(row, cellNum, dto.getDate(), dateCellStyle);
+                cellNum = writeString(row, cellNum, dto.getOperation() != null ? dto.getOperation().toString() : null);
+                cellNum = writeNumber(row, cellNum, dto.getAmount());
+                cellNum = writeString(row, cellNum, dto.getSource() != null ? dto.getSource().toString() : null);
+                cellNum = writeString(row, cellNum, dto.getStudyName());
+                cellNum = writeString(row, cellNum, dto.getStudyOdooId());
+                cellNum = writeString(row, cellNum, dto.getStudyObs());
+                cellNum = writeString(row, cellNum, dto.getStudyClientName());
+                cellNum = writeString(row, cellNum, dto.getStudyArea());
+                cellNum = writeNumber(row, cellNum, dto.getStudyTotalReportedCost());
+                cellNum = writeNumber(row, cellNum, dto.getStudyTotalTransfered());
+                cellNum = writeNumber(row, cellNum, dto.getStudyExpectedRevenue());
+                cellNum = writeString(row, cellNum, dto.getSurveyorFirstName());
+                cellNum = writeString(row, cellNum, dto.getSurveyorLastName());
+                cellNum = writeString(row, cellNum, dto.getSurveyorLogin());
+                cellNum = writeString(row, cellNum, dto.getSurveyorCi());
+                cellNum = writeString(row, cellNum, dto.getSurveyorSurveyToGoId());
+                cellNum = writeNumber(row, cellNum, dto.getSurveyorBalance());
+            }
+
+            workbook.write(out);
+            return out;
+        }
+    }
+
+    private static int writeString(Row row, int cellNum, String value) {
+        row.createCell(cellNum++).setCellValue(value != null ? value : "");
+        return cellNum;
+    }
+
+    private static int writeNumber(Row row, int cellNum, Double value) {
+        Cell cell = row.createCell(cellNum++);
+        if (value != null) {
+            cell.setCellValue(value);
+        } else {
+            cell.setCellValue("");
+        }
+        return cellNum;
+    }
+
+    private static int writeDate(Row row, int cellNum, Date value, CellStyle dateCellStyle) {
+        Cell cell = row.createCell(cellNum++);
+        if (value != null) {
+            cell.setCellValue(value);
+            cell.setCellStyle(dateCellStyle);
+        } else {
+            cell.setCellValue("");
+        }
+        return cellNum;
+    }
 
     public static ByteArrayOutputStream generateExcel(List<JournalEntry> journalEntries) throws IOException {
         try (XSSFWorkbook workbook = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {

--- a/src/main/java/uy/com/bay/utiles/services/JournalEntryService.java
+++ b/src/main/java/uy/com/bay/utiles/services/JournalEntryService.java
@@ -13,7 +13,16 @@ import java.util.Set;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 import uy.com.bay.utiles.data.JournalEntry;
+import uy.com.bay.utiles.data.JournalEntryReportDTO;
 import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.data.Surveyor;
 import uy.com.bay.utiles.data.repository.JournalEntryRepository;
@@ -22,6 +31,9 @@ import uy.com.bay.utiles.data.repository.JournalEntryRepository;
 public class JournalEntryService {
 
 	private final JournalEntryRepository repository;
+
+	@PersistenceContext
+	private EntityManager entityManager;
 
 	public JournalEntryService(JournalEntryRepository repository) {
 		this.repository = repository;
@@ -64,8 +76,53 @@ public class JournalEntryService {
 		return result;
 	}
 
-	public List<JournalEntry> list(Specification<JournalEntry> filter) {
-		return repository.findAll(filter);
+	/**
+	 * Loads the data required to build the expenses Excel report as a lightweight
+	 * scalar projection.
+	 *
+	 * <p>
+	 * The report only needs scalar fields of {@link JournalEntry} plus a few from
+	 * the associated {@link Study} and {@link Surveyor}. Fetching full entities via
+	 * {@code repository.findAll(filter)} eagerly loaded the attachment collections
+	 * (which hold {@code @Lob} binary content), exhausting the heap when many
+	 * entries matched the filter. This projection selects only the needed columns
+	 * (with {@code LEFT} joins so entries without a study or surveyor are kept) and
+	 * therefore never materializes the binary attachments.
+	 *
+	 * @param filter the same dynamic filter used by the UI (may be {@code null})
+	 * @return the report rows ordered by date
+	 */
+	public List<JournalEntryReportDTO> listReport(Specification<JournalEntry> filter) {
+		CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+		CriteriaQuery<Object[]> query = cb.createQuery(Object[].class);
+		Root<JournalEntry> root = query.from(JournalEntry.class);
+		Join<JournalEntry, Study> study = root.join("study", JoinType.LEFT);
+		Join<JournalEntry, Surveyor> surveyor = root.join("surveyor", JoinType.LEFT);
+
+		query.multiselect(root.get("detail"), root.get("obs"), root.get("date"), root.get("operation"),
+				root.get("amount"), root.get("source"), study.get("name"), study.get("odooId"), study.get("obs"),
+				study.get("clientName"), study.get("area"), study.get("totalReportedCost"),
+				study.get("totalTransfered"), study.get("expectedRevenue"), surveyor.get("firstName"),
+				surveyor.get("lastName"), surveyor.get("login"), surveyor.get("ci"), surveyor.get("surveyToGoId"),
+				surveyor.get("balance"));
+
+		if (filter != null) {
+			Predicate predicate = filter.toPredicate(root, query, cb);
+			if (predicate != null) {
+				query.where(predicate);
+			}
+		}
+		query.orderBy(cb.asc(root.get("date")));
+
+		List<JournalEntryReportDTO> result = new java.util.ArrayList<>();
+		for (Object[] row : entityManager.createQuery(query).getResultList()) {
+			result.add(new JournalEntryReportDTO((String) row[0], (String) row[1], (Date) row[2],
+					(uy.com.bay.utiles.data.Operation) row[3], (Double) row[4], (uy.com.bay.utiles.data.Source) row[5],
+					(String) row[6], (String) row[7], (String) row[8], (String) row[9], (String) row[10],
+					(Double) row[11], (Double) row[12], (Double) row[13], (String) row[14], (String) row[15],
+					(String) row[16], (String) row[17], (String) row[18], (Double) row[19]));
+		}
+		return result;
 	}
 
 	public Specification<JournalEntry> createFilterSpecification(LocalDate fechaDesde, LocalDate fechaHasta,

--- a/src/main/java/uy/com/bay/utiles/views/expenses/ReportesDialog.java
+++ b/src/main/java/uy/com/bay/utiles/views/expenses/ReportesDialog.java
@@ -11,6 +11,7 @@ import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.server.StreamResource;
 
 import uy.com.bay.utiles.data.JournalEntry;
+import uy.com.bay.utiles.data.JournalEntryReportDTO;
 import uy.com.bay.utiles.data.Study;
 import uy.com.bay.utiles.data.Surveyor;
 import uy.com.bay.utiles.services.ExcelReportGenerator;
@@ -71,7 +72,7 @@ public class ReportesDialog extends Dialog {
     private void downloadReport() {
         Specification<JournalEntry> spec = journalEntryService.createFilterSpecification(fechaDesde.getValue(),
                 fechaHasta.getValue(), encuestadores.getValue(), estudios.getValue());
-        List<JournalEntry> journalEntries = journalEntryService.list(spec);
+        List<JournalEntryReportDTO> journalEntries = journalEntryService.listReport(spec);
 
         if (journalEntries.isEmpty()) {
             Notification.show("No hay datos para generar el reporte con los filtros seleccionados.");
@@ -79,7 +80,7 @@ public class ReportesDialog extends Dialog {
         }
 
         try {
-            ByteArrayOutputStream excelStream = ExcelReportGenerator.generateExcel(journalEntries);
+            ByteArrayOutputStream excelStream = ExcelReportGenerator.generateReport(journalEntries);
             StreamResource resource = new StreamResource("reporte.xlsx",
                     () -> new ByteArrayInputStream(excelStream.toByteArray()));
 


### PR DESCRIPTION
## Summary
Refactored the expenses Excel report generation to use a lightweight scalar projection (`JournalEntryReportDTO`) instead of loading full `JournalEntry` entities. This prevents `OutOfMemoryError` when exporting large numbers of entries by avoiding eager loading of attachment collections containing `@Lob` binary content.

## Key Changes
- **New DTO class**: Created `JournalEntryReportDTO` to carry only the scalar fields needed for the report from `JournalEntry`, `Study`, and `Surveyor` entities
- **New report generation method**: Added `ExcelReportGenerator.generateReport(List<JournalEntryReportDTO>)` that builds the Excel file from the lightweight projection
- **New service method**: Implemented `JournalEntryService.listReport()` using Criteria API with `LEFT` joins to fetch only required columns without materializing binary attachments
- **Updated controllers and views**: Modified `FileDownloadController` and `ReportesDialog` to use the new `listReport()` method instead of `list()`
- **Helper methods**: Added private utility methods in `ExcelReportGenerator` for writing strings, numbers, and dates to Excel cells

## Implementation Details
- The `listReport()` method uses JPA Criteria API to construct a query that selects only the 20 scalar fields needed for the report
- `LEFT` joins are used for `Study` and `Surveyor` relationships to preserve entries without associated entities
- Results are manually mapped from `Object[]` arrays to `JournalEntryReportDTO` instances
- The same `Specification<JournalEntry>` filter used by the UI is applied to the Criteria query for consistency
- Results are ordered by date to match expected report ordering

https://claude.ai/code/session_016QLf97FhQByFfeaxaDZG9k